### PR TITLE
Reduce indexdb memory footprint

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -136,6 +136,11 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             return tx.table('cleartexts').toCollection().delete()
         })
 
+        // Version 5: changed how we store scrollback miniblocs, drop all saved miniblocks
+        this.version(5).upgrade((tx) => {
+            return tx.table('miniblocks').toCollection().delete()
+        })
+
         this.requestPersistentStorage()
         this.logPersistenceStats()
     }

--- a/packages/sdk/src/streamUtils.ts
+++ b/packages/sdk/src/streamUtils.ts
@@ -104,6 +104,9 @@ export function parsedMiniblockToPersistedMiniblock(
     miniblock: ParsedMiniblock,
     direction: 'forward' | 'backward',
 ) {
+    if (direction === 'backward') {
+        miniblock.header.snapshot = undefined
+    }
     return create(PersistedMiniblockSchema, {
         hash: miniblock.hash,
         header: miniblock.header,


### PR DESCRIPTION
this doesn’t go as far as i’d like it, but it takes the memory footprint way down and should help temporarily until i can get my major refactors in.

reasoning: users will have to re-download all miniblocks. All but the most recent will not store snapshots, which will take less space

test plan: tested in harmony running against omega. seemed fine.