### PR TITLE
test(contract): improve log handling with `LogUtils` utility

### DIFF
--- a/contracts/test/crosschain/EntitlementGated.t.sol
+++ b/contracts/test/crosschain/EntitlementGated.t.sol
@@ -18,10 +18,10 @@ import {BaseSetup} from "contracts/test/spaces/BaseSetup.sol";
 import {Vm} from "forge-std/Test.sol";
 
 contract EntitlementGatedTest is
-  EntitlementTestUtils,
-  BaseSetup,
   IEntitlementGatedBase,
-  IEntitlementCheckerBase
+  IEntitlementCheckerBase,
+  EntitlementTestUtils,
+  BaseSetup
 {
   MockEntitlementGated public gated;
 

--- a/contracts/test/utils/LogUtils.sol
+++ b/contracts/test/utils/LogUtils.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Vm} from "forge-std/Vm.sol";
+
+abstract contract LogUtils {
+  /// @dev Returns the first log that matches the topic0
+  function _getFirstMatchingLog(
+    Vm.Log[] memory logs,
+    bytes32 topic0
+  ) internal pure returns (Vm.Log memory log) {
+    for (uint256 i; i < logs.length; ++i) {
+      log = logs[i];
+      if (log.topics.length > 0 && log.topics[0] == topic0) {
+        return log;
+      }
+    }
+    revert("Log not found");
+  }
+
+  /// @dev Returns the count of logs that match the topic0
+  function _getMatchingLogCount(
+    Vm.Log[] memory logs,
+    bytes32 topic0
+  ) internal pure returns (uint256 count) {
+    for (uint256 i; i < logs.length; ++i) {
+      Vm.Log memory log = logs[i];
+      if (log.topics.length > 0 && log.topics[0] == topic0) {
+        ++count;
+      }
+    }
+  }
+
+  /// @dev Returns an array of logs that match the topic0
+  /// No alloc is done for the array. It is just an array of pointers to the existing logs.
+  function _getMatchingLogs(
+    Vm.Log[] memory logs,
+    bytes32 topic0
+  ) internal pure returns (Vm.Log[] memory matchingLogs) {
+    uint256 length = logs.length;
+    // allocates an array of pointers to the logs
+    // similar to `matchingLogs = new Vm.Log[](length)` without the struct allocation
+    assembly ("memory-safe") {
+      matchingLogs := mload(0x40)
+      mstore(matchingLogs, length)
+      mstore(0x40, add(add(matchingLogs, shl(5, length)), 0x20))
+    }
+    uint256 index;
+    for (uint256 i; i < length; ++i) {
+      Vm.Log memory log = logs[i];
+      if (log.topics.length > 0 && log.topics[0] == topic0) {
+        matchingLogs[index++] = log;
+      }
+    }
+    assembly ("memory-safe") {
+      mstore(matchingLogs, index)
+    }
+  }
+}


### PR DESCRIPTION
Add `LogUtils` as a reusable utility for log matching to simplify and optimize log-related operations. Refactor `EntitlementTestUtils` and associated tests to utilize `LogUtils`, reducing repetitive code and enhancing readability. Reorganize contract inheritance and refine test assertions for better maintainability and efficiency.