### PR TITLE
chore(contract): update OpenZeppelin, Solady and diamond contracts

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -16,20 +16,20 @@
         "test:unit": "make test"
     },
     "dependencies": {
-        "@openzeppelin/contracts": "^5.1.0",
-        "@openzeppelin/contracts-upgradeable": "^5.1.0",
+        "@openzeppelin/contracts": "^5.2.0",
+        "@openzeppelin/contracts-upgradeable": "^5.2.0",
         "@prb/math": "^4.1.0",
-        "@river-build/diamond": "github:river-build/diamond#5b9f60d7ff0d4ff99c560d95c15a5e7e8caf922a",
+        "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9",
         "account-abstraction": "github:eth-infinitism/account-abstraction",
-        "solady": "^0.0.289"
+        "solady": "^0.1.2"
     },
     "devDependencies": {
         "@prb/test": "^0.6.4",
         "ds-test": "github:dapphub/ds-test",
-        "forge-std": "github:foundry-rs/forge-std#v1.9.4",
+        "forge-std": "github:foundry-rs/forge-std#v1.9.5",
         "prettier": "^2.8.8",
-        "prettier-plugin-solidity": "^1.4.1",
-        "solhint": "^5.0.3",
+        "prettier-plugin-solidity": "^1.4.2",
+        "solhint": "^5.0.5",
         "turbo": "^2.0.12"
     }
 }

