### PR TITLE
repltest: ensure sync works in replicated scenario testing

### DIFF
--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -328,7 +328,7 @@ func TestAppRegistry_RegisterWebhook(t *testing.T) {
 	)
 
 	// Create needed streams and add an encryption device to the user metadata stream for the app service.
-	tc := tester.newTestClient(0)
+	tc := tester.newTestClient(0, testClientOpts{})
 	defaultEncryptionDevice := app_client.EncryptionDevice{
 		DeviceKey:   "deviceKey",
 		FallbackKey: "fallbackKey",

--- a/core/node/rpc/media_stream_test.go
+++ b/core/node/rpc/media_stream_test.go
@@ -21,7 +21,7 @@ func TestCreateMediaStream(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	mediaStreamId, err := StreamIdFromString(STREAM_MEDIA_PREFIX + strings.Repeat("0", 62))
 	tt.require.NoError(err)
@@ -158,7 +158,7 @@ func TestCreateMediaStream_Legacy(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	mediaStreamId, err := StreamIdFromString(STREAM_MEDIA_PREFIX + strings.Repeat("0", 62))
 	tt.require.NoError(err)

--- a/core/node/rpc/media_stream_test.go
+++ b/core/node/rpc/media_stream_test.go
@@ -18,7 +18,7 @@ import (
 func TestCreateMediaStream(t *testing.T) {
 	tt := newServiceTester(t, serviceTesterOpts{numNodes: 5, replicationFactor: 5, start: true})
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)
@@ -111,7 +111,7 @@ func TestCreateMediaStream(t *testing.T) {
 		}
 
 		// Make sure all replicas have the stream sealed
-		for i, client := range tt.newTestClients(5) {
+		for i, client := range tt.newTestClients(5, testClientOpts{}) {
 			t.Run(fmt.Sprintf("Stream sealed in node %d", i), func(t *testing.T) {
 				t.Parallel()
 
@@ -155,7 +155,7 @@ func TestCreateMediaStream(t *testing.T) {
 func TestCreateMediaStream_Legacy(t *testing.T) {
 	tt := newServiceTester(t, serviceTesterOpts{numNodes: 1, start: true})
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)

--- a/core/node/rpc/node2node_ephemeral_test.go
+++ b/core/node/rpc/node2node_ephemeral_test.go
@@ -17,7 +17,7 @@ import (
 func TestCreateEphemeralStream(t *testing.T) {
 	tt := newServiceTester(t, serviceTesterOpts{numNodes: 1, start: true})
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)

--- a/core/node/rpc/node2node_ephemeral_test.go
+++ b/core/node/rpc/node2node_ephemeral_test.go
@@ -20,7 +20,7 @@ func TestCreateEphemeralStream(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	// Nodes should accept ephemeral miniblocks even if a stream does not exist.
 	t.Run("Send ephemeral miniblock for non-existing stream", func(t *testing.T) {

--- a/core/node/rpc/node2node_test.go
+++ b/core/node/rpc/node2node_test.go
@@ -24,7 +24,7 @@ func Test_Node2Node_GetMiniblocksByIds(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, creationMb := alice.createChannel(spaceId)
+	channelId, creationMb, _ := alice.createChannel(spaceId)
 
 	mbNums := []int64{creationMb.Num}
 	const messagesNumber = 100

--- a/core/node/rpc/node2node_test.go
+++ b/core/node/rpc/node2node_test.go
@@ -21,7 +21,7 @@ func Test_Node2Node_GetMiniblocksByIds(t *testing.T) {
 		},
 	})
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, creationMb, _ := alice.createChannel(spaceId)

--- a/core/node/rpc/repl_mc_norace_test.go
+++ b/core/node/rpc/repl_mc_norace_test.go
@@ -17,19 +17,19 @@ func TestReplMcConversationNoRace(t *testing.T) {
 		if testing.Short() {
 			t.Skip("skipping 10x1000 in short mode")
 		}
-		testReplMcConversation(t, 10, 1000, 20, 1000)
+		testReplMcConversation(t, 10, 1000, 20, 1000, 1000)
 	})
 	t.Run("30x1000", func(t *testing.T) {
 		if testing.Short() {
 			t.Skip("skipping 30x1000 in short mode")
 		}
-		testReplMcConversation(t, 30, 1000, 50, 1000)
+		testReplMcConversation(t, 30, 1000, 50, 1000, 1000)
 	})
 	t.Run("100x100", func(t *testing.T) {
 		testutils.SkipFlakyTest(t, "TODO: REPLICATION: FIX: flaky")
 		if testing.Short() {
 			t.Skip("skipping 100x100 in short mode")
 		}
-		testReplMcConversation(t, 100, 100, 20, 50)
+		testReplMcConversation(t, 100, 100, 20, 50, 100)
 	})
 }

--- a/core/node/rpc/repl_multiclient_test.go
+++ b/core/node/rpc/repl_multiclient_test.go
@@ -53,7 +53,7 @@ func TestReplMcSpeakUntilMbTrim(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	for count := range 1000 {
 		alice.say(channelId, fmt.Sprintf("hello from Alice %d", count))

--- a/core/node/rpc/repl_multiclient_test.go
+++ b/core/node/rpc/repl_multiclient_test.go
@@ -29,7 +29,7 @@ func newServiceTesterForReplication(t *testing.T) *serviceTester {
 func TestReplMcSimple(t *testing.T) {
 	tt := newServiceTesterForReplication(t)
 
-	clients := tt.newTestClients(3)
+	clients := tt.newTestClients(3, testClientOpts{})
 	spaceId, _ := clients[0].createSpace()
 	channelId := clients.createChannelAndJoin(spaceId)
 	phrases1 := []string{"hello from Alice", "hello from Bob", "hello from Carol"}
@@ -50,7 +50,7 @@ func TestReplMcSpeakUntilMbTrim(t *testing.T) {
 	tt := newServiceTesterForReplication(t)
 	require := tt.require
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)
@@ -67,9 +67,16 @@ func TestReplMcSpeakUntilMbTrim(t *testing.T) {
 	require.Fail("failed to trim miniblocks")
 }
 
-func testReplMcConversation(t *testing.T, numClients int, numSteps int, listenInterval int, compareInterval int) {
+func testReplMcConversation(
+	t *testing.T,
+	numClients int,
+	numSteps int,
+	listenInterval int,
+	compareInterval int,
+	syncInterval int,
+) {
 	tt := newServiceTesterForReplication(t)
-	clients := tt.newTestClients(numClients)
+	clients := tt.newTestClients(numClients, testClientOpts{enableSync: true})
 	spaceId, _ := clients[0].createSpace()
 	channelId := clients.createChannelAndJoin(spaceId)
 
@@ -87,7 +94,7 @@ func testReplMcConversation(t *testing.T, numClients int, numSteps int, listenIn
 		if i+1 < len(messages) {
 			t.Errorf("got through %d steps out of %d", i+1, len(messages))
 			testfmt.Println(t, "Comparing all streams")
-			clients.compare(channelId)
+			clients.compare(channelId, true, true)
 			testfmt.Println(t, "Compared all streams")
 		}
 	}()
@@ -102,26 +109,28 @@ func testReplMcConversation(t *testing.T, numClients int, numSteps int, listenIn
 		if listenInterval > 0 && (i+1)%listenInterval == 0 {
 			clients.listen(channelId, messages[:i+1])
 		}
-		if compareInterval > 0 && (i+1)%compareInterval == 0 {
-			clients.compare(channelId)
-		}
+
+		compareMiniblocks := compareInterval > 0 && (i+1)%compareInterval == 0
+		compareSync := syncInterval > 0 && (i+1)%syncInterval == 0
+		clients.compare(channelId, compareMiniblocks, compareSync)
 	}
 
 	if listenInterval <= 0 || numSteps%listenInterval != 0 {
 		clients.listen(channelId, messages)
 	}
 
-	if compareInterval <= 0 || numSteps%compareInterval != 0 {
-		clients.compare(channelId)
-	}
+	compareMiniblocks := compareInterval <= 0 || numSteps%compareInterval != 0
+	compareSync := syncInterval <= 0 || numSteps%compareInterval != 0
+
+	clients.compare(channelId, compareMiniblocks, compareSync)
 }
 
 func TestReplMcConversationShort(t *testing.T) {
 	t.Parallel()
 	t.Run("5x5", func(t *testing.T) {
-		testReplMcConversation(t, 5, 5, 1, 1)
+		testReplMcConversation(t, 5, 5, 1, 1, 5)
 	})
 	t.Run("5x100", func(t *testing.T) {
-		testReplMcConversation(t, 5, 100, 10, 100)
+		testReplMcConversation(t, 5, 100, 10, 100, 100)
 	})
 }

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -1781,7 +1781,7 @@ func TestGetMiniblocksRangeLimit(t *testing.T) {
 		crypto.ABIEncodeUint64(uint64(expectedLimit)),
 	)
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -1784,7 +1784,7 @@ func TestGetMiniblocksRangeLimit(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	// Here we create a miniblock for each message sent by Alice.
 	// Creating a bit more miniblocks than limit.

--- a/core/node/rpc/stream_test.go
+++ b/core/node/rpc/stream_test.go
@@ -37,7 +37,7 @@ func TestGetStreamEx(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	for count := range 100 {
 		alice.say(channelId, fmt.Sprintf("hello from Alice %d", count))
@@ -104,7 +104,7 @@ func TestMiniBlockProductionFrequency(t *testing.T) {
 	alice := tt.newTestClient(0)
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
-	channelId, _ := alice.createChannel(spaceId)
+	channelId, _, _ := alice.createChannel(spaceId)
 
 	// retrieve set last miniblock events and make sure that only 1 out of miniblockRegistrationFrequency
 	// miniblocks is registered

--- a/core/node/rpc/stream_test.go
+++ b/core/node/rpc/stream_test.go
@@ -34,7 +34,7 @@ func TestGetStreamEx(t *testing.T) {
 	)
 	require := tt.require
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)
@@ -101,7 +101,7 @@ func TestMiniBlockProductionFrequency(t *testing.T) {
 		config.Graffiti = "firstNode"
 	}})
 
-	alice := tt.newTestClient(0)
+	alice := tt.newTestClient(0, testClientOpts{})
 	_ = alice.createUserStream()
 	spaceId, _ := alice.createSpace()
 	channelId, _, _ := alice.createChannel(spaceId)


### PR DESCRIPTION
With this change each time when test clients are instantiated a stream sync session is started. When `testClients#createChannelAndJoin` is called all clients will subscribe for updates on the created stream though modify sync. When the test calls `testClients#compare(StreamId)` not only the stream are compared between clients but also ensured that all clients received the same updates through the sync session.