### PR TITLE
Omit alchemy secret from repo

### DIFF
--- a/packages/xchain-monitor/docker-compose.yml
+++ b/packages/xchain-monitor/docker-compose.yml
@@ -5,6 +5,6 @@ services:
             dockerfile: ./packages/xchain-monitor/Dockerfile
         environment:
             RIVER_ENV: omega
-            INITIAL_BLOCK_NUM: 25287260
+            INITIAL_BLOCK_NUM: 26051573
             TRANSACTION_VALID_BLOCKS: 20
-            BASE_PROVIDER_URL: https://base-mainnet.g.alchemy.com/v2/ghkfp_vHzHlXdPaQpQuehc7K_RN9zb76
+            BASE_PROVIDER_URL: https://mainnet.base.org


### PR DESCRIPTION
I already deleted the app and rotated my usage of alchemy URLs, but I'm deleting this from the repo as well for hygienic reasons.