### PR TITLE
Reduce memory by not saving miniblock signatures in memory

### DIFF
--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -5,10 +5,12 @@ import {
     DecryptionStatus,
     EncryptedContentItem,
     EntitlementsDelegate,
+    EventSignatureBundle,
     GroupSessionsData,
     KeyFulfilmentData,
     KeySolicitationContent,
     KeySolicitationData,
+    KeySolicitationItem,
     makeSessionKeys,
 } from '../decryptionExtensions'
 import {
@@ -87,6 +89,15 @@ describe.concurrent('TestDecryptionExtensions', () => {
                 alice,
                 aliceUserAddress,
                 keySolicitationData,
+                {
+                    hash: new Uint8Array(),
+                    signature: new Uint8Array(),
+                    event: {
+                        creatorAddress: new Uint8Array(),
+                        delegateSig: new Uint8Array(),
+                        delegateExpiryEpochMs: 0n,
+                    },
+                },
             )
             // alice waits for the response
             await keySolicitation
@@ -316,6 +327,7 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
         fromUserId: string,
         fromUserAddress: Uint8Array,
         keySolicitation: KeySolicitationContent,
+        sigBundle: EventSignatureBundle,
     ): Promise<void> {
         log('keySolicitationRequest', streamId, keySolicitation)
         this.markStreamUpToDate(streamId)
@@ -326,7 +338,13 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
                 DecryptionStatus.done,
             )
             // start processing the request
-            this.enqueueKeySolicitation(streamId, fromUserId, fromUserAddress, keySolicitation)
+            this.enqueueKeySolicitation(
+                streamId,
+                fromUserId,
+                fromUserAddress,
+                keySolicitation,
+                sigBundle,
+            )
         })
         return p
     }
@@ -336,8 +354,8 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
         return this._upToDateStreams.has(streamId)
     }
 
-    public isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
-        log('isValidEvent', streamId, eventId)
+    public isValidEvent(item: KeySolicitationItem): { isValid: boolean; reason?: string } {
+        log('isValidEvent', item)
         return { isValid: true }
     }
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -319,10 +319,6 @@ export class Client
         return stream
     }
 
