### PR TITLE
Stop decryption when sync errors out

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -385,6 +385,11 @@ export abstract class BaseDecryptionExtensions {
         this.checkStartTicking()
     }
 
+    public resetUpToDateStreams(): void {
+        this.upToDateStreams.clear()
+        this.checkStartTicking()
+    }
+
     public retryDecryptionFailures(streamId: string): void {
         const streamQueue = this.streamQueues.getQueue(streamId)
         if (

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -95,6 +95,13 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             }
         }
 
+        const onStreamSyncActive = (active: boolean) => {
+            this.log.info('onStreamSyncActive', active)
+            if (!active) {
+                this.resetUpToDateStreams()
+            }
+        }
+
         client.on('streamUpToDate', onStreamUpToDate)
         client.on('newGroupSessions', onNewGroupSessions)
         client.on('newEncryptedContent', onNewEncryptedContent)
@@ -103,6 +110,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         client.on('initKeySolicitations', onInitKeySolicitations)
         client.on('streamNewUserJoined', onMembershipChange)
         client.on('streamInitialized', onStreamInitialized)
+        client.on('streamSyncActive', onStreamSyncActive)
 
         this._onStopFn = () => {
             client.off('streamUpToDate', onStreamUpToDate)
@@ -113,6 +121,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             client.off('initKeySolicitations', onInitKeySolicitations)
             client.off('streamNewUserJoined', onMembershipChange)
             client.off('streamInitialized', onStreamInitialized)
+            client.off('streamSyncActive', onStreamSyncActive)
         }
         this.log.debug('new ClientDecryptionExtensions', { userDevice })
     }

--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -171,4 +171,8 @@ export class SyncedStream extends Stream implements ISyncedStream {
         this.isUpToDate = true
         this.emit('streamUpToDate', this.streamId)
     }
+
+    resetUpToDate(): void {
+        this.isUpToDate = false
+    }
 }


### PR DESCRIPTION
Firgured out that in local stress tests at least we get into a local ddos situation when you’re not syncing but you’re still processing key requests, you start spamming the node with fulfillments for keys that have already been fulfilled and it all goes pear shaped.

This code sets these streams as not up to date and clears the up to date list in the encryption loop, which will prevent them from processing until they receive another update.