### PR TITLE
perf(contract): refactor `StringSet` and add tests

### DIFF
--- a/contracts/src/utils/StringSet.sol
+++ b/contracts/src/utils/StringSet.sol
@@ -80,15 +80,15 @@ library StringSet {
         let len := shr(1, packed)
         // the number of words used to store the string
         let words := shr(5, add(len, 0x1f))
-        let p := keccak256(0, 0x20)
-        for {
-          let i := 0
-        } 1 {} {
-          if iszero(lt(i, words)) {
+        mstore(0, $.slot)
+        let ptr := keccak256(0, 0x20)
+        let end := add(ptr, words)
+        for {} 1 {} {
+          if iszero(lt(ptr, end)) {
             break
           }
-          sstore(add(p, i), 0)
-          i := add(i, 1)
+          sstore(ptr, 0)
+          ptr := add(ptr, 1)
         }
         break
       }

--- a/contracts/src/utils/StringSet.sol
+++ b/contracts/src/utils/StringSet.sol
@@ -130,6 +130,19 @@ library StringSet {
   }
 
   /**
+   * @dev Removes all values from a set. O(n).
+   */
+  function clear(Set storage set) internal {
+    Uint256Ref storage lengthRef = _valuesLengthRef(set);
+    uint256 len = lengthRef.value;
+    for (uint256 i; i < len; ++i) {
+      _indexRef(set, set._values[i]).value = 0;
+      delete set._values[i];
+    }
+    lengthRef.value = 0;
+  }
+
+  /**
    * @dev Returns true if the value is in the set. O(1).
    */
   function contains(

--- a/contracts/src/utils/StringSet.sol
+++ b/contracts/src/utils/StringSet.sol
@@ -101,9 +101,13 @@ library StringSet {
    * Returns true if the value was added to the set, that is if it was not
    * already present.
    */
-  function add(Set storage set, string memory value) internal returns (bool) {
+  function add(
+    Set storage set,
+    string memory value
+  ) internal returns (bool added) {
     Uint256Ref storage indexRef = _indexRef(set, value);
-    if (indexRef.value == 0) {
+    added = indexRef.value == 0;
+    if (added) {
       Uint256Ref storage lengthRef = _valuesLengthRef(set);
       uint256 len = lengthRef.value;
       uint256 newLen;
@@ -117,9 +121,6 @@ library StringSet {
       // and use 0 as a sentinel value
       // equivalent: set._indexes[value] = set._values.length;
       indexRef.value = newLen;
-      return true;
-    } else {
-      return false;
     }
   }
 
@@ -132,12 +133,12 @@ library StringSet {
   function remove(
     Set storage set,
     string memory value
-  ) internal returns (bool) {
+  ) internal returns (bool removed) {
     // We read and store the value's index to prevent multiple reads from the same storage slot
     Uint256Ref storage indexRef = _indexRef(set, value);
     uint256 valueIndex = indexRef.value;
-
-    if (valueIndex != 0) {
+    removed = valueIndex != 0;
+    if (removed) {
       // Equivalent to contains(set, value)
       // To delete an element from the _values array in O(1), we swap the element to delete with the last one in
       // the array, and then remove the last element (sometimes called as 'swap and pop').
@@ -153,7 +154,6 @@ library StringSet {
       string storage lastRef = _at(set, lastIndex);
       if (len != valueIndex) {
         string memory lastValue = lastRef;
-
         unchecked {
           // Move the last value to the index where the value to delete is
           set._values[valueIndex - 1] = lastValue;
@@ -169,10 +169,6 @@ library StringSet {
 
       // Delete the index for the deleted slot
       indexRef.value = 0;
-
-      return true;
-    } else {
-      return false;
     }
   }
 

--- a/contracts/src/utils/StringSet.sol
+++ b/contracts/src/utils/StringSet.sol
@@ -55,7 +55,7 @@ library StringSet {
    * Returns true if the value was added to the set, that is if it was not
    * already present.
    */
-  function _add(Set storage set, string memory value) private returns (bool) {
+  function add(Set storage set, string memory value) internal returns (bool) {
     Uint256Ref storage indexRef = _indexRef(set, value);
     if (indexRef.value == 0) {
       Uint256Ref storage lengthRef = _valuesLengthRef(set);
@@ -83,10 +83,10 @@ library StringSet {
    * Returns true if the value was removed from the set, that is if it was
    * present.
    */
-  function _remove(
+  function remove(
     Set storage set,
     string memory value
-  ) private returns (bool) {
+  ) internal returns (bool) {
     // We read and store the value's index to prevent multiple reads from the same storage slot
     Uint256Ref storage indexRef = _indexRef(set, value);
     uint256 valueIndex = indexRef.value;
@@ -132,88 +132,19 @@ library StringSet {
   /**
    * @dev Returns true if the value is in the set. O(1).
    */
-  function _contains(
-    Set storage set,
-    string memory value
-  ) private view returns (bool) {
-    // equivalent: return set._indexes[value] != 0;
-    return _indexRef(set, value).value != 0;
-  }
-
-  /**
-   * @dev Returns the number of values on the set. O(1).
-   */
-  function _length(Set storage set) private view returns (uint256) {
-    return set._values.length;
-  }
-
-  /**
-   * @dev Returns the value stored at position `index` in the set. O(1).
-   *
-   * Note that there are no guarantees on the ordering of values inside the
-   * array, and it may change when more values are added or removed.
-   *
-   * Requirements:
-   *
-   * - `index` must be strictly less than {length}.
-   */
-  function _at(
-    Set storage set,
-    uint256 index
-  ) private view returns (string memory) {
-    return set._values[index];
-  }
-
-  /**
-   * @dev Return the entire set in an array
-   *
-   * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-   * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
-   * this function has an unbounded cost, and using it as part of a state-changing function may render the function
-   * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
-   */
-  function _values(Set storage set) private view returns (string[] memory) {
-    return set._values;
-  }
-
-  /**
-   * @dev Add a value to a set. O(1).
-   *
-   * Returns true if the value was added to the set, that is if it was not
-   * already present.
-   */
-  function add(Set storage set, string memory value) internal returns (bool) {
-    return _add(set, value);
-  }
-
-  /**
-   * @dev Removes a value from a set. O(1).
-   *
-   * Returns true if the value was removed from the set, that is if it was
-   * present.
-   */
-  function remove(
-    Set storage set,
-    string memory value
-  ) internal returns (bool) {
-    return _remove(set, value);
-  }
-
-  /**
-   * @dev Returns true if the value is in the set. O(1).
-   */
   function contains(
     Set storage set,
     string memory value
   ) internal view returns (bool) {
-    return _contains(set, value);
+    // equivalent: return set._indexes[value] != 0;
+    return _indexRef(set, value).value != 0;
   }
 
   /**
    * @dev Returns the number of values in the set. O(1).
    */
   function length(Set storage set) internal view returns (uint256) {
-    return _length(set);
+    return set._values.length;
   }
 
   /**
@@ -230,7 +161,7 @@ library StringSet {
     Set storage set,
     uint256 index
   ) internal view returns (string memory) {
-    return _at(set, index);
+    return set._values[index];
   }
 
   /**
@@ -242,6 +173,6 @@ library StringSet {
    * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
    */
   function values(Set storage set) internal view returns (string[] memory) {
-    return _values(set);
+    return set._values;
   }
 }

--- a/contracts/test/utils/StringSet.t.sol
+++ b/contracts/test/utils/StringSet.t.sol
@@ -63,10 +63,7 @@ contract StringSetTest is TestUtils {
   }
 
   function test_at() public {
-    // Add multiple values
-    mockSet.add("value1");
-    mockSet.add("value2");
-    mockSet.add("value3");
+    _addValues();
 
     // Retrieve values by index
     string memory firstValue = mockSet.at(0);
@@ -99,9 +96,7 @@ contract StringSetTest is TestUtils {
 
   function test_removeAndSwap() public {
     /* Ensure the removal logic 'swap and pop' is tested */
-    mockSet.add("value1");
-    mockSet.add("value2");
-    mockSet.add("value3");
+    _addValues();
 
     // Remove middle value and test index integrity
     bool removed = mockSet.remove("value2");
@@ -117,21 +112,37 @@ contract StringSetTest is TestUtils {
   }
 
   function test_removeAll() public {
-    mockSet.add("value1");
-    mockSet.add("value2");
-    mockSet.add("value3");
+    _addValues();
     mockSet.remove("value1");
     mockSet.remove("value2");
     mockSet.remove("value3");
+    _checkRemovedValues();
   }
 
   function test_removeAll_reverse() public {
-    mockSet.add("value1");
-    mockSet.add("value2");
-    mockSet.add("value3");
+    _addValues();
     mockSet.remove("value3");
     mockSet.remove("value2");
     mockSet.remove("value1");
+    _checkRemovedValues();
+  }
+
+  function test_clear() public {
+    _addValues();
+    mockSet.clear();
+    _checkRemovedValues();
+  }
+
+  function _addValues() private {
+    mockSet.add("value1");
+    mockSet.add("value2");
+    mockSet.add("value3");
+  }
+
+  function _checkRemovedValues() private view {
+    assertFalse(mockSet.contains("value1"), "Expected 'value1' to be removed");
+    assertFalse(mockSet.contains("value2"), "Expected 'value2' to be removed");
+    assertFalse(mockSet.contains("value3"), "Expected 'value3' to be removed");
   }
 }
 
@@ -146,6 +157,10 @@ contract MockStringSet {
 
   function remove(string memory value) external returns (bool) {
     return testSet.remove(value);
+  }
+
+  function clear() external {
+    testSet.clear();
   }
 
   function contains(string memory value) external view returns (bool) {

--- a/contracts/test/utils/StringSet.t.sol
+++ b/contracts/test/utils/StringSet.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {stdError} from "forge-std/StdError.sol";
+import {StringSet} from "contracts/src/utils/StringSet.sol";
+import {TestUtils} from "./TestUtils.sol";
+
+contract StringSetTest is TestUtils {
+  MockStringSet private mockSet = new MockStringSet();
+
+  function test_add() public {
+    // Test adding unique strings
+    bool added = mockSet.add("value1");
+    assertTrue(added, "Expected to add 'value1' successfully");
+
+    // Test adding duplicate string
+    added = mockSet.add("value1");
+    assertFalse(added, "Expected not to add duplicate 'value1'");
+  }
+
+  function test_remove() public {
+    // Add values to the set
+    mockSet.add("value1");
+    mockSet.add("value2");
+
+    // Test successful removal
+    bool removed = mockSet.remove("value1");
+    assertTrue(removed, "Expected to remove 'value1' successfully");
+
+    // Test removing a non-existent value
+    removed = mockSet.remove("value3");
+    assertFalse(removed, "Expected not to remove non-existent 'value3'");
+  }
+
+  function test_contains() public {
+    // Add value and check for its existence
+    mockSet.add("value1");
+    bool exists = mockSet.contains("value1");
+    assertTrue(exists, "'value1' should exist in the set");
+
+    // Check for a non-existent value
+    exists = mockSet.contains("value2");
+    assertFalse(exists, "'value2' should not exist in the set");
+  }
+
+  function test_length() public {
+    // Initially, the set should be empty
+    uint256 length = mockSet.length();
+    assertEq(length, 0, "Expected initial length to be 0");
+
+    // Add some values
+    mockSet.add("value1");
+    mockSet.add("value2");
+
+    // Length should now be 2
+    length = mockSet.length();
+    assertEq(length, 2, "Expected length to be 2 after adding two values");
+
+    // Remove a value and check length
+    mockSet.remove("value1");
+    length = mockSet.length();
+    assertEq(length, 1, "Expected length to be 1 after removing one value");
+  }
+
+  function test_at() public {
+    // Add multiple values
+    mockSet.add("value1");
+    mockSet.add("value2");
+    mockSet.add("value3");
+
+    // Retrieve values by index
+    string memory firstValue = mockSet.at(0);
+    assertEq(firstValue, "value1", "Expected the first value to be 'value1'");
+
+    string memory secondValue = mockSet.at(1);
+    assertEq(secondValue, "value2", "Expected the second value to be 'value2'");
+
+    string memory thirdValue = mockSet.at(2);
+    assertEq(thirdValue, "value3", "Expected the third value to be 'value3'");
+
+    // Test accessing out-of-bounds index
+    vm.expectRevert(stdError.indexOOBError);
+    mockSet.at(3);
+  }
+
+  function test_values() public {
+    // Add multiple values
+    mockSet.add("value1");
+    mockSet.add("value2");
+
+    // Retrieve all values
+    string[] memory values = mockSet.values();
+
+    // Check array length and content
+    assertEq(values.length, 2, "Expected values array length to be 2");
+    assertEq(values[0], "value1", "Expected first value to be 'value1'");
+    assertEq(values[1], "value2", "Expected second value to be 'value2'");
+  }
+
+  function test_removeAndSwap() public {
+    /* Ensure the removal logic 'swap and pop' is tested */
+    mockSet.add("value1");
+    mockSet.add("value2");
+    mockSet.add("value3");
+
+    // Remove middle value and test index integrity
+    bool removed = mockSet.remove("value2");
+    assertTrue(removed, "Expected to remove 'value2' successfully");
+    assertFalse(mockSet.contains("value2"), "Expected 'value2' to be removed");
+
+    // Ensure remaining values are consistent
+    string memory firstValue = mockSet.at(0);
+    assertEq(firstValue, "value1", "Expected the first value to be 'value1'");
+
+    string memory secondValue = mockSet.at(1);
+    assertEq(secondValue, "value3", "Expected the second value to be 'value3'");
+  }
+
+  function test_removeAll() public {
+    mockSet.add("value1");
+    mockSet.add("value2");
+    mockSet.add("value3");
+    mockSet.remove("value1");
+    mockSet.remove("value2");
+    mockSet.remove("value3");
+  }
+
+  function test_removeAll_reverse() public {
+    mockSet.add("value1");
+    mockSet.add("value2");
+    mockSet.add("value3");
+    mockSet.remove("value3");
+    mockSet.remove("value2");
+    mockSet.remove("value1");
+  }
+}
+
+contract MockStringSet {
+  using StringSet for StringSet.Set;
+
+  StringSet.Set private testSet;
+
+  function add(string memory value) external returns (bool) {
+    return testSet.add(value);
+  }
+
+  function remove(string memory value) external returns (bool) {
+    return testSet.remove(value);
+  }
+
+  function contains(string memory value) external view returns (bool) {
+    return testSet.contains(value);
+  }
+
+  function length() external view returns (uint256) {
+    return testSet.length();
+  }
+
+  function at(uint256 index) external view returns (string memory) {
+    return testSet.at(index);
+  }
+
+  function values() external view returns (string[] memory) {
+    return testSet.values();
+  }
+}

--- a/contracts/test/utils/StringSet.t.sol
+++ b/contracts/test/utils/StringSet.t.sol
@@ -7,6 +7,14 @@ import {TestUtils} from "./TestUtils.sol";
 
 contract StringSetTest is TestUtils {
   MockStringSet private mockSet = new MockStringSet();
+  string private s;
+
+  function test_fuzz_delete(string memory _s) public {
+    s = _s;
+    StringSet._delete(s);
+    _s = s;
+    assertEq(_s, "");
+  }
 
   function test_add() public {
     // Test adding unique strings


### PR DESCRIPTION
- Add unit tests for `StringSet` library
- Refactor `StringSet` to use assembly for index management
- Refactor `StringSet` to use `Uint256Ref` for cleaner indexing
- Refactor `StringSet` to optimize array length handling
- Refactor `StringSet` to remove private helper functions
- Add `clear` function to `StringSet` and refactor tests
- Add `_delete` function to handle string deletion in storage
- Fix storage clearing logic in `StringSet` delete operation
- Refactor `add` and `remove` functions to use named returns