### PR TITLE
Update the test util “waitFor” to be more explicit about return types

### DIFF
--- a/packages/sdk/src/tests/multi/transactions_Tip.test.ts
+++ b/packages/sdk/src/tests/multi/transactions_Tip.test.ts
@@ -225,8 +225,7 @@ describe('transactions_Tip', () => {
                 throw new Error('no tip event found')
             return tip.remoteEvent.event.payload.value.content.value
         })
-        expect(tipEvent?.transaction?.receipt).toBeDefined()
-        expect(userIdFromAddress(tipEvent!.fromUserAddress)).toEqual(bobIdentity.rootWallet.address)
+        expect(userIdFromAddress(tipEvent.fromUserAddress)).toEqual(bobIdentity.rootWallet.address)
         expect(stream.view.membershipContent.tips[ETH_ADDRESS]).toEqual(1000n)
     })
 

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -943,6 +943,8 @@ export function waitFor<T>(
             clearInterval(timeoutId)
             if (result) {
                 resolve(result)
+            } else if (result === undefined && promiseStatus === 'resolved') {
+                resolve(undefined as T)
             } else {
                 reject(lastError)
             }

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -927,7 +927,7 @@ export async function linkWallets(
 export function waitFor<T>(
     callback: (() => T) | (() => Promise<T>),
     options: { timeoutMS: number } = { timeoutMS: 5000 },
-): Promise<T | undefined> {
+): Promise<T> {
     const timeoutContext: Error = new Error(
         'waitFor timed out after ' + options.timeoutMS.toString() + 'ms',
     )
@@ -941,7 +941,7 @@ export function waitFor<T>(
         function onDone(result?: T) {
             clearInterval(intervalId)
             clearInterval(timeoutId)
-            if (result || promiseStatus === 'resolved') {
+            if (result) {
                 resolve(result)
             } else {
                 reject(lastError)


### PR DESCRIPTION
I want to be able to extract data from this function, wondering if this has any side effects