### PR TITLE
Fix for reivew receipt parsing in IReviewShim, pass proper sender address

### DIFF
--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -204,7 +204,13 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                         if (!receipt) {
                             return
                         }
-                        const review = getSpaceReviewEventDataBin(receipt.logs, receipt.from)
+                        if (!transactionContent.value.event) {
+                            return
+                        }
+                        const review = getSpaceReviewEventDataBin(
+                            receipt.logs,
+                            transactionContent.value.event.user,
+                        )
                         const existingReview = this.spaceReviews.find(
                             (r) => r.review.user === review.user,
                         )
@@ -423,7 +429,13 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                         if (!receipt) {
                             return
                         }
-                        const review = getSpaceReviewEventDataBin(receipt.logs, receipt.from)
+                        if (!transactionContent.value.event) {
+                            return
+                        }
+                        const review = getSpaceReviewEventDataBin(
+                            receipt.logs,
+                            transactionContent.value.event.user,
+                        )
                         const existingReviewIndex = this.spaceReviews.findIndex(
                             (r) => r.review.user === review.user,
                         )

--- a/packages/sdk/src/sync-agent/timeline/models/timelineEvent.ts
+++ b/packages/sdk/src/sync-agent/timeline/models/timelineEvent.ts
@@ -415,9 +415,12 @@ function toTownsContent_MemberPayload(
                         return { error: `${description} no receipt` }
                     }
                     const reviewContent = transaction.content.value
+                    if (!reviewContent.event) {
+                        return { error: `${description} no event in space review` }
+                    }
                     const { comment, rating } = getSpaceReviewEventDataBin(
                         transaction.receipt.logs,
-                        transaction.receipt.from,
+                        reviewContent.event.user,
                     )
                     return {
                         content: {

--- a/packages/sdk/src/tests/multi/transactions_SpaceReview.test.ts
+++ b/packages/sdk/src/tests/multi/transactions_SpaceReview.test.ts
@@ -86,7 +86,7 @@ describe('transaction_SpaceReview', () => {
         expect(tx).toBeDefined()
         const receipt = await tx.wait(2)
         expect(receipt).toBeDefined()
-        const reviewEvent = getSpaceReviewEventData(receipt.logs, receipt.from)
+        const reviewEvent = getSpaceReviewEventData(receipt.logs, aliceIdentity.userId)
         expect(reviewEvent).toBeDefined()
         expect(reviewEvent.rating).toBe(5)
         expect(reviewEvent.comment).toBe('This is a test review')
@@ -120,9 +120,12 @@ describe('transaction_SpaceReview', () => {
         }
         expect(reviewEvent.receipt).toBeDefined()
         expect(reviewEvent.content.value.action).toBe(BlockchainTransaction_SpaceReview_Action.Add)
+        if (!reviewEvent.content.value.event) {
+            throw new Error('no event in space review')
+        }
         const { comment, rating, action } = getSpaceReviewEventDataBin(
             reviewEvent.receipt!.logs,
-            reviewEvent.receipt!.from,
+            reviewEvent.content.value.event.user,
         )
         expect(action).toBe(SpaceReviewAction.Add)
         expect(comment).toBe('This is a test review')

--- a/packages/web3/src/v3/IReviewShim.ts
+++ b/packages/web3/src/v3/IReviewShim.ts
@@ -118,37 +118,41 @@ export function getSpaceReviewEventData(
 ): SpaceReviewEventObject {
     const contractInterface = new ethers.utils.Interface(DevAbi) as IReviewInterface
     for (const log of logs) {
-        const parsedLog = contractInterface.parseLog(log)
-        if (
-            parsedLog.name === 'ReviewAdded' &&
-            (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
-        ) {
-            return {
-                user: parsedLog.args.user,
-                comment: parsedLog.args.comment,
-                rating: parsedLog.args.rating,
-                action: SpaceReviewAction.Add,
+        try {
+            const parsedLog = contractInterface.parseLog(log)
+            if (
+                parsedLog.name === 'ReviewAdded' &&
+                (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
+            ) {
+                return {
+                    user: parsedLog.args.user,
+                    comment: parsedLog.args.comment,
+                    rating: parsedLog.args.rating,
+                    action: SpaceReviewAction.Add,
+                }
+            } else if (
+                parsedLog.name === 'ReviewUpdated' &&
+                (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
+            ) {
+                return {
+                    user: parsedLog.args.user,
+                    comment: parsedLog.args.comment,
+                    rating: parsedLog.args.rating,
+                    action: SpaceReviewAction.Update,
+                }
+            } else if (
+                parsedLog.name === 'ReviewDeleted' &&
+                (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
+            ) {
+                return {
+                    user: parsedLog.args.user,
+                    comment: undefined,
+                    rating: 0,
+                    action: SpaceReviewAction.Delete,
+                }
             }
-        } else if (
-            parsedLog.name === 'ReviewUpdated' &&
-            (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
-        ) {
-            return {
-                user: parsedLog.args.user,
-                comment: parsedLog.args.comment,
-                rating: parsedLog.args.rating,
-                action: SpaceReviewAction.Update,
-            }
-        } else if (
-            parsedLog.name === 'ReviewDeleted' &&
-            (parsedLog.args.user as string).toLowerCase() === senderAddress.toLowerCase()
-        ) {
-            return {
-                user: parsedLog.args.user,
-                comment: undefined,
-                rating: 0,
-                action: SpaceReviewAction.Delete,
-            }
+        } catch {
+            // no need for error, this log is not from the contract we're interested in
         }
     }
     return { user: '', comment: undefined, rating: 0, action: SpaceReviewAction.None }


### PR DESCRIPTION
The added/updated/deleted event is not the only event
for smart wallets receipt.from !== senderAddress