### PR TITLE
Refactor GetView & so on

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -435,7 +435,7 @@ func (s *StreamCache) ForceFlushAll(ctx context.Context) {
 func (s *StreamCache) GetLoadedViews(ctx context.Context) []*StreamView {
 	var result []*StreamView
 	s.cache.Range(func(streamID StreamId, stream *Stream) bool {
-		view := stream.tryGetView()
+		view, _ := stream.tryGetView()
 		if view != nil {
 			result = append(result, view)
 		}

--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -45,9 +45,7 @@ func (s *StreamCache) onStreamCreated(
 		}
 
 		// Cache the stream
-		stream.mu.Lock()
 		s.cache.Store(stream.streamId, stream)
-		stream.mu.Unlock()
 	}()
 }
 


### PR DESCRIPTION
1) Restructure code to always use defer for unlock.
2) Do not call Scrub multiple times in the same time period.
3) Do not call Scrub under lock.
4) Remove unnecessary lock on putting stream in a map.