### PR TITLE
Add a warn to the persistence store retrier

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -21,6 +21,7 @@ import { fromBinary, toBinary } from '@bufbuild/protobuf'
 const MAX_CACHED_SCROLLBACK_COUNT = 3
 const DEFAULT_RETRY_COUNT = 2
 const log = dlog('csb:persistence', { defaultEnabled: false })
+const logWarn = dlog('csb:persistence:warn', { defaultEnabled: true })
 const logError = dlogError('csb:persistence:error')
 
 export interface LoadedStream {
@@ -41,7 +42,7 @@ async function fnReadRetryer<T>(
     while (retryCounter > 0) {
         try {
             if (retryCounter < retries) {
-                log('retrying...', `${retryCounter}/${retries} retries left`)
+                logWarn('retrying...', `${retryCounter}/${retries} retries left`)
                 retryCounter--
                 // wait a bit before retrying
                 await new Promise((resolve) => setTimeout(resolve, 100))


### PR DESCRIPTION
this thing only retrys clear texts… not sure why it’s there, history is lost. add log to see if it is happening.