### PR TITLE
Set deployment override for InteractRiverAlpha

### DIFF
--- a/contracts/scripts/interactions/InteractRiverAlpha.s.sol
+++ b/contracts/scripts/interactions/InteractRiverAlpha.s.sol
@@ -15,7 +15,8 @@ contract InteractRiverAlpha is AlphaHelper {
   DeployRiverRegistry deployRiverRegistry = new DeployRiverRegistry();
 
   function __interact(address deployer) internal override {
-    address riverRegistry = deployRiverRegistry.deploy(deployer);
+    vm.setEnv("OVERRIDE_DEPLOYMENTS", "1");
+    address riverRegistry = getDeployment("riverRegistry");
 
     removeRemoteFacets(deployer, riverRegistry);
     FacetCut[] memory newCuts;


### PR DESCRIPTION
Now all facets are redeployed when running InteractRiverAlpha which is the desired behavior.

https://testnet.explorer.towns.com/address/0x44354786EacBEBf981453A05728E1653Bc3c5def?tab=read_contract