### PR TITLE
docs: fix dead link in `packages/docs/towns-token/delegation.mdx`

### DIFF
--- a/packages/docs/towns-token/delegation.mdx
+++ b/packages/docs/towns-token/delegation.mdx
@@ -23,7 +23,7 @@ Any tokens received from network operation will be claimable by calling the `cla
 
 Towns tokens held on Ethereum mainnet can also be delegated at https://river.build/delegate.
 
-Post-delegation, the details (such as delegating wallet, operator wallet, token quantity) are bridged to the Base network and referenced in the Node Operator Registry using the [L1CrossDomainMessenger](https://docs.optimism.io/builders/app-developers/bridging/messaging) contract.
+Post-delegation, the details (such as delegating wallet, operator wallet, token quantity) are bridged to the Base network and referenced in the Node Operator Registry using the [L1CrossDomainMessenger](https://docs.optimism.io/app-developers/bridging/messaging) contract.
 
 <Warning>
 Tokens rewarded for network operation are only claimable on Base. This means in the case where a user delegating from Ethereum mainnet doesn’t own the same wallet address on both Ethereum mainnet and Base, they must authorize a different wallet address that they own on Base which can claim on behalf of the Ethereum mainnet wallet.


### PR DESCRIPTION
Hi! I fixes a dead link in the delegation.mdx file. The original link pointing to Optimism's documentation for the L1CrossDomainMessenger contract was outdated and has been updated to the correct URL. 