### PR TITLE
Switch removeStreamFromSync to use the modifySync call

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -259,10 +259,13 @@ export class SyncedStreamsLoop {
         }
         if (this.syncState === SyncState.Syncing) {
             try {
-                await this.rpcClient.removeStreamFromSync({
+                const resp = await this.rpcClient.modifySync({
                     syncId: this.syncId,
-                    streamId: streamIdAsBytes(streamId),
+                    removeStreams: [streamIdAsBytes(streamId)],
                 })
+                if (resp.removals.length > 0) {
+                    this.log('removeStreamFromSync err', resp.removals)
+                }
             } catch (err) {
                 // Trigger restart of sync loop
                 this.log('removeStreamFromSync err', err)

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -271,18 +271,6 @@ export class SyncedStreamsLoop {
             await this.waitForSyncingState()
         }
         if (this.syncState === SyncState.Syncing) {
-            try {
-                const resp = await this.rpcClient.modifySync({
-                    syncId: this.syncId,
-                    removeStreams: [streamIdAsBytes(streamId)],
-                })
-                if (resp.removals.length > 0) {
-                    this.log('removeStreamFromSync err', resp.removals)
-                }
-            } catch (err) {
-                // Trigger restart of sync loop
-                this.log('removeStreamFromSync err', err)
-            }
             this.pendingStreamsToDelete.push(streamId)
             streamRecord.stream.stop()
             this.streams.delete(streamId)


### PR DESCRIPTION
seems like this is all we need to do…
though we might want to detect when we’re getting updates for streams we’re not subscribed to and call modify sync again here:
```
                    if (streamRecord === undefined) {
                        this.log('sync got stream', streamId, 'NOT FOUND')
                    }
```