### PR TITLE
Fix error log order on stress test

### DIFF
--- a/packages/stress/src/start.ts
+++ b/packages/stress/src/start.ts
@@ -68,6 +68,6 @@ const run = async () => {
     exit(0)
 }
 run().catch((e) => {
-    logger.error('unhandled error:', e)
+    logger.error(e, 'unhandled error:')
     exit(1)
 })


### PR DESCRIPTION
why does pino have to be like this?