### PR TITLE
test(contract): strengthen non-member check in addReview test

### DIFF
--- a/contracts/test/spaces/review/ReviewFacet.t.sol
+++ b/contracts/test/spaces/review/ReviewFacet.t.sol
@@ -35,6 +35,8 @@ contract ReviewFacetTest is MembershipBaseSetup, IReviewBase {
 
   function test_fuzz_addReview_revertIf_notMember(address user) public {
     vm.assume(user != address(0));
+    vm.assume(user != founder);
+    vm.assume(membershipToken.balanceOf(user) == 0);
 
     vm.expectRevert(Entitlement__NotMember.selector);
     vm.prank(user);


### PR DESCRIPTION
Add additional assumptions to ensure the `user` is neither the founder nor holds membership tokens. This enhances test robustness by better isolating the non-member scenario.