### PR TITLE
Fix for wrong sigBundle update on fulfillment

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -63,7 +63,6 @@ export interface KeySolicitationContent {
     fallbackKey: string
     isNewDevice: boolean
     sessionIds: string[]
-    srcEventId: string
 }
 
 // paired down from StreamEvent, required for signature validation
@@ -84,6 +83,7 @@ export interface KeySolicitationItem {
     solicitation: KeySolicitationContent
     respondAfter: number // ms since epoch
     sigBundle: EventSignatureBundle
+    hashStr: string
 }
 
 export interface KeySolicitationData {
@@ -317,6 +317,7 @@ export abstract class BaseDecryptionExtensions {
 
     public enqueueInitKeySolicitations(
         streamId: string,
+        eventHashStr: string,
         members: {
             userId: string
             userAddress: Uint8Array
@@ -350,6 +351,7 @@ export abstract class BaseDecryptionExtensions {
                     respondAfter:
                         Date.now() + this.getRespondDelayMSForKeySolicitation(streamId, fromUserId),
                     sigBundle,
+                    hashStr: eventHashStr,
                 } satisfies KeySolicitationItem)
             }
         }
@@ -359,6 +361,7 @@ export abstract class BaseDecryptionExtensions {
 
     public enqueueKeySolicitation(
         streamId: string,
+        eventHashStr: string,
         fromUserId: string,
         fromUserAddress: Uint8Array,
         keySolicitation: KeySolicitationContent,
@@ -392,6 +395,7 @@ export abstract class BaseDecryptionExtensions {
                 respondAfter:
                     Date.now() + this.getRespondDelayMSForKeySolicitation(streamId, fromUserId),
                 sigBundle,
+                hashStr: eventHashStr,
             } satisfies KeySolicitationItem)
             this.checkStartTicking()
         } else if (index > -1) {
@@ -823,7 +827,7 @@ export abstract class BaseDecryptionExtensions {
         if (!isValid) {
             this.log.error('processing key solicitation: invalid event id', {
                 streamId,
-                eventId: item.solicitation.srcEventId,
+                eventId: item.hashStr,
                 reason,
             })
             return

--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -83,12 +83,12 @@ describe.concurrent('TestDecryptionExtensions', () => {
                 fallbackKey: aliceDex.userDevice.fallbackKey,
                 isNewDevice: true,
                 sessionIds: [sessionId],
-                srcEventId: '',
             }
             const keySolicitation = aliceClient.sendKeySolicitation(keySolicitationData)
             // pretend bob receives a key solicitation request from alice, and starts processing it.
             await bobDex.handleKeySolicitationRequest(
                 streamId,
+                '',
                 alice,
                 aliceUserAddress,
                 keySolicitationData,
@@ -328,6 +328,7 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
 
     public async handleKeySolicitationRequest(
         streamId: string,
+        eventHashStr: string,
         fromUserId: string,
         fromUserAddress: Uint8Array,
         keySolicitation: KeySolicitationContent,
@@ -344,6 +345,7 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
             // start processing the request
             this.enqueueKeySolicitation(
                 streamId,
+                eventHashStr,
                 fromUserId,
                 fromUserAddress,
                 keySolicitation,

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -83,6 +83,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
 
         const onKeySolicitation = (
             streamId: string,
+            eventHashStr: string,
             fromUserId: string,
             fromUserAddress: Uint8Array,
             keySolicitation: KeySolicitationContent,
@@ -90,6 +91,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         ) =>
             this.enqueueKeySolicitation(
                 streamId,
+                eventHashStr,
                 fromUserId,
                 fromUserAddress,
                 keySolicitation,
@@ -98,13 +100,14 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
 
         const onInitKeySolicitations = (
             streamId: string,
+            eventHashStr: string,
             members: {
                 userId: string
                 userAddress: Uint8Array
                 solicitations: KeySolicitationContent[]
             }[],
             sigBundle: EventSignatureBundle,
-        ) => this.enqueueInitKeySolicitations(streamId, members, sigBundle)
+        ) => this.enqueueInitKeySolicitations(streamId, eventHashStr, members, sigBundle)
 
         const onStreamInitialized = (streamId: string) => {
             if (isUserInboxStreamId(streamId)) {
@@ -229,7 +232,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         if (this.unpackEnvelopeOpts?.disableSignatureValidation !== true) {
             return { isValid: true }
         }
-        const eventId = item.solicitation.srcEventId
+        const eventId = item.hashStr
         const sigBundle = item.sigBundle
         if (!sigBundle) {
             return { isValid: false, reason: 'event not found' }

--- a/packages/sdk/src/streamEvents.ts
+++ b/packages/sdk/src/streamEvents.ts
@@ -35,6 +35,7 @@ export type StreamEncryptionEvents = {
     newEncryptedContent: (streamId: string, eventId: string, content: EncryptedContent) => void
     newKeySolicitation: (
         streamId: string,
+        eventHashStr: string,
         fromUserId: string,
         fromUserAddress: Uint8Array,
         event: KeySolicitationContent,
@@ -42,6 +43,7 @@ export type StreamEncryptionEvents = {
     ) => void
     updatedKeySolicitation: (
         streamId: string,
+        eventHashStr: string,
         fromUserId: string,
         fromUserAddress: Uint8Array,
         event: KeySolicitationContent,
@@ -49,6 +51,7 @@ export type StreamEncryptionEvents = {
     ) => void
     initKeySolicitations: (
         streamId: string,
+        eventHashStr: string,
         members: {
             userId: string
             userAddress: Uint8Array

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -228,7 +228,6 @@ export class StreamStateView implements IStreamStateView {
     }
 
     private applySnapshot(
-        eventHash: string,
         event: ParsedEvent,
         inSnapshot: Snapshot,
         cleartexts: Record<string, Uint8Array | string> | undefined,
@@ -298,7 +297,6 @@ export class StreamStateView implements IStreamStateView {
                 logNever(snapshot.content)
         }
         this.membershipContent.applySnapshot(
-            eventHash,
             event,
             snapshot,
             cleartexts,
@@ -586,7 +584,6 @@ export class StreamStateView implements IStreamStateView {
 
         // initialize from snapshot data, this gets all memberships and channel data, etc
         this.applySnapshot(
-            bin_toHexString(miniblocks[0].hash),
             miniblockHeaderEvent,
             snapshot,
             cleartexts,

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -296,12 +296,7 @@ export class StreamStateView implements IStreamStateView {
             default:
                 logNever(snapshot.content)
         }
-        this.membershipContent.applySnapshot(
-            event,
-            snapshot,
-            cleartexts,
-            encryptionEmitter,
-        )
+        this.membershipContent.applySnapshot(event, snapshot, cleartexts, encryptionEmitter)
     }
 
     private appendStreamAndCookie(
@@ -583,12 +578,7 @@ export class StreamStateView implements IStreamStateView {
         )
 
         // initialize from snapshot data, this gets all memberships and channel data, etc
-        this.applySnapshot(
-            miniblockHeaderEvent,
-            snapshot,
-            cleartexts,
-            emitter,
-        )
+        this.applySnapshot(miniblockHeaderEvent, snapshot, cleartexts, emitter)
         // initialize from miniblocks, the first minblock is the snapshot block, it's events are accounted for
         const block0Events = miniblocks[0].events.map((parsedEvent, i) => {
             const eventNum = miniblocks[0].header.eventNumOffset + BigInt(i)

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -86,7 +86,6 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
 
     // initialization
     applySnapshot(
-        eventId: string,
         event: ParsedEvent,
         snapshot: Snapshot,
         cleartexts: Record<string, Uint8Array | string> | undefined,
@@ -109,7 +108,6 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                             fallbackKey: s.fallbackKey,
                             isNewDevice: s.isNewDevice,
                             sessionIds: [...s.sessionIds],
-                            srcEventId: eventId,
                         } satisfies KeySolicitationContent),
                 ),
                 encryptedUsername: member.username,
@@ -160,6 +158,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
         )
         const sigBundle = getEventSignature(event)
         this.solicitHelper.initSolicitations(
+            event.hashStr,
             Array.from(this.joined.values()),
             sigBundle,
             encryptionEmitter,
@@ -316,7 +315,6 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                     this.solicitHelper.applyFulfillment(
                         stateMember,
                         payload.content.value,
-                        getEventSignature(event.remoteEvent),
                         encryptionEmitter,
                     )
                 }

--- a/packages/sdk/src/streamStateView_Members_Solicitations.ts
+++ b/packages/sdk/src/streamStateView_Members_Solicitations.ts
@@ -4,18 +4,27 @@ import { StreamEncryptionEvents } from './streamEvents'
 import { StreamMember } from './streamStateView_Members'
 import { removeCommon } from './utils'
 import { EventSignatureBundle, KeySolicitationContent } from '@river-build/encryption'
+import { check } from '@river-build/dlog'
+import { isDefined } from './check'
 
 export class StreamStateView_Members_Solicitations {
+    snapshotSigBundle?: EventSignatureBundle
+    snapshotEventId?: string
+
     constructor(readonly streamId: string) {}
 
     initSolicitations(
+        eventHashStr: string,
         members: StreamMember[],
         sigBundle: EventSignatureBundle,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
+        this.snapshotSigBundle = sigBundle
+        this.snapshotEventId = eventHashStr
         encryptionEmitter?.emit(
             'initKeySolicitations',
             this.streamId,
+            eventHashStr,
             members.map((member) => ({
                 userId: member.userId,
                 userAddress: member.userAddress,
@@ -40,12 +49,12 @@ export class StreamStateView_Members_Solicitations {
             fallbackKey: solicitation.fallbackKey,
             isNewDevice: solicitation.isNewDevice,
             sessionIds: solicitation.sessionIds.toSorted(),
-            srcEventId: eventId,
         } satisfies KeySolicitationContent
         user.solicitations.push(newSolicitation)
         encryptionEmitter?.emit(
             'newKeySolicitation',
             this.streamId,
+            eventId,
             user.userId,
             user.userAddress,
             newSolicitation,
@@ -56,9 +65,10 @@ export class StreamStateView_Members_Solicitations {
     applyFulfillment(
         user: StreamMember,
         fulfillment: MemberPayload_KeyFulfillment,
-        sigBundle: EventSignatureBundle,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
+        check(isDefined(this.snapshotSigBundle), 'snapshotSigBundle not set')
+        check(isDefined(this.snapshotEventId), 'snapshotEventId not set')
         const index = user.solicitations.findIndex((x) => x.deviceKey === fulfillment.deviceKey)
         if (index === undefined || index === -1) {
             return
@@ -69,16 +79,16 @@ export class StreamStateView_Members_Solicitations {
             fallbackKey: prev.fallbackKey,
             isNewDevice: false,
             sessionIds: [...removeCommon(prev.sessionIds, fulfillment.sessionIds.toSorted())],
-            srcEventId: prev.srcEventId,
         } satisfies KeySolicitationContent
         user.solicitations[index] = newEvent
         encryptionEmitter?.emit(
             'updatedKeySolicitation',
             this.streamId,
+            this.snapshotEventId,
             user.userId,
             user.userAddress,
             newEvent,
-            sigBundle,
+            this.snapshotSigBundle,
         )
     }
 }


### PR DESCRIPTION
and simplify the function signatures

we were passing the sig bundle of the last person who fulfilled a solicitation instead of the miniblock header, this was wrong and would cause lots of extra checks

remove the unused eventid param

Trying to simplify things to make a bigger refactor of the stream state view