### PR TITLE
chore(contract): move `account-abstraction` to `devDependencies`

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -20,11 +20,11 @@
         "@openzeppelin/contracts-upgradeable": "^5.2.0",
         "@prb/math": "^4.1.0",
         "@river-build/diamond": "github:river-build/diamond#552c970ed60cf452d28e7713b00a95c7bd10a5d9",
-        "account-abstraction": "github:eth-infinitism/account-abstraction",
         "solady": "^0.1.2"
     },
     "devDependencies": {
         "@prb/test": "^0.6.4",
+        "account-abstraction": "github:eth-infinitism/account-abstraction",
         "forge-std": "github:foundry-rs/forge-std#v1.9.5",
         "prettier": "^2.8.8",
         "prettier-plugin-solidity": "^1.4.2",


### PR DESCRIPTION
The `account-abstraction` package was relocated from dependencies to devDependencies, likely reflecting its use only in development or testing. This change optimizes the dependency structure and ensures the production build remains minimal.