### PR TITLE
node/sync: add initial stream to sync session one by one

### DIFF
--- a/core/node/rpc/sync/client/syncer_set.go
+++ b/core/node/rpc/sync/client/syncer_set.go
@@ -92,7 +92,7 @@ func NewSyncers(
 	localNodeAddress common.Address,
 	cookies StreamCookieSetGroupedByNodeAddress,
 	otelTracer trace.Tracer,
-) (*SyncerSet, <-chan *SyncStreamsResponse, error) {
+) (*SyncerSet, chan *SyncStreamsResponse, error) {
 	var (
 		log             = logging.FromCtx(ctx)
 		syncers         = make(map[common.Address]StreamsSyncer)
@@ -177,14 +177,6 @@ func (ss *SyncerSet) Run() {
 	ss.muSyncers.Unlock()
 
 	ss.syncerTasks.Wait() // background syncers finished -> safe to close messages channel
-}
-
-func (ss *SyncerSet) AddInitialStreams() {
-	ss.muSyncers.Lock()
-	for _, syncer := range ss.syncers {
-		ss.startSyncer(syncer)
-	}
-	ss.muSyncers.Unlock()
 }
 
 func (ss *SyncerSet) AddStream(

--- a/core/node/rpc/sync/operation.go
+++ b/core/node/rpc/sync/operation.go
@@ -94,7 +94,7 @@ func (syncOp *StreamSyncOperation) Run(
 	res StreamsResponseSubscriber,
 ) error {
 	log := logging.FromCtx(syncOp.ctx).With("syncId", syncOp.SyncID)
-
+	
 	messagesSendToClient := 0
 
 	log.Info("Stream sync operation start")
@@ -111,7 +111,7 @@ func (syncOp *StreamSyncOperation) Run(
 
 	go func() {
 		for _, cookie := range req.Msg.GetSyncPos() {
-			if err = syncOp.process(&subCommand{
+			cmd := &subCommand{
 				Ctx: syncOp.ctx,
 				AddStreamReq: &connect.Request[AddStreamToSyncRequest]{
 					Msg: &AddStreamToSyncRequest{
@@ -120,7 +120,8 @@ func (syncOp *StreamSyncOperation) Run(
 					},
 				},
 				reply: make(chan error, 1),
-			}); err != nil {
+			}
+			if err := syncOp.process(cmd); err != nil {
 				select {
 				case messages <- &SyncStreamsResponse{
 					SyncOp:   SyncOp_SYNC_DOWN,
@@ -146,7 +147,7 @@ func (syncOp *StreamSyncOperation) Run(
 			}
 
 			msg.SyncId = syncOp.SyncID
-			if err = res.Send(msg); err != nil {
+			if err := res.Send(msg); err != nil {
 				log.Errorw("Unable to send sync stream update to client", "err", err)
 				return err
 			}
@@ -181,7 +182,7 @@ func (syncOp *StreamSyncOperation) Run(
 				}
 				cmd.Reply(syncers.RemoveStream(cmd.Ctx, streamID))
 			} else if cmd.PingReq != nil {
-				err = res.Send(&SyncStreamsResponse{
+				err := res.Send(&SyncStreamsResponse{
 					SyncId:    syncOp.SyncID,
 					SyncOp:    SyncOp_SYNC_PONG,
 					PongNonce: cmd.PingReq.Msg.GetNonce(),

--- a/core/node/rpc/sync_test.go
+++ b/core/node/rpc/sync_test.go
@@ -10,14 +10,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-
 	"github.com/stretchr/testify/require"
-
 	"github.com/towns-protocol/towns/core/node/crypto"
 	. "github.com/towns-protocol/towns/core/node/events"
 	"github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	. "github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/testutils"
+	"github.com/towns-protocol/towns/core/node/testutils/testfmt"
 )
 
 const defaultTimeout = 5 * time.Second
@@ -33,10 +33,10 @@ type syncClient struct {
 	pongC   chan string
 }
 
-func (c *syncClient) sync(ctx context.Context, cookie *protocol.SyncCookie) {
+func (c *syncClient) syncMany(ctx context.Context, cookies []*protocol.SyncCookie) {
 	req := &protocol.SyncStreamsRequest{}
-	if cookie != nil {
-		req.SyncPos = []*protocol.SyncCookie{cookie}
+	if len(cookies) > 0 {
+		req.SyncPos = cookies
 	}
 	resp, err := c.client.SyncStreams(ctx, connect.NewRequest(req))
 	if err == nil {
@@ -85,6 +85,10 @@ func (c *syncClient) sync(ctx context.Context, cookie *protocol.SyncCookie) {
 	}
 }
 
+func (c *syncClient) sync(ctx context.Context, cookie *protocol.SyncCookie) {
+	c.syncMany(ctx, []*protocol.SyncCookie{cookie})
+}
+
 func (c *syncClient) cancelSync(t *testing.T, ctx context.Context) {
 	_, err := c.client.CancelSync(ctx, connect.NewRequest(&protocol.CancelSyncRequest{
 		SyncId: c.syncId,
@@ -111,6 +115,29 @@ func makeSyncClients(tt *serviceTester, numNodes int) *syncClients {
 	}
 
 	return &syncClients{clients: clients}
+}
+
+func (sc *syncClients) startSyncMany(t *testing.T, ctx context.Context, cookies []*protocol.SyncCookie) {
+	for _, client := range sc.clients {
+		go client.syncMany(ctx, cookies)
+	}
+
+	t.Cleanup(func() {
+		sc.cancelAll(t, ctx)
+	})
+
+	for i, client := range sc.clients {
+		select {
+		case <-client.syncIdC:
+			// Received syncId, continue
+		case err := <-client.errC:
+			t.Fatalf("Error in sync client %d: %v", i, err)
+			return
+		case <-time.After(defaultTimeout):
+			t.Fatalf("Timeout waiting for syncId from client %d", i)
+			return
+		}
+	}
 }
 
 func (sc *syncClients) startSync(t *testing.T, ctx context.Context, cookie *protocol.SyncCookie) {
@@ -176,6 +203,37 @@ func (sc *syncClients) expectOneUpdate(t *testing.T, opts *updateOpts) {
 		case <-timer.C:
 			t.Fatalf("Timeout waiting for update on client %d", i)
 			return
+		}
+	}
+}
+
+func (sc *syncClients) expectNUpdates(
+	t *testing.T,
+	wantedUniqueStreamsWithUpdates int,
+	timeout time.Duration,
+	opts *updateOpts,
+) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	uniqueStreamsWithUpdates := make(map[StreamId]struct{})
+
+	for i, client := range sc.clients {
+		for len(uniqueStreamsWithUpdates) < wantedUniqueStreamsWithUpdates {
+			select {
+			case update := <-client.updateC:
+				checkUpdate(t, update, opts)
+				if t.Failed() {
+					return
+				}
+
+				streamID, _ := StreamIdFromBytes(update.GetNextSyncCookie().GetStreamId())
+				uniqueStreamsWithUpdates[streamID] = struct{}{}
+			case <-timer.C:
+				t.Fatalf("Timeout waiting for update on client %d", i)
+				return
+			}
 		}
 	}
 }
@@ -295,6 +353,65 @@ func TestSyncWithFlush(t *testing.T) {
 	require.NotEmpty(mbRef.Hash)
 	require.Equal(int64(2), mbRef.Num)
 	syncClients.expectOneUpdate(t, &updateOpts{events: 1, eventType: "MiniblockHeader"})
+
+	syncClients.cancelAll(t, ctx)
+	syncClients.checkDone(t)
+}
+
+// TestSyncWithManyStreams ensures that when starting a sync session with a lot of initial streams
+// the client receives for each stream an update and the sync session remains valid.
+func TestSyncWithManyStreams(t *testing.T) {
+	numNodes := 10
+	tt := newServiceTester(t, serviceTesterOpts{numNodes: numNodes, start: true})
+	ctx := tt.ctx
+	require := tt.require
+
+	syncClients := makeSyncClients(tt, 1)
+	syncClient0 := syncClients.clients[0].client
+
+	wallet, err := crypto.NewWallet(ctx)
+	require.NoError(err)
+	resuser, _, err := createUser(ctx, wallet, syncClient0, nil)
+	require.NoError(err)
+	require.NotNil(resuser)
+
+	_, _, err = createUserMetadataStream(ctx, wallet, syncClient0, nil)
+	require.NoError(err)
+
+	// create space with 500 channels and add 1 event to each channel
+	spaceId := testutils.FakeStreamId(STREAM_SPACE_BIN)
+	_, _, err = createSpace(ctx, wallet, syncClient0, spaceId, &protocol.StreamSettings{})
+	require.NoError(err)
+
+	var channelCookies []*protocol.SyncCookie
+
+	for range 500 {
+		channelId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
+		channel, channelHash, err := createChannel(
+			ctx,
+			wallet,
+			syncClient0,
+			spaceId,
+			channelId,
+			&protocol.StreamSettings{DisableMiniblockCreation: true},
+		)
+		require.NoError(err)
+		require.NotNil(channel)
+		b0ref, err := makeMiniblock(ctx, syncClient0, channelId, false, -1)
+		require.NoError(err)
+		require.Equal(int64(0), b0ref.Num)
+
+		// add 1 event to the channel
+		addMessageToChannel(ctx, syncClient0, wallet, "hello", channelId, channelHash, require)
+
+		channelCookies = append(channelCookies, channel)
+	}
+
+	// start sync session with all channels and ensure that for each stream an update is received with 1 message
+	now := time.Now()
+	syncClients.startSyncMany(t, ctx, channelCookies)
+	syncClients.expectNUpdates(t, len(channelCookies), 30*time.Second, &updateOpts{events: 1, eventType: "ChannelPayload"})
+	testfmt.Printf(t, "Received first update for all %d streams in init sync session took: %s", len(channelCookies), time.Since(now))
 
 	syncClients.cancelAll(t, ctx)
 	syncClients.checkDone(t)


### PR DESCRIPTION
When the client initiates a sync session it passes a set of sync cookies that it wants to get updates for. Currently these updates are send to an internal channel and when all streams are internally added the node starts sending these updates to the client. If there are more updates available than the capacity of the channel it ends up in buffer too full and the sync session is cancelled.

This change starts adding the streams to sync and immediately starts sending updates to the client. This should not yield to a buffer full as long as the client can keep up.

As a side effect the time it takes for a client to receive the first update is decreased because the node starts sending them immediately.

There is a unittest that hit the buffer too full problem reliable with the old implementation that now passes. Downside of this test is that it takes a long time to create enough streams making it a slow test.

Long term adding a better pacing mechanism is needed but the design of stream syncing could be improved by switch to a shared approach where multiple sync sessions share the same update buffer/"forwarder sync sessions".