### PR TITLE
sdk: use `between` in getMiniblocks query

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -25,6 +25,8 @@ const log = dlog('csb:persistence', { defaultEnabled: false })
 const logWarn = dlog('csb:persistence:warn', { defaultEnabled: true })
 const logError = dlogError('csb:persistence:error')
 
+const KEY_PAD_WIDTH = 20
+
 export interface LoadedStream {
     persistedSyncedStream: ParsedPersistedSyncedStream
     miniblocks: ParsedMiniblock[]
@@ -293,7 +295,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
         const cachedMiniblock = parsedMiniblockToPersistedMiniblock(miniblock, 'forward')
         await this.miniblocks.put({
             streamId: streamId,
-            miniblockNum: miniblock.header.miniblockNum.toString().padStart(20, '0'),
+            miniblockNum: miniblock.header.miniblockNum.toString().padStart(KEY_PAD_WIDTH, '0'),
             data: toBinary(PersistedMiniblockSchema, cachedMiniblock),
         })
     }
@@ -307,7 +309,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             miniblocks.map((mb) => {
                 return {
                     streamId: streamId,
-                    miniblockNum: mb.header.miniblockNum.toString().padStart(20, '0'),
+                    miniblockNum: mb.header.miniblockNum.toString().padStart(KEY_PAD_WIDTH, '0'),
                     data: toBinary(
                         PersistedMiniblockSchema,
                         parsedMiniblockToPersistedMiniblock(mb, direction),
@@ -321,7 +323,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
         streamId: string,
         miniblockNum: bigint,
     ): Promise<ParsedMiniblock | undefined> {
-        const record = await this.miniblocks.get([streamId, miniblockNum.toString().padStart(20, '0')])
+        const record = await this.miniblocks.get([streamId, miniblockNum.toString().padStart(KEY_PAD_WIDTH, '0')])
         if (!record) {
             return undefined
         }
@@ -338,8 +340,8 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
         .where('[streamId+miniblockNum]')
             .between(
                 // padStart to fix lexicographic ordering
-                [streamId, rangeStart.toString().padStart(20, '0')],
-                [streamId, rangeEnd.toString().padStart(20, '0')],
+                [streamId, rangeStart.toString().padStart(KEY_PAD_WIDTH, '0')],
+                [streamId, rangeEnd.toString().padStart(KEY_PAD_WIDTH, '0')],
             )
             .toArray()
 

--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -356,7 +356,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             }
             miniblocks.push(parsedMiniblock)
         }
-        return miniblocks.length === Number(rangeEnd - rangeStart) ? miniblocks : []
+        return miniblocks.length === Number(rangeEnd - rangeStart + 1n) ? miniblocks : []
     }
 
     async saveSnapshot(streamId: string, miniblockNum: bigint, snapshot: Snapshot): Promise<void> {


### PR DESCRIPTION
now
```
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 18.329833984375 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 150.27294921875 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 151.60986328125 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 185.18505859375 ms
```

previously:
```
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 76.501953125 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 199.236083984375 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 171.22900390625 ms
time-getMiniblocks-202d19b13129e6e045200101882169308671f4b3470000000000000000000000: 313.4970703125 ms
```