-    isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
-        // if we didn't disable signature validation, we can assume the event is valid
-    }
-
     private initUserJoinedStreams() {
         assert(isDefined(this.userStreamId), 'userStreamId must be set')
         assert(isDefined(this.syncedStreamsExtensions), 'syncedStreamsExtensions must be set')

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -90,14 +90,7 @@ import {
     contractAddressFromSpaceId,
     isUserId,
 } from './id'
-import {
-    checkEventSignature,
-    makeEvent,
-    unpackEnvelope,
-    UnpackEnvelopeOpts,
-    unpackStream,
-    unpackStreamEx,
-} from './sign'
+import { makeEvent, unpackEnvelope, UnpackEnvelopeOpts, unpackStream, unpackStreamEx } from './sign'
 import { StreamEvents } from './streamEvents'
 import { IStreamStateView, StreamStateView } from './streamStateView'
 import {
@@ -328,34 +321,6 @@ export class Client
 
     isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
         // if we didn't disable signature validation, we can assume the event is valid
-        if (this.unpackEnvelopeOpts?.disableSignatureValidation !== true) {
-            return { isValid: true }
-        }
-        const stream = this.stream(streamId)
-        if (!stream) {
-            return { isValid: false, reason: 'stream not found' }
-        }
-        const sigBundle = stream.view.getSignature(eventId)
-        if (!sigBundle) {
-            return { isValid: false, reason: 'event not found' }
-        }
-        if (!sigBundle.signature) {
-            return { isValid: false, reason: 'remote event signature not found' }
-        }
-        if (this.validatedEvents[eventId]) {
-            return this.validatedEvents[eventId]
-        }
-        try {
-            checkEventSignature(sigBundle.event, sigBundle.hash, sigBundle.signature)
-            const result = { isValid: true }
-            this.validatedEvents[eventId] = result
-            return result
-        } catch (err) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            const result = { isValid: false, reason: `error: ${err}` }
-            this.validatedEvents[eventId] = result
-            return result
-        }
     }
 
     private initUserJoinedStreams() {

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -3,11 +3,13 @@ import {
     DecryptionSessionError,
     EncryptedContentItem,
     EntitlementsDelegate,
+    EventSignatureBundle,
     GroupEncryptionCrypto,
     GroupSessionsData,
     KeyFulfilmentData,
     KeySolicitationContent,
     KeySolicitationData,
+    KeySolicitationItem,
     UserDevice,
 } from '@river-build/encryption'
 import {
@@ -34,9 +36,12 @@ import {
     isUserStreamId,
     isChannelStreamId,
 } from './id'
+import { checkEventSignature } from './sign'
 
 export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
     private isMobileSafariBackgrounded = false
+    private validatedEvents: Record<string, { isValid: boolean; reason?: string }> = {}
+    private unpackEnvelopeOpts?: { disableSignatureValidation: boolean }
 
     constructor(
         private readonly client: Client,
@@ -44,6 +49,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         delegate: EntitlementsDelegate,
         userId: string,
         userDevice: UserDevice,
+        unpackEnvelopeOpts?: { disableSignatureValidation: boolean },
     ) {
         const upToDateStreams = new Set<string>()
         client.streams.getStreams().forEach((stream) => {
@@ -54,6 +60,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
 
         super(client, crypto, delegate, userDevice, userId, upToDateStreams)
 
+        this.unpackEnvelopeOpts = unpackEnvelopeOpts
         const onMembershipChange = (streamId: string, userId: string) => {
             if (userId === this.userId) {
                 this.retryDecryptionFailures(streamId)
@@ -78,7 +85,15 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             fromUserId: string,
             fromUserAddress: Uint8Array,
             keySolicitation: KeySolicitationContent,
-        ) => this.enqueueKeySolicitation(streamId, fromUserId, fromUserAddress, keySolicitation)
+            sigBundle: EventSignatureBundle,
+        ) =>
+            this.enqueueKeySolicitation(
+                streamId,
+                fromUserId,
+                fromUserAddress,
+                keySolicitation,
+                sigBundle,
+            )
 
         const onInitKeySolicitations = (
             streamId: string,
@@ -87,7 +102,8 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
                 userAddress: Uint8Array
                 solicitations: KeySolicitationContent[]
             }[],
-        ) => this.enqueueInitKeySolicitations(streamId, members)
+            sigBundle: EventSignatureBundle,
+        ) => this.enqueueInitKeySolicitations(streamId, members, sigBundle)
 
         const onStreamInitialized = (streamId: string) => {
             if (isUserInboxStreamId(streamId)) {
@@ -208,8 +224,32 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         return true
     }
 
-    public isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
-        return this.client.isValidEvent(streamId, eventId)
+    public isValidEvent(item: KeySolicitationItem): { isValid: boolean; reason?: string } {
+        if (this.unpackEnvelopeOpts?.disableSignatureValidation !== true) {
+            return { isValid: true }
+        }
+        const eventId = item.solicitation.srcEventId
+        const sigBundle = item.sigBundle
+        if (!sigBundle) {
+            return { isValid: false, reason: 'event not found' }
+        }
+        if (!sigBundle.signature) {
+            return { isValid: false, reason: 'remote event signature not found' }
+        }
+        if (this.validatedEvents[eventId]) {
+            return this.validatedEvents[eventId]
+        }
+        try {
+            checkEventSignature(sigBundle.event, sigBundle.hash, sigBundle.signature)
+            const result = { isValid: true }
+            this.validatedEvents[eventId] = result
+            return result
+        } catch (err) {
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            const result = { isValid: false, reason: `error: ${err}` }
+            this.validatedEvents[eventId] = result
+            return result
+        }
     }
 
     public onDecryptionError(item: EncryptedContentItem, err: DecryptionSessionError): void {

--- a/packages/sdk/src/streamEvents.ts
+++ b/packages/sdk/src/streamEvents.ts
@@ -16,7 +16,7 @@ import {
     RemoteTimelineEvent,
     StreamTimelineEvent,
 } from './types'
-import { KeySolicitationContent, UserDevice } from '@river-build/encryption'
+import { EventSignatureBundle, KeySolicitationContent, UserDevice } from '@river-build/encryption'
 import { EncryptedContent } from './encryptedContentTypes'
 import { SyncState } from './syncedStreamsLoop'
 import { Pin } from './streamStateView_Members'
@@ -38,12 +38,14 @@ export type StreamEncryptionEvents = {
         fromUserId: string,
         fromUserAddress: Uint8Array,
         event: KeySolicitationContent,
+        sigBundle: EventSignatureBundle,
     ) => void
     updatedKeySolicitation: (
         streamId: string,
         fromUserId: string,
         fromUserAddress: Uint8Array,
         event: KeySolicitationContent,
+        sigBundle: EventSignatureBundle,
     ) => void
     initKeySolicitations: (
         streamId: string,
@@ -52,6 +54,7 @@ export type StreamEncryptionEvents = {
             userAddress: Uint8Array
             solicitations: KeySolicitationContent[]
         }[],
+        sigBundle: EventSignatureBundle,
     ) => void
     userDeviceKeyMessage: (streamId: string, userId: string, userDevice: UserDevice) => void
 }

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -11,7 +11,6 @@ import {
 import TypedEmitter from 'typed-emitter'
 import {
     ConfirmedTimelineEvent,
-    EventSignatureBundle,
     LocalEventStatus,
     LocalTimelineEvent,
     ParsedEvent,
@@ -84,7 +83,6 @@ export interface IStreamStateView {
     get userInboxContent(): StreamStateView_UserInbox
     get mediaContent(): StreamStateView_Media
     snapshot(): Snapshot | undefined
-    getSignature(eventId: string): EventSignatureBundle | undefined
     getMembers(): StreamStateView_Members
     getMemberMetadata(): StreamStateView_MemberMetadata
     getChannelMetadata(): StreamStateView_ChannelMetadata | undefined
@@ -99,7 +97,6 @@ export class StreamStateView implements IStreamStateView {
     readonly contentKind: SnapshotCaseType
     readonly timeline: StreamTimelineEvent[] = []
     readonly events = new Map<string, StreamTimelineEvent>()
-    readonly signatures = new Map<string, EventSignatureBundle>()
     isInitialized = false
     prevMiniblockHash?: Uint8Array
     lastEventNum = 0n
@@ -232,6 +229,7 @@ export class StreamStateView implements IStreamStateView {
 
     private applySnapshot(
         eventHash: string,
+        event: ParsedEvent,
         inSnapshot: Snapshot,
         cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
@@ -300,7 +298,13 @@ export class StreamStateView implements IStreamStateView {
             default:
                 logNever(snapshot.content)
         }
-        this.membershipContent.applySnapshot(eventHash, snapshot, cleartexts, encryptionEmitter)
+        this.membershipContent.applySnapshot(
+            eventHash,
+            event,
+            snapshot,
+            cleartexts,
+            encryptionEmitter,
+        )
     }
 
     private appendStreamAndCookie(
@@ -354,21 +358,8 @@ export class StreamStateView implements IStreamStateView {
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): ConfirmedTimelineEvent[] | undefined {
-        check(
-            !this.events.has(timelineEvent.hashStr) && !this.signatures.has(timelineEvent.hashStr),
-        )
-        if (timelineEvent.remoteEvent.event.payload.case === 'miniblockHeader') {
-            // just save the signature, saving the whole event is overkill
-            this.signatures.set(timelineEvent.hashStr, {
-                hash: timelineEvent.remoteEvent.hash,
-                signature: timelineEvent.remoteEvent.signature,
-                event: {
-                    creatorAddress: timelineEvent.remoteEvent.event.creatorAddress,
-                    delegateSig: timelineEvent.remoteEvent.event.delegateSig,
-                    delegateExpiryEpochMs: timelineEvent.remoteEvent.event.delegateExpiryEpochMs,
-                },
-            })
-        } else {
+        check(!this.events.has(timelineEvent.hashStr))
+        if (timelineEvent.remoteEvent.event.payload.case !== 'miniblockHeader') {
             this.events.set(timelineEvent.hashStr, timelineEvent)
         }
 
@@ -464,20 +455,8 @@ export class StreamStateView implements IStreamStateView {
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
-        check(
-            !this.events.has(timelineEvent.hashStr) && !this.signatures.has(timelineEvent.hashStr),
-        )
-        if (timelineEvent.remoteEvent.event.payload.case === 'miniblockHeader') {
-            this.signatures.set(timelineEvent.hashStr, {
-                hash: timelineEvent.remoteEvent.hash,
-                signature: timelineEvent.remoteEvent.signature,
-                event: {
-                    creatorAddress: timelineEvent.remoteEvent.event.creatorAddress,
-                    delegateSig: timelineEvent.remoteEvent.event.delegateSig,
-                    delegateExpiryEpochMs: timelineEvent.remoteEvent.event.delegateExpiryEpochMs,
-                },
-            })
-        } else {
+        check(!this.events.has(timelineEvent.hashStr))
+        if (timelineEvent.remoteEvent.event.payload.case !== 'miniblockHeader') {
             this.events.set(timelineEvent.hashStr, timelineEvent)
         }
 
@@ -599,8 +578,16 @@ export class StreamStateView implements IStreamStateView {
     ): void {
         check(miniblocks.length > 0, `Stream has no miniblocks ${this.streamId}`, Err.STREAM_EMPTY)
         // parse the blocks
+        const miniblockHeaderEvent = miniblocks[0].events[-1]
+
         // initialize from snapshot data, this gets all memberships and channel data, etc
-        this.applySnapshot(bin_toHexString(miniblocks[0].hash), snapshot, cleartexts, emitter)
+        this.applySnapshot(
+            bin_toHexString(miniblocks[0].hash),
+            miniblockHeaderEvent,
+            snapshot,
+            cleartexts,
+            emitter,
+        )
         // initialize from miniblocks, the first minblock is the snapshot block, it's events are accounted for
         const block0Events = miniblocks[0].events.map((parsedEvent, i) => {
             const eventNum = miniblocks[0].header.eventNumOffset + BigInt(i)
@@ -787,18 +774,6 @@ export class StreamStateView implements IStreamStateView {
             previousId,
             timelineEvent,
         )
-    }
-
-    getSignature(eventId: string): EventSignatureBundle | undefined {
-        const event = this.events.get(eventId)
-        if (event) {
-            return event.remoteEvent
-        }
-        const signature = this.signatures.get(eventId)
-        if (signature) {
-            return signature
-        }
-        return undefined
     }
 
     getMembers(): StreamStateView_Members {

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -578,7 +578,12 @@ export class StreamStateView implements IStreamStateView {
     ): void {
         check(miniblocks.length > 0, `Stream has no miniblocks ${this.streamId}`, Err.STREAM_EMPTY)
         // parse the blocks
-        const miniblockHeaderEvent = miniblocks[0].events[-1]
+        const miniblockHeaderEvent = miniblocks[0].events.at(-1)
+        check(
+            isDefined(miniblockHeaderEvent),
+            `Miniblock header event not found ${this.streamId}`,
+            Err.STREAM_EMPTY,
+        )
 
         // initialize from snapshot data, this gets all memberships and channel data, etc
         this.applySnapshot(

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -9,8 +9,10 @@ import TypedEmitter from 'typed-emitter'
 import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 import {
     ConfirmedTimelineEvent,
+    ParsedEvent,
     RemoteTimelineEvent,
     StreamTimelineEvent,
+    getEventSignature,
     makeRemoteTimelineEvent,
 } from './types'
 import { isDefined, logNever } from './check'
@@ -71,6 +73,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
     // initialization
     applySnapshot(
         eventId: string,
+        event: ParsedEvent,
         snapshot: Snapshot,
         cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
@@ -141,7 +144,12 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
             cleartexts,
             encryptionEmitter,
         )
-        this.solicitHelper.initSolicitations(Array.from(this.joined.values()), encryptionEmitter)
+        const sigBundle = getEventSignature(event)
+        this.solicitHelper.initSolicitations(
+            Array.from(this.joined.values()),
+            sigBundle,
+            encryptionEmitter,
+        )
 
         snapshot.members?.pins.forEach((snappedPin) => {
             if (snappedPin.pin?.event) {
@@ -266,6 +274,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                         stateMember,
                         event.hashStr,
                         payload.content.value,
+                        getEventSignature(event.remoteEvent),
                         encryptionEmitter,
                     )
                 }
@@ -278,6 +287,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                     this.solicitHelper.applyFulfillment(
                         stateMember,
                         payload.content.value,
+                        getEventSignature(event.remoteEvent),
                         encryptionEmitter,
                     )
                 }

--- a/packages/sdk/src/streamStateView_Members_Solicitations.ts
+++ b/packages/sdk/src/streamStateView_Members_Solicitations.ts
@@ -3,13 +3,14 @@ import { MemberPayload_KeyFulfillment, MemberPayload_KeySolicitation } from '@ri
 import { StreamEncryptionEvents } from './streamEvents'
 import { StreamMember } from './streamStateView_Members'
 import { removeCommon } from './utils'
-import { KeySolicitationContent } from '@river-build/encryption'
+import { EventSignatureBundle, KeySolicitationContent } from '@river-build/encryption'
 
 export class StreamStateView_Members_Solicitations {
     constructor(readonly streamId: string) {}
 
     initSolicitations(
         members: StreamMember[],
+        sigBundle: EventSignatureBundle,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         encryptionEmitter?.emit(
@@ -20,6 +21,7 @@ export class StreamStateView_Members_Solicitations {
                 userAddress: member.userAddress,
                 solicitations: member.solicitations,
             })),
+            sigBundle,
         )
     }
 
@@ -27,6 +29,7 @@ export class StreamStateView_Members_Solicitations {
         user: StreamMember,
         eventId: string,
         solicitation: MemberPayload_KeySolicitation,
+        sigBundle: EventSignatureBundle,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         user.solicitations = user.solicitations.filter(
@@ -46,12 +49,14 @@ export class StreamStateView_Members_Solicitations {
             user.userId,
             user.userAddress,
             newSolicitation,
+            sigBundle,
         )
     }
 
     applyFulfillment(
         user: StreamMember,
         fulfillment: MemberPayload_KeyFulfillment,
+        sigBundle: EventSignatureBundle,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         const index = user.solicitations.findIndex((x) => x.deviceKey === fulfillment.deviceKey)
@@ -73,6 +78,7 @@ export class StreamStateView_Members_Solicitations {
             user.userId,
             user.userAddress,
             newEvent,
+            sigBundle,
         )
     }
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -42,24 +42,13 @@ import { bin_toHexString } from '@river-build/dlog'
 import { isDefined } from './check'
 import { DecryptedContent } from './encryptedContentTypes'
 import { addressFromUserId, streamIdAsBytes } from './id'
-import { DecryptionSessionError } from '@river-build/encryption'
+import { DecryptionSessionError, EventSignatureBundle } from '@river-build/encryption'
 
 export type LocalEventStatus = 'sending' | 'sent' | 'failed'
 export interface LocalEvent {
     localId: string
     channelMessage: ChannelMessage
     status: LocalEventStatus
-}
-
-// paired down from StreamEvent, required for signature validation
-export interface EventSignatureBundle {
-    hash: Uint8Array
-    signature: Uint8Array | undefined
-    event: {
-        creatorAddress: Uint8Array
-        delegateSig: Uint8Array
-        delegateExpiryEpochMs: bigint
-    }
 }
 
 export interface ParsedEvent {
@@ -140,6 +129,18 @@ export function isConfirmedEvent(event: StreamTimelineEvent): event is Confirmed
         event.confirmedEventNum !== undefined &&
         event.miniblockNum !== undefined
     )
+}
+
+export function getEventSignature(remoteEvent: ParsedEvent): EventSignatureBundle {
+    return {
+        hash: remoteEvent.hash,
+        signature: remoteEvent.signature,
+        event: {
+            creatorAddress: remoteEvent.event.creatorAddress,
+            delegateSig: remoteEvent.event.delegateSig,
+            delegateExpiryEpochMs: remoteEvent.event.delegateExpiryEpochMs,
+        },
+    }
 }
 
 export function makeRemoteTimelineEvent(params: {


### PR DESCRIPTION
approx half of our events are miniblock headers
i stopped saving them and saved a whole bunch of memory, but it broke signature validation
https://github.com/towns-protocol/towns/pull/2290

this fixes signature validation to pass the required info along with the solicitation, instead of programming a loopdyloop where we go back into the view for it.

much better imo