### PR TITLE
pull eventIds from snapshot when parsing sync reset

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -425,7 +425,7 @@ function topLevelRenderableEventInMiniblock(miniblock: ParsedMiniblock): boolean
     return false
 }
 
-function eventIdsFromSnapshot(snapshot: Snapshot): string[] {
+export function eventIdsFromSnapshot(snapshot: Snapshot): string[] {
     const usernameEventIds =
         snapshot.members?.joined
             .filter((m) => isDefined(m.username))

--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -29,6 +29,7 @@ import { SignerContext, checkDelegateSig } from './signerContext'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { createHash } from 'crypto'
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
+import { eventIdsFromSnapshot } from './persistenceStore'
 
 export interface UnpackEnvelopeOpts {
     // the client recreates the hash from the event bytes in the envelope
@@ -131,6 +132,7 @@ export const unpackStream = async (
             (mb) => mb.events.map((e) => e.hashStr),
             streamAndCookie.events.map((e) => e.hashStr),
         ),
+        ...eventIdsFromSnapshot(snapshot),
     ]
 
     return {


### PR DESCRIPTION
these are used in the `initializeFromResponse` function in syncedStream.ts
the result of this would be that usernames and dispaly names wouldn’t decrypt imediately, they’d be pushed in the decryption queue. They items would not be decrypted a second time, it would hit the cache again before trying to decrypt, but still this clogs the queue and slows everything down.