### PR TITLE
Add “extend” to the combined dlogger

### DIFF
--- a/packages/dlog/src/dlog.ts
+++ b/packages/dlog/src/dlog.ts
@@ -228,15 +228,25 @@ export const dlogError = (ns: string): DLogger => {
     return l
 }
 
+export interface ExtendedLogger {
+    info: DLogger
+    log: DLogger
+    error: DLogger
+    extend: (namespace: string) => ExtendedLogger
+}
+
 /**
  * Create complex logger with multiple levels
  * @param ns Namespace for the logger.
  * @returns New logger with log/info/error namespace `ns`.
  */
-export const dlogger = (ns: string): { log: DLogger; info: DLogger; error: DLogger } => {
+export const dlogger = (ns: string): ExtendedLogger => {
     return {
         log: makeDlog(debug(ns + ':log')),
         info: makeDlog(debug(ns + ':info'), { defaultEnabled: true, allowJest: true }),
         error: dlogError(ns + ':error'),
+        extend: (sub: string) => {
+            return dlogger(ns + ':' + sub)
+        },
     }
 }


### PR DESCRIPTION
matches the api of the dlog
not sure why you don’t just pass this as the ns, but allows for easy composability i guess.