### PR TITLE
Fix big number error when fetching token member metadata

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -112,7 +112,7 @@ export function setupRoutes(srv: Server) {
 	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
 	srv.get('/space/:spaceAddress/image/:eventId', fetchSpaceImage)
 	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
-	srv.get('/space/:spaceAddress/token/:tokenId', fetchSpaceMemberMetadata)
+	srv.get('/space/:spaceAddress/token/:tokenId', fetchSpaceMemberMetadata) // for fetching token info (i.e. openSea metadata)
 	srv.get('/user/:userId/bio', fetchUserBio)
 
 	// not cached

--- a/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
@@ -101,12 +101,12 @@ const getSpaceMemberMetadata = async (
 			{
 				trait_type: 'Renewal Price',
 				display_type: 'number',
-				value: renewalPrice.toNumber(),
+				value: renewalPrice.toString(),
 			},
 			{
 				trait_type: 'Membership Expiration',
 				display_type: 'date',
-				value: membershipExpiration.toNumber(),
+				value: membershipExpiration.toString(),
 			},
 			{
 				trait_type: 'Membership Banned',


### PR DESCRIPTION
We're getting overflows

example error: https://app.datadoghq.com/logs?query=status:error%20service:stream-metadata&agg_m=count&agg_m_source=base&agg_q=service,env&agg_q_source=base,base&agg_t=count&clustering_pattern_field_path=message&cols=service&event=AwAAAZVajzZftyDhDAAAABhBWlZhanp2TkFBQWJBdEtmcG5id0lnQVIAAAA1MDE5NTVhZjItNzI2Zi00NjQ3LTlmY2UtNjgyMGRkMzJlNjEwLXN5bnRoZXRpYy1saXN0LTAAAdCO&fromUser=false&messageDisplay=inline&sort_m=,&sort_m_source=,&sort_t=,&storage=hot&stream_sort=desc&top_n=10,10&top_o=top,top&viz=pattern&x_missing=true,true&from_ts=1739817261843&start=1741023442604&end=1741027042604&to_ts=1741026861843&live=true&paused=false

log: Failed to fetch space contract info

```

code | NUMERIC_FAULT
-- | --
fault | overflow
message | overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", value="10000000000000000", code=NUMERIC_FAULT, version=bignumber/5.7.0)
operation | toNumber
reason | overflow
stack | Error: overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", value="10000000000000000", code=NUMERIC_FAULT, version=bignumber/5.7.0)     at Logger2.Logger2.makeError (/river/node_modules/@ethersproject/logger/src.ts/index.ts:269:28)     at Logger2.Logger2.throwError (/river/node_modules/@ethersproject/logger/src.ts/index.ts:281:20)     at throwFault (/river/node_modules/@ethersproject/bignumber/src.ts/bignumber.ts:356:19)     at BigNumber5.BigNumber5.toNumber (/river/node_modules/@ethersproject/bignumber/src.ts/bignumber.ts:186:13)     at getSpaceMemberMetadata (/river/packages/stream-metadata/src/routes/spaceMemberMetadata.ts:104:25)     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)     at async Object.fetchSpaceMemberMetadata (/river/packages/stream-metadata/src/routes/spaceMemberMetadata.ts:51:20)


```