### PR TITLE
NPM ci fix final

### DIFF
--- a/.github/workflows/Publish_npm_packages.yml
+++ b/.github/workflows/Publish_npm_packages.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event_name == 'schedule' && 'main' || github.ref }}
+                  ref: main
 
             - name: Install GPG
               run: |

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -15,7 +15,7 @@ if [[ "$(git status --porcelain)" != "" ]]; then
     exit 1
 elif [[ "$(parse_git_branch)" != "main" ]]; then
     echo "You must be on the main branch to run this script."
-    # exit 1
+    exit 1
 fi
 
 # get the current git hash 


### PR DESCRIPTION
Now that npm publish CI job is fixed, revert back to just allowing it to run on `main`. 