### PR TITLE
Add logs to alpha in order to debug the entitlement failures for delegated wallets

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/towns-protocol/towns/core/config"
 	"github.com/towns-protocol/towns/core/contracts/base"
@@ -412,6 +413,9 @@ func (ca *chainAuth) IsEntitled(ctx context.Context, cfg *config.Config, args *C
 		ca.checkEntitlement,
 	)
 	if err != nil {
+		if args.kind == chainAuthKindIsSpaceMember {
+			log.Infow("Returning cached false IsEntitled result for IsSpaceMember", "args", args)
+		}
 		return false, AsRiverError(err).Func("IsEntitled")
 	}
 
@@ -1017,6 +1021,9 @@ func (ca *chainAuth) checkEntitlement(
 	}
 
 	args = args.withLinkedWallets(wallets)
+	if args.kind == chainAuthKindIsSpaceMember {
+		log.Infow("Checking linked wallets for IsSpaceMember", "args", args, "wallets", wallets)
+	}
 
 	isMemberCtx, isMemberCancel := context.WithCancel(ctx)
 	defer isMemberCancel()
@@ -1093,15 +1100,17 @@ func (ca *chainAuth) checkEntitlement(
 		} else {
 			// It is expected that some membership checks will fail when the user is legitimately
 			// not entitled, so this log statement is for debugging only.
-			log.Debugw(
-				"User is not a member of the space",
-				"userId",
-				args.principal,
-				"spaceId",
-				args.spaceId,
-				"wallets",
-				wallets,
-			)
+			if args.kind == chainAuthKindIsSpaceMember {
+				log.Infow(
+					"User is not a member of the space",
+					"userId",
+					args.principal,
+					"spaceId",
+					args.spaceId,
+					"wallets",
+					wallets,
+				)
+			}
 			return boolCacheResult(false), nil
 		}
 	}

--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/towns-protocol/towns/core/config"
 	"github.com/towns-protocol/towns/core/contracts/base"
@@ -414,7 +413,7 @@ func (ca *chainAuth) IsEntitled(ctx context.Context, cfg *config.Config, args *C
 	)
 	if err != nil {
 		if args.kind == chainAuthKindIsSpaceMember {
-			log.Infow("Returning cached false IsEntitled result for IsSpaceMember", "args", args)
+			logging.FromCtx(ctx).Infow("Returning cached false IsEntitled result for IsSpaceMember", "args", args)
 		}
 		return false, AsRiverError(err).Func("IsEntitled")
 	}


### PR DESCRIPTION
We cannot test the delegate wallets feature fully locally because we rely on delegate contracts deployed to sepolia. There is probably a more hermetic solution, but this is the fastest way to get to the bottom of this that I can figure out.

The token seems to be minted, but joining the space is failing, and it's the IsSpaceMember chain auth kind that's failing. I'd like to get to the bottom of why.