### PR TITLE
Block clients from uploading key solicitations with empty session ids

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -1702,6 +1702,14 @@ func (ru *aeKeySolicitationRules) validKeySolicitation() (bool, error) {
 		return false, RiverError(Err_INVALID_ARGUMENT, "session ids must be sorted")
 	}
 
+	if len(ru.solicitation.SessionIds) > 0 {
+		for _, sessionId := range ru.solicitation.SessionIds {
+			if sessionId == "" {
+				return false, RiverError(Err_INVALID_ARGUMENT, "session ids must not be empty")
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -341,6 +341,17 @@ describe('clientTest', () => {
             bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),
         ).rejects.toThrow('INVALID_ARGUMENT')
 
+        // solicitation with empty key should fail
+        payload = make_MemberPayload_KeySolicitation({
+            deviceKey: 'foo',
+            sessionIds: [''],
+            fallbackKey: 'baz',
+            isNewDevice: false,
+        })
+        await expect(
+            bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),
+        ).rejects.toThrow('INVALID_ARGUMENT')
+
         // solicitation for isNewDevice should resolve
         payload = make_MemberPayload_KeySolicitation({
             deviceKey: 'foo',


### PR DESCRIPTION
Sadly some clients are requesting empty session ids over and over (tracked general down to caroline’s client)

Need to track down the actual cause, this will prevent the streams from blowing up.