### PR TITLE
Update attachment static info to allow ens name

### DIFF
--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -85,6 +85,7 @@ message ChannelMessage {
                     optional string displayName = 2;
                     optional string channelName = 3;
                     optional string spaceName = 4;
+                    optional string ensName = 5;
                 }
 
                 string url = 1;


### PR DESCRIPTION
seems like it was an oversite