### PR TITLE
Kerem/fix metrics aggregator docker

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -20,8 +20,11 @@
         "@openzeppelin/contracts-upgradeable": "^5.2.0",
         "@prb/math": "^4.1.0",
         "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9",
-        "account-abstraction": "github:eth-infinitism/account-abstraction",
-        "solady": "^0.1.2"
+        "account-abstraction": "github:eth-infinitism/account-abstraction#7af70c8993a6f42973f520ae0752386a5032abe7",
+        "ethers": "^5.7.2",
+        "lodash": "^4.17.21",
+        "solady": "^0.1.2",
+        "typechain": "^8.1.1"
     },
     "devDependencies": {
         "@prb/test": "^0.6.4",

--- a/packages/metrics-discovery/Dockerfile
+++ b/packages/metrics-discovery/Dockerfile
@@ -2,6 +2,10 @@ FROM node:lts-alpine3.20
 
 WORKDIR /river
 
+RUN apk update 
+RUN apk add --no-cache git curl make build-base
+RUN apk add --no-cache python3 
+
 # monorepo root config
 COPY ./package.json ./package.json
 COPY ./.yarn/plugins ./.yarn/plugins
@@ -25,16 +29,14 @@ COPY ./packages/generated /river/packages/generated
 COPY ./packages/web3 /river/packages/web3
 COPY ./packages/dlog /river/packages/dlog
 COPY ./packages/proto /river/packages/proto
+COPY ./contracts /river/contracts
 COPY ./packages/metrics-discovery /river/packages/metrics-discovery
 
 # install dependencies and build
-RUN apk add --no-cache git curl
 RUN corepack enable
 RUN yarn install
 RUN yarn run turbo build --filter @river-build/metrics-discovery
 
 WORKDIR /river/packages/metrics-discovery
-
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080 || exit 1
 
 CMD [ "yarn", "start"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6611,12 +6611,15 @@ __metadata:
     "@prb/test": ^0.6.4
     "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9"
     account-abstraction: "github:eth-infinitism/account-abstraction"
+    ethers: ^5.7.2
     forge-std: "github:foundry-rs/forge-std#v1.9.5"
+    lodash: ^4.17.21
     prettier: ^2.8.8
     prettier-plugin-solidity: ^1.4.2
     solady: ^0.1.2
     solhint: ^5.0.5
     turbo: ^2.0.12
+    typechain: ^8.1.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,7 +6610,7 @@ __metadata:
     "@prb/math": ^4.1.0
     "@prb/test": ^0.6.4
     "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9"
-    account-abstraction: "github:eth-infinitism/account-abstraction"
+    account-abstraction: "github:eth-infinitism/account-abstraction#7af70c8993a6f42973f520ae0752386a5032abe7"
     ethers: ^5.7.2
     forge-std: "github:foundry-rs/forge-std#v1.9.5"
     lodash: ^4.17.21
@@ -9928,7 +9928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"account-abstraction@github:eth-infinitism/account-abstraction":
+"account-abstraction@github:eth-infinitism/account-abstraction#7af70c8993a6f42973f520ae0752386a5032abe7":
   version: 0.7.0
   resolution: "account-abstraction@https://github.com/eth-infinitism/account-abstraction.git#commit=7af70c8993a6f42973f520ae0752386a5032abe7"
   dependencies:


### PR DESCRIPTION
the recent changes in the contracts workspace broke the metrics-aggregator docker build. this pr fixes this by adding the missing binary and node dependencies