### PR TITLE
more logs for the stress tests

### DIFF
--- a/packages/sdk/src/sync-agent/river-connection/models/riverChain.ts
+++ b/packages/sdk/src/sync-agent/river-connection/models/riverChain.ts
@@ -35,6 +35,7 @@ export class RiverChain extends PersistedObservable<RiverChainModel> {
 
     // implement start function then wire it up from parent
     protected override onLoaded() {
+        log.info('riverChain onLoaded')
         this.withInfiniteRetries(() => this.fetchUrls())
         this.withInfiniteRetries(() => this.fetchStreamExists(makeUserStreamId(this.userId)))
     }
@@ -47,7 +48,7 @@ export class RiverChain extends PersistedObservable<RiverChainModel> {
         // urls is returning the cached data if it exists, otherwise waiting for the data to be fetched
         // if the cached data returns a stale node url, the startup will fail
         // nodes almost never exit the network, so this is a very rare case
-        await this.when((x) => x.data.urls.fetchedAtMs !== undefined)
+        await this.when((x) => x.data.urls.fetchedAtMs !== undefined, { timeoutMs: 15000 })
         return this.data.urls.value
     }
 

--- a/packages/sdk/src/sync-agent/syncAgent.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.ts
@@ -24,6 +24,7 @@ import type { EncryptionDeviceInitOpts } from '@river-build/encryption'
 import { Gdms, type GdmsModel } from './gdms/gdms'
 import { Dms, DmsModel } from './dms/dms'
 import { UnpackEnvelopeOpts } from '../sign'
+import { dlog, DLogger, shortenHexString } from '@river-build/dlog'
 
 export interface SyncAgentConfig {
     context: SignerContext
@@ -41,6 +42,7 @@ export interface SyncAgentConfig {
 }
 
 export class SyncAgent {
+    log: DLogger
     userId: string
     config: SyncAgentConfig
     riverConnection: RiverConnection
@@ -68,6 +70,8 @@ export class SyncAgent {
 
     constructor(config: SyncAgentConfig) {
         this.userId = userIdFromAddress(config.context.creatorAddress)
+        const logId = config.logId ?? shortenHexString(this.userId)
+        this.log = dlog('csb:syncAgent', { defaultEnabled: true }).extend(logId)
         this.config = config
         const base = config.riverConfig.base
         const river = config.riverConfig.river
@@ -118,9 +122,11 @@ export class SyncAgent {
         }
         // commit the initialization transaction, which triggers onLoaded on the models
         await this.store.commitTransaction()
+        this.log('SyncAgent::start: starting river connection')
         // start thie river connection, this will log us in if the user is already signed up
         // it will leave us in a connected state otherwise, see riverConnection.authStatus
         await this.riverConnection.start()
+        this.log('SyncAgent::start: river connection started')
     }
 
     async stop() {


### PR DESCRIPTION
saw an interesting error in the logs

Error: Timeout waiting for condition
    at RiverChain2.when (/monorepo/packages/sdk/src/observable/observable.ts:48:30)
    at RiverChain2.urls (/monorepo/packages/sdk/src/sync-agent/river-connection/models/riverChain.ts:50:20)
    at RiverConnection2.start (/monorepo/packages/sdk/src/sync-agent/river-connection/riverConnection.ts:86:29)
    at SyncAgent.start (/monorepo/packages/sdk/src/sync-agent/syncAgent.ts:123:36)
    at async makeStressClient (/monorepo/packages/stress/src/utils/stressClient.ts:88:5)
    at async Promise.all (index 9)
    at async startStressChat (/monorepo/packages/stress/src/mode/chat/root_chat.ts:33:21)
    at async run (/monorepo/packages/stress/src/start.ts:46:13)