### PR TITLE
Remove artifical delay before processing keys in user inbox

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -238,7 +238,6 @@ export abstract class BaseDecryptionExtensions {
     public abstract downloadNewMessages(): Promise<void>
     public abstract getKeySolicitations(streamId: string): KeySolicitationContent[]
     public abstract hasStream(streamId: string): boolean
-    public abstract hasUnprocessedSession(item: EncryptedContentItem): boolean
     public abstract isUserEntitledToKeyExchange(
         streamId: string,
         userId: string,

--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -361,11 +361,6 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
         return []
     }
 
-    public hasUnprocessedSession(_item: EncryptedContentItem): boolean {
-        log('hasUnprocessedSession')
-        return true
-    }
-
     public isUserEntitledToKeyExchange(_streamId: string, _userId: string): Promise<boolean> {
         log('isUserEntitledToKeyExchange')
         return Promise.resolve(true)

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -176,16 +176,6 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         return waitTime * multiplier
     }
 
-    public hasUnprocessedSession(item: EncryptedContentItem): boolean {
-        check(isDefined(this.client.userInboxStreamId), 'userInboxStreamId not found')
-        const inboxStream = this.client.stream(this.client.userInboxStreamId)
-        check(isDefined(inboxStream), 'inboxStream not found')
-        return inboxStream.view.userInboxContent.hasPendingSessionId(
-            this.userDevice.deviceKey,
-            item.encryptedData.sessionId,
-        )
-    }
-
     public async isUserEntitledToKeyExchange(
         streamId: string,
         userId: string,


### PR DESCRIPTION
This only really became a problem when blocks weren’t getting created, but tbh i put this in thinking it would protect the user from bad events, but we have nothing on the node that re-checks the event after sending it to the user before confirming it anyway so this was just dead time

also i think i was passing the wrong emitter so it’s possible we were missing a few of these events during initialization, which is news to me

and we used to have custom code to retry events that had pending sessions and that code has been deleted, so this is probably a good change all around.