### PR TITLE
test(contract): refactor `EIP712Utils` usage across test contracts

### DIFF
--- a/contracts/test/airdrop/DropFacet.t.sol
+++ b/contracts/test/airdrop/DropFacet.t.sol
@@ -17,7 +17,6 @@ import {DropFacet} from "contracts/src/airdrop/drop/DropFacet.sol";
 import {RewardsDistribution} from "contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol";
 import {BasisPoints} from "contracts/src/utils/libraries/BasisPoints.sol";
 import {DropStorage} from "contracts/src/airdrop/drop/DropStorage.sol";
-import {EIP712Utils} from "contracts/test/utils/EIP712Utils.sol";
 import {NodeOperatorStatus} from "contracts/src/base/registry/facets/operator/NodeOperatorStorage.sol";
 
 // contracts
@@ -29,7 +28,6 @@ import {StakingRewards} from "contracts/src/base/registry/facets/distribution/v2
 
 contract DropFacetTest is
   BaseSetup,
-  EIP712Utils,
   IDropFacetBase,
   IOwnableBase,
   IRewardsDistributionBase

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -17,19 +17,13 @@ import {RewardsDistributionStorage} from "contracts/src/base/registry/facets/dis
 
 // contracts
 import {DeployRewardsDistributionV2} from "contracts/scripts/deployments/facets/DeployRewardsDistributionV2.s.sol";
-import {EIP712Utils} from "contracts/test/utils/EIP712Utils.sol";
 import {Towns} from "contracts/src/tokens/towns/base/Towns.sol";
 import {DelegationProxy} from "contracts/src/base/registry/facets/distribution/v2/DelegationProxy.sol";
 import {UpgradeableBeaconBase} from "contracts/src/diamond/facets/beacon/UpgradeableBeacon.sol";
 import {RewardsDistribution} from "contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol";
 import {BaseRegistryTest} from "./BaseRegistry.t.sol";
 
-contract RewardsDistributionV2Test is
-  BaseRegistryTest,
-  EIP712Utils,
-  IOwnableBase,
-  IDiamond
-{
+contract RewardsDistributionV2Test is BaseRegistryTest, IOwnableBase, IDiamond {
   using FixedPointMathLib for uint256;
 
   bytes32 internal constant STAKE_TYPEHASH =

--- a/contracts/test/spaces/BaseSetup.sol
+++ b/contracts/test/spaces/BaseSetup.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 // utils
 import {TestUtils} from "contracts/test/utils/TestUtils.sol";
-
+import {EIP712Utils} from "contracts/test/utils/EIP712Utils.sol";
 import {SimpleAccountFactory} from "account-abstraction/samples/SimpleAccountFactory.sol";
 import {SimpleAccount} from "account-abstraction/samples/SimpleAccount.sol";
 
@@ -47,15 +47,11 @@ import {DeployRiverAirdrop} from "contracts/scripts/deployments/diamonds/DeployR
  * @notice - This is the base setup to start testing the entire suite of contracts
  * @dev - This contract is inherited by all other test contracts, it will create one diamond contract which represent the factory contract that creates all spaces
  */
-contract BaseSetup is TestUtils, SpaceHelper {
+contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
   uint256 internal constant FREE_ALLOCATION = 1_000;
   string public constant LINKED_WALLET_MESSAGE = "Link your external wallet";
   bytes32 private constant _LINKED_WALLET_TYPEHASH =
     0x6bb89d031fcd292ecd4c0e6855878b7165cebc3a2f35bc6bbac48c088dd8325c;
-  bytes32 private constant _TYPE_HASH =
-    keccak256(
-      "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-    );
 
   DeployBaseRegistry internal deployBaseRegistry = new DeployBaseRegistry();
   DeploySpaceFactory internal deploySpaceFactory = new DeploySpaceFactory();
@@ -223,51 +219,18 @@ contract BaseSetup is TestUtils, SpaceHelper {
     address newWallet,
     uint256 nonce
   ) internal view returns (bytes memory) {
-    (
-      ,
-      string memory name,
-      string memory version,
-      uint256 chainId,
-      address verifyingContract,
-      ,
-
-    ) = eip712Facet.eip712Domain();
-
     bytes32 linkedWalletHash = _getLinkedWalletTypedDataHash(
       LINKED_WALLET_MESSAGE,
       newWallet,
       nonce
     );
-    bytes32 typeDataHash = MessageHashUtils.toTypedDataHash(
-      _getDomainSeparator(name, version, chainId, verifyingContract),
+    (uint8 v, bytes32 r, bytes32 s) = signIntent(
+      privateKey,
+      address(eip712Facet),
       linkedWalletHash
     );
 
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, typeDataHash);
-
     return abi.encodePacked(r, s, v);
-  }
-
-  // https://eips.ethereum.org/EIPS/eip-5267
-  function _getDomainSeparator(
-    string memory name,
-    string memory version,
-    uint256 chainId,
-    address verifyingContract
-  ) public pure returns (bytes32) {
-    bytes32 nameHash = keccak256(abi.encodePacked(name));
-    bytes32 versionHash = keccak256(abi.encodePacked(version));
-
-    return
-      keccak256(
-        abi.encode(
-          _TYPE_HASH,
-          nameHash,
-          versionHash,
-          chainId,
-          verifyingContract
-        )
-      );
   }
 
   function _getLinkedWalletTypedDataHash(


### PR DESCRIPTION
EIP712Utils was removed from unnecessary test files and added only to `BaseSetup` to centralize its usage. This reduces redundancy and simplifies contract inheritance structures for better maintainability.