### PR TITLE
Remove salt in towns mainnet deployer to fix local dev

### DIFF
--- a/contracts/scripts/deployments/utils/DeployTownsMainnet.s.sol
+++ b/contracts/scripts/deployments/utils/DeployTownsMainnet.s.sol
@@ -38,10 +38,7 @@ contract DeployTownsMainnet is Deployer, ITownsBase {
     InflationConfig memory config = inflationConfig(manager);
 
     vm.broadcast(deployer);
-    return
-      address(
-        new Towns({vault: vault, manager: manager, config: config})
-      );
+    return address(new Towns({vault: vault, manager: manager, config: config}));
   }
 
   function _getVault() internal view returns (address) {

--- a/contracts/scripts/deployments/utils/DeployTownsMainnet.s.sol
+++ b/contracts/scripts/deployments/utils/DeployTownsMainnet.s.sol
@@ -40,9 +40,7 @@ contract DeployTownsMainnet is Deployer, ITownsBase {
     vm.broadcast(deployer);
     return
       address(
-        new Towns{
-          salt: 0x9f2667b9ec9a7d09a47d87156f032c6735a077adfe74d91cc4d708e8da080040
-        }({vault: vault, manager: manager, config: config})
+        new Towns({vault: vault, manager: manager, config: config})
       );
   }
 


### PR DESCRIPTION
we run both multi and multi_ne environments locally, this causes both to be deployed at the same address which doesn’t work