### PR TITLE
feat(contract): add `permitAndIncreaseStake` function

### DIFF
--- a/contracts/deployments/gamma/base/addresses/rewardsDistributionV2Facet.json
+++ b/contracts/deployments/gamma/base/addresses/rewardsDistributionV2Facet.json
@@ -1,3 +1,3 @@
 {
-  "address": "0xfd17a7B5066f308762c63d6B0c60a3C7ca46404D"
+  "address": "0xb2D4d274CB8a8EC9c81516eEb2457a8165a33672"
 }

--- a/contracts/deployments/omega/base/addresses/rewardsDistributionV2Facet.json
+++ b/contracts/deployments/omega/base/addresses/rewardsDistributionV2Facet.json
@@ -1,3 +1,3 @@
 {
-  "address": "0x83ae43E8441fb08CDe5159506a1b1064e3D35c5c"
+  "address": "0x4B20D6455fFb25D64F8C89228f671f3227cc6c23"
 }

--- a/contracts/scripts/deployments/facets/DeployRewardsDistributionV2.s.sol
+++ b/contracts/scripts/deployments/facets/DeployRewardsDistributionV2.s.sol
@@ -19,6 +19,7 @@ contract DeployRewardsDistributionV2 is Deployer, FacetHelper {
     addSelector(RewardsDistribution.permitAndStake.selector);
     addSelector(RewardsDistribution.stakeOnBehalf.selector);
     addSelector(RewardsDistribution.increaseStake.selector);
+    addSelector(RewardsDistribution.permitAndIncreaseStake.selector);
     addSelector(RewardsDistribution.redelegate.selector);
     addSelector(RewardsDistribution.changeBeneficiary.selector);
     addSelector(RewardsDistribution.initiateWithdraw.selector);

--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -228,6 +228,24 @@ interface IRewardsDistribution is IRewardsDistributionBase {
   /// @param amount The amount of stakeToken to stake
   function increaseStake(uint256 depositId, uint96 amount) external;
 
+  /// @notice Approves the contract to spend the stakeToken with an EIP-2612 permit and increases the
+  /// stake of an existing deposit
+  /// @dev The caller must be the owner of the deposit
+  /// @param depositId The ID of the deposit
+  /// @param amount The amount of stakeToken to stake
+  /// @param deadline The deadline for the permit
+  /// @param v The recovery byte of the permit
+  /// @param r The R signature of the permit
+  /// @param s The S signature of the permit
+  function permitAndIncreaseStake(
+    uint256 depositId,
+    uint96 amount,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external;
+
   /// @notice Redelegates an existing deposit to a new delegatee or reactivates a pending withdrawal
   /// @dev The caller must be the owner of the deposit
   /// @param depositId The ID of the deposit


### PR DESCRIPTION
This introduces a new function `permitAndIncreaseStake` that allows users to stake with EIP-2612 permits and increase the stake of existing deposits. It refactors related logic into reusable internal functions `_permitStakeToken` and `_increaseStake` for better maintainability. Comprehensive tests have been added to ensure correct behavior.