### PR TITLE
node/repl: correct error handling on MB candidate promotion

### DIFF
--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -474,6 +474,9 @@ func (p *miniblockProducer) promoteConfirmedCandidates(ctx context.Context, jobs
 		if err != nil {
 			log.Error("Unable to retrieve stream details from registry",
 				"streamId", job.stream.streamId, "err", err)
+
+			p.jobDone(ctx, job)
+			continue
 		}
 
 		committedLocalCandidateRef := MiniblockRef{


### PR DESCRIPTION
When stream details can't be fetched from the smart contract the error handling logs the issue and continue the flow that uses the uninitialised returned value which results in a nil panic.