### PR TITLE
If modify sync fails and we’re still syncing with the same syncid, re-add streams to sync

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -485,6 +485,7 @@ export class SyncedStreamsLoop {
                 this.inFlightSyncCookies.size <= this.MIN_IN_FLIGHT_COOKIES &&
                 this.pendingSyncCookies.length > 0
             ) {
+                const syncId = this.syncId
                 this.pendingSyncCookies.sort((a, b) => {
                     const aPriority = priorityFromStreamId(a, this.highPriorityIds)
                     const bPriority = priorityFromStreamId(b, this.highPriorityIds)
@@ -492,7 +493,7 @@ export class SyncedStreamsLoop {
                 })
                 const streamsToAdd = this.pendingSyncCookies.splice(0, this.MAX_IN_FLIGHT_COOKIES)
                 this.logSync('tick: modifySync', {
-                    syncId: this.syncId,
+                    syncId,
                     addStreams: streamsToAdd,
                     inFlight: this.inFlightSyncCookies.size,
                 })
@@ -500,11 +501,16 @@ export class SyncedStreamsLoop {
                 const syncPos = streamsToAdd.map((x) => this.streams.get(x)?.syncCookie)
                 try {
                     await this.rpcClient.modifySync({
-                        syncId: this.syncId,
+                        syncId,
                         addStreams: syncPos.filter(isDefined),
                     })
                 } catch (err) {
                     this.logError('modifySync error', err)
+                    if (this.syncId === syncId && this.syncState === SyncState.Syncing) {
+                        streamsToAdd.forEach((x) => this.inFlightSyncCookies.delete(x))
+                        this.pendingSyncCookies.push(...streamsToAdd)
+                        this.checkStartTicking()
+                    }
                 }
             }
         }

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -507,8 +507,11 @@ export class SyncedStreamsLoop {
                 } catch (err) {
                     this.logError('modifySync error', err)
                     if (this.syncId === syncId && this.syncState === SyncState.Syncing) {
-                        streamsToAdd.forEach((x) => this.inFlightSyncCookies.delete(x))
-                        this.pendingSyncCookies.push(...streamsToAdd)
+                        streamsToAdd.forEach((x) => {
+                            if (this.inFlightSyncCookies.delete(x)) {
+                                this.pendingSyncCookies.push(x)
+                            }
+                        })
                         this.checkStartTicking()
                     }
                 }


### PR DESCRIPTION
to avoid getting stuck