--- a/contracts/scripts/common/DeployHelpers.s.sol
+++ b/contracts/scripts/common/DeployHelpers.s.sol
@@ -111,7 +111,7 @@ abstract contract DeployHelpers is CommonBase {
   // =============================================================
   //                     FILE SYSTEM HELPERS
   // =============================================================
-  function exists(string memory path) internal returns (bool) {
+  function exists(string memory path) internal view returns (bool) {
     return vm.exists(path);
   }
 

--- a/contracts/src/diamond/facets/token/ERC20/permit/ERC20PermitBase.sol
+++ b/contracts/src/diamond/facets/token/ERC20/permit/ERC20PermitBase.sol
@@ -46,6 +46,6 @@ abstract contract ERC20PermitBase is IERC20PermitBase, EIP712, Nonces {
 
     address signer = ECDSA.recover(hash, v, r, s);
     require(signer == owner, "ERC20Permit: invalid signature");
-    ERC20Storage.layout().inner.approve(owner, spender, value);
+    ERC20Storage.layout().inner._approve(owner, spender, value);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,12 +5409,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts-upgradeable@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openzeppelin/contracts-upgradeable@npm:5.1.0"
+"@openzeppelin/contracts-upgradeable@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@openzeppelin/contracts-upgradeable@npm:5.2.0"
   peerDependencies:
-    "@openzeppelin/contracts": 5.1.0
-  checksum: 6bbb2665d97714921a4c1e6d4a0ec03a285480d2a6b3f3944bfda514696d86ec3c3190cafb6206132574c95e46d6df185bcf21343ab7a4fddccf1191d42ad35a
+    "@openzeppelin/contracts": 5.2.0
+  checksum: 5736d40287899e72e240acdcddd72961f792a0c90a22a96f2a6705aa01286ab99ca96e800567d763d66cf90b40d814fa1f1ff48844dfa0676b96a85edf9854b3
   languageName: node
   linkType: hard
 
@@ -5425,10 +5425,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openzeppelin/contracts@npm:5.1.0"
-  checksum: dd42b4b331912cc743bc7eb27c8cf9e78249909c065bb59513c00d66941444c085c4e3b2ebf1cdd89535c26497fc994a7ab028b3c88858b636694e3c9c2d622f
+"@openzeppelin/contracts@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@openzeppelin/contracts@npm:5.2.0"
+  checksum: badff8c3be46b099c331e90ba27f75e36f7af681279952cf0b123c7448bc53cd541ef447de8e6ebc38e7b29aed8f17dacf0756aac5891eed03fe96a0a4eba1a0
   languageName: node
   linkType: hard
 
@@ -6430,29 +6430,29 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@river-build/contracts@workspace:contracts"
   dependencies:
-    "@openzeppelin/contracts": ^5.1.0
-    "@openzeppelin/contracts-upgradeable": ^5.1.0
+    "@openzeppelin/contracts": ^5.2.0
+    "@openzeppelin/contracts-upgradeable": ^5.2.0
     "@prb/math": ^4.1.0
     "@prb/test": ^0.6.4
-    "@river-build/diamond": "github:river-build/diamond#5b9f60d7ff0d4ff99c560d95c15a5e7e8caf922a"
+    "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9"
     account-abstraction: "github:eth-infinitism/account-abstraction"
     ds-test: "github:dapphub/ds-test"
-    forge-std: "github:foundry-rs/forge-std#v1.9.4"
+    forge-std: "github:foundry-rs/forge-std#v1.9.5"
     prettier: ^2.8.8
-    prettier-plugin-solidity: ^1.4.1
-    solady: ^0.0.289
-    solhint: ^5.0.3
+    prettier-plugin-solidity: ^1.4.2
+    solady: ^0.1.2
+    solhint: ^5.0.5
     turbo: ^2.0.12
   languageName: unknown
   linkType: soft
 
-"@river-build/diamond@github:river-build/diamond#5b9f60d7ff0d4ff99c560d95c15a5e7e8caf922a":
-  version: 1.1.0
-  resolution: "@river-build/diamond@https://github.com/river-build/diamond.git#commit=5b9f60d7ff0d4ff99c560d95c15a5e7e8caf922a"
+"@river-build/diamond@github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9":
+  version: 1.2.0
+  resolution: "@river-build/diamond@https://github.com/river-build/diamond.git#commit=552c970ed60cf452d28e7713b00a95c7bd10a5d9"
   dependencies:
-    "@openzeppelin/contracts": ^5.1.0
-    solady: ^0.0.281
-  checksum: 2666668787f50af79a76004ccea89798fb362f07eea88557cdcf13a70d1164b2ad58c9278fd19ff5b304d9fc1439d097d57e03676b6c1dfeeb98535dd5059b50
+    "@openzeppelin/contracts": ^5.2.0
+    solady: ^0.1.2
+  checksum: ddd2585da9c20eafac400fad4751abbc5a7d4377ea166b7712d9f559b7075f69ccfc5b08bb57f1340c7e11ac14b174a0533a5b384a2ad4245f8afe5125b1725e
   languageName: node
   linkType: hard
 
@@ -7989,6 +7989,13 @@ __metadata:
   version: 0.18.0
   resolution: "@solidity-parser/parser@npm:0.18.0"
   checksum: 970d991529d632862fa88e107531339d84df35bf0374e31e8215ce301b19a01ede33fccf4d374402649814263f8bc278a8e6d62a0129bb877539fbdd16a604cc
+  languageName: node
+  linkType: hard
+
+"@solidity-parser/parser@npm:^0.19.0":
+  version: 0.19.0
+  resolution: "@solidity-parser/parser@npm:0.19.0"
+  checksum: b1c556eeb83ac99f066ea4b0eb0bee45321a667f76dbafef95f8bc6adf32d1f8f52f752fb47620c61d1a264d3acb7534d75a8daa6d21099f55bc52b0af13ad83
   languageName: node
   linkType: hard
 
@@ -15758,10 +15765,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"forge-std@github:foundry-rs/forge-std#v1.9.4":
-  version: 1.9.4
-  resolution: "forge-std@https://github.com/foundry-rs/forge-std.git#commit=1eea5bae12ae557d589f9f0f0edae2faa47cb262"
-  checksum: a765a8797fb46808f476db6504d4192489a723d26764be73dde4c583ecfef0d8a453ee4f51e7f22be360670827814e5ed6260e085f19d4d9e9b973fb011f563c
+"forge-std@github:foundry-rs/forge-std#v1.9.5":
+  version: 1.9.5
+  resolution: "forge-std@https://github.com/foundry-rs/forge-std.git#commit=b93cf4bc34ff214c099dc970b153f85ade8c9f66"
+  checksum: 71aead7ca70cc51b46f0336074a9721aa765ba85030080577460c76f2a824abfb26bd1f4a77811c8ffbbce2cb9788f95dc0340926b041a3e2477c9a624f3503b
   languageName: node
   linkType: hard
 
@@ -24364,15 +24371,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-solidity@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "prettier-plugin-solidity@npm:1.4.1"
+"prettier-plugin-solidity@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "prettier-plugin-solidity@npm:1.4.2"
   dependencies:
-    "@solidity-parser/parser": ^0.18.0
-    semver: ^7.5.4
+    "@solidity-parser/parser": ^0.19.0
+    semver: ^7.6.3
   peerDependencies:
     prettier: ">=2.3.0"
-  checksum: ac9f3cc525553a45e70f60898da5d4a7b733128cdd9893686364790ff688c56dd6eb0234620759dc6fabad4dc354a27097927b29ea7761c5814c64613c07222f
+  checksum: 0ff7a1f24cf4917fa15e4ecfc0c714f01aea424226cb20a5a408957a59d23ae2864efc805930240d9d7a0e64d4333bd26057e39d1cf5e01600453a1fa191fc91
   languageName: node
   linkType: hard
 
@@ -26864,25 +26871,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"solady@npm:^0.0.281":
-  version: 0.0.281
-  resolution: "solady@npm:0.0.281"
-  checksum: c36dafdde5d732d13d2f28a1437350ecd2ba71000ab765bc74028d41fbe098bc934714bf28af7323feb5c227d9ab110a015fca8ae077b3ebca6f6dfa01b44224
+"solady@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "solady@npm:0.1.2"
+  checksum: aba8b991a1cb0bf36e0a3f6b76795aa6d2d40019a50ef8d058eedcbb43781f54081937d2e723e6d219b4a44a04df273fd50da29e7e5750dc50c7ccfd75f5a6f9
   languageName: node
   linkType: hard
 
-"solady@npm:^0.0.289":
-  version: 0.0.289
-  resolution: "solady@npm:0.0.289"
-  checksum: 65643a91f441ec7ccf7ff2b073e4efa0e649d67581dae9572fa461131c715e7cac6b82752e3f105b94cb15e8c4d7bcf686dcd1d474e925a7f6fe9d2c260a3626
-  languageName: node
-  linkType: hard
-
-"solhint@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "solhint@npm:5.0.3"
+"solhint@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "solhint@npm:5.0.5"
   dependencies:
-    "@solidity-parser/parser": ^0.18.0
+    "@solidity-parser/parser": ^0.19.0
     ajv: ^6.12.6
     antlr4: ^4.13.1-patch-1
     ast-parents: ^0.0.1
@@ -26906,7 +26906,7 @@ __metadata:
       optional: true
   bin:
     solhint: solhint.js
-  checksum: 30361c0099cded492059719e477cecadcc7390f87a1737904411e8dbf15277344a5892e0762738a025cefd78467455601db1d7d6ffb3d489a6ab6e296c6a7b92
+  checksum: 8fa19a4411564c79c17017fdc68d4cccff46a67b11da5fc6c435aab9b5c8b8c22f25ea49307d82b4ba03a87ff57e6b91be8f9fee5e95227e80b539905c07a7ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgraded key dependencies such as OpenZeppelin, Solady, and @river-build/diamond for improved features and compatibility. Fixed `_approve` method usage in `ERC20PermitBase` and added `view` modifier to the `exists` function in `DeployHelpers`. These changes ensure better consistency and compliance with updated standards.