### PR TITLE
Add an error if the sessionId is 0 so that we don’t attempt to push a key solicitation for it

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -138,10 +138,13 @@ class StreamQueues {
         return true
     }
     toString() {
-        const counts = Array.from(this.streams.entries()).reduce((acc, [_, tasks]) => {
-            acc['encryptedContent'] = (acc['encryptedContent'] ?? 0) + tasks.encryptedContent.length
-            acc['missingKeys'] = (acc['missingKeys'] ?? 0) + (tasks.isMissingKeys ? 1 : 0)
-            acc['keySolicitations'] = (acc['keySolicitations'] ?? 0) + tasks.keySolicitations.length
+        const counts = Array.from(this.streams.entries()).reduce((acc, [_, stream]) => {
+            acc['encryptedContent'] =
+                (acc['encryptedContent'] ?? 0) + stream.encryptedContent.length
+            acc['streamsMissingKeys'] =
+                (acc['streamsMissingKeys'] ?? 0) + (stream.isMissingKeys ? 1 : 0)
+            acc['keySolicitations'] =
+                (acc['keySolicitations'] ?? 0) + stream.keySolicitations.length
             return acc
         }, {} as Record<string, number>)
 
@@ -706,6 +709,14 @@ export abstract class BaseDecryptionExtensions {
                     item.encryptedData.sessionId && item.encryptedData.sessionId.length > 0
                         ? item.encryptedData.sessionId
                         : bin_toHexString(item.encryptedData.sessionIdBytes)
+                if (sessionId.length === 0) {
+                    this.log.error('session id length is 0 for failed decryption', {
+                        err,
+                        streamId: item.streamId,
+                        eventId: item.eventId,
+                    })
+                    return
+                }
                 if (!this.decryptionFailures[streamId]) {
                     this.decryptionFailures[streamId] = { [sessionId]: [item] }
                 } else if (!this.decryptionFailures[streamId][sessionId]) {
@@ -713,7 +724,6 @@ export abstract class BaseDecryptionExtensions {
                 } else if (!this.decryptionFailures[streamId][sessionId].includes(item)) {
                     this.decryptionFailures[streamId][sessionId].push(item)
                 }
-
                 const streamQueue = this.streamQueues.getQueue(streamId)
                 streamQueue.isMissingKeys = true
             } else {


### PR DESCRIPTION
I have seen solicitations in the streams with [“”] and I don’t think this is the cause, but it should prevent it. I have added a check in the node to block it.