### PR TITLE
node: move node to unified eventing model

### DIFF
--- a/core/contracts/river/stream_registry_v1_ex.go
+++ b/core/contracts/river/stream_registry_v1_ex.go
@@ -1,47 +1,119 @@
 package river
 
 import (
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"encoding/json"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	. "github.com/towns-protocol/towns/core/node/base"
+	"github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/shared"
 )
 
-const (
-	Event_StreamAllocated            = "StreamAllocated"
-	Event_StreamCreated              = "StreamCreated"
-	Event_StreamLastMiniblockUpdated = "StreamLastMiniblockUpdated"
-	Event_StreamPlacementUpdated     = "StreamPlacementUpdated"
+type (
+	// StreamUpdated is the unified event emitted by the stream registry when a stream mutation occurs.
+	// Either when its created or modified.
+	StreamUpdated = StreamRegistryV1StreamUpdated
+
+	// StreamUpdatedEventType defines Solidity IStreamRegistryBase.StreamEventType enum type.
+	StreamUpdatedEventType uint8
+
+	// StreamState indicates a stream state in the river streams registry.
+	StreamState struct {
+		// Stream contains the new stream state after the transaction was processed.
+		Stream
+		// StreamID identifies the stream
+		StreamID StreamId
+		// Reason contains the reason why the stream state was updated/created.
+		reason StreamUpdatedEventType
+		// raw is the raw event log that triggered the state change and this stream state was parsed from.
+		raw types.Log
+	}
+
+	// StreamMiniblockUpdate indicates that the stream identified by StreamID has a new miniblock.
+	StreamMiniblockUpdate struct {
+		// SetMiniblock contains the stream updated data.
+		SetMiniblock
+		// StreamID identifies the stream
+		StreamID StreamId
+		// raw is the raw event log that triggered the state change and this stream state was parsed from.
+		raw types.Log
+	}
+
+	// StreamUpdatedEvent represents an event that was decoded from a StreamUpdated log by the stream registry.
+	StreamUpdatedEvent interface {
+		// GetStreamId returns the stream ID of the stream that was updated.
+		GetStreamId() StreamId
+		// Reason returns the reason the StreamUpdated log was emitted.
+		Reason() StreamUpdatedEventType
+		// Raw returns the log from which the StreamUpdate event was decoded.
+		Raw() types.Log
+	}
 )
 
-type (
-	StreamAllocated            = StreamRegistryV1StreamAllocated
-	StreamCreated              = StreamRegistryV1StreamCreated
-	StreamLastMiniblockUpdated = StreamRegistryV1StreamLastMiniblockUpdated
-	StreamPlacementUpdated     = StreamRegistryV1StreamPlacementUpdated
+const (
+	// Event_StreamUpdated is the unified event emitted by the stream registry when a stream mutation occurs.
+	// Either when its created or modified.
+	Event_StreamUpdated = "StreamUpdated"
+
+	StreamUpdatedEventTypeAllocate                  StreamUpdatedEventType = 0
+	StreamUpdatedEventTypeCreate                    StreamUpdatedEventType = 1
+	StreamUpdatedEventTypePlacementUpdated          StreamUpdatedEventType = 2
+	StreamUpdatedEventTypeLastMiniblockBatchUpdated StreamUpdatedEventType = 3
+)
+
+var (
+	_ StreamUpdatedEvent = (*StreamState)(nil)
+	_ StreamUpdatedEvent = (*StreamMiniblockUpdate)(nil)
+
+	// TODO: update definition when replication factor is added
+	streamABIType, _ = abi.NewType("tuple", "structStream", []abi.ArgumentMarshaling{
+		{Name: "lastMiniblockHash", Type: "bytes32", InternalType: "bytes32"},
+		{Name: "lastMiniblockNum", Type: "uint64", InternalType: "uint64"},
+		{Name: "reserved0", Type: "uint64", InternalType: "uint64"},
+		{Name: "flags", Type: "uint64", InternalType: "uint64"},
+		{Name: "nodes", Type: "address[]", InternalType: "address[]"},
+	})
+
+	setMiniblockABIType, _ = abi.NewType("tuple", "structSetMiniblock", []abi.ArgumentMarshaling{
+		{Name: "streamId", Type: "bytes32", InternalType: "bytes32"},
+		{Name: "prevMiniBlockHash", Type: "bytes32", InternalType: "bytes32"},
+		{Name: "lastMiniblockHash", Type: "bytes32", InternalType: "bytes32"},
+		{Name: "lastMiniblockNum", Type: "uint64", InternalType: "uint64"},
+		{Name: "isSealed", Type: "bool", InternalType: "bool"},
+	})
 )
 
 func (_StreamRegistryV1 *StreamRegistryV1Caller) BoundContract() *bind.BoundContract {
 	return _StreamRegistryV1.contract
 }
 
-type EventWithStreamId interface {
-	GetStreamId() StreamId
+// GetStreamId implements the EventWithStreamId interface.
+func (ss *StreamState) GetStreamId() StreamId {
+	return ss.StreamID
 }
 
-func (e *StreamAllocated) GetStreamId() StreamId {
-	return e.StreamId
+func (ss *StreamState) Reason() StreamUpdatedEventType {
+	return ss.reason
 }
 
-func (e *StreamCreated) GetStreamId() StreamId {
-	return e.StreamId
+func (ss *StreamState) Raw() types.Log {
+	return ss.raw
 }
 
-func (e *StreamLastMiniblockUpdated) GetStreamId() StreamId {
-	return e.StreamId
+// GetStreamId implements the EventWithStreamId interface.
+func (smu *StreamMiniblockUpdate) GetStreamId() StreamId {
+	return smu.StreamID
 }
 
-func (e *StreamPlacementUpdated) GetStreamId() StreamId {
-	return e.StreamId
+func (smu *StreamMiniblockUpdate) Reason() StreamUpdatedEventType {
+	return StreamUpdatedEventTypeLastMiniblockBatchUpdated
+}
+
+func (smu *StreamMiniblockUpdate) Raw() types.Log {
+	return smu.raw
 }
 
 func MiniblockRefFromContractRecord(stream *Stream) *MiniblockRef {
@@ -49,4 +121,80 @@ func MiniblockRefFromContractRecord(stream *Stream) *MiniblockRef {
 		Hash: stream.LastMiniblockHash,
 		Num:  int64(stream.LastMiniblockNum),
 	}
+}
+
+// ParseStreamUpdatedEvent parses the given stream update into the stream registry state after the update.
+// The returned slice contains one or more *StreamState or *StreamMiniblockUpdate instances.
+func ParseStreamUpdatedEvent(event *StreamRegistryV1StreamUpdated) ([]StreamUpdatedEvent, error) {
+	reason := StreamUpdatedEventType(event.EventType)
+	switch reason {
+	case StreamUpdatedEventTypeAllocate:
+		streamID, stream, err := parseStreamIDAndStreamFromSolABIEncoded(event.Data)
+		if err != nil {
+			return nil, err
+		}
+		return []StreamUpdatedEvent{&StreamState{Stream: *stream, StreamID: streamID, reason: reason, raw: event.Raw}}, nil
+	case StreamUpdatedEventTypeCreate:
+		streamID, stream, err := parseStreamIDAndStreamFromSolABIEncoded(event.Data)
+		if err != nil {
+			return nil, err
+		}
+		return []StreamUpdatedEvent{&StreamState{Stream: *stream, StreamID: streamID, reason: reason, raw: event.Raw}}, nil
+	case StreamUpdatedEventTypePlacementUpdated:
+		streamID, stream, err := parseStreamIDAndStreamFromSolABIEncoded(event.Data)
+		if err != nil {
+			return nil, err
+		}
+		return []StreamUpdatedEvent{&StreamState{Stream: *stream, StreamID: streamID, reason: reason, raw: event.Raw}}, nil
+	case StreamUpdatedEventTypeLastMiniblockBatchUpdated:
+		return parseSetMiniblocksFromSolABIEncoded(event)
+	default:
+		return nil, AsRiverError(nil, protocol.Err_BAD_EVENT).
+			Message("Unsupported StreamUpdated event type").
+			Tags("type", reason, "tx", event.Raw.TxHash, "eventIndex", event.Raw.Index)
+	}
+}
+
+func parseStreamIDAndStreamFromSolABIEncoded(data []byte) (StreamId, *Stream, error) {
+	values := abi.Arguments{{Type: abi.Type{Size: 32, T: abi.FixedBytesTy}}, {Type: streamABIType}}
+	unpacked, err := values.Unpack(data)
+	if err != nil {
+		return StreamId{}, nil, AsRiverError(err, protocol.Err_BAD_EVENT).
+			Message("Unable to decode stream updated event").
+			Func("parseStreamIDAndStreamFromSolABIEncoded")
+	}
+
+	var streamID StreamId
+	abi.ConvertType(unpacked[0], &streamID)
+	stream := *abi.ConvertType(unpacked[1], new(Stream)).(*Stream)
+
+	return streamID, &stream, nil
+}
+
+func parseSetMiniblocksFromSolABIEncoded(event *StreamRegistryV1StreamUpdated) ([]StreamUpdatedEvent, error) {
+	values := abi.Arguments{{Type: abi.Type{T: abi.SliceTy, Elem: &setMiniblockABIType}}}
+	unpacked, err := values.Unpack(event.Data)
+	if err != nil {
+		return nil, AsRiverError(err, protocol.Err_BAD_EVENT).
+			Message("Unable to decode stream updated event").
+			Func("parseSetMiniblocksFromSolcABIEncoded")
+	}
+
+	// TODO: workaround for abi.ConvertType(unpacked[1], make([]*SetMiniblock, 0)).([]*SetMiniblock) that panics
+	serialized, _ := json.Marshal(unpacked[0])
+	var setMiniblocks []*SetMiniblock
+	if err := json.Unmarshal(serialized, &setMiniblocks); err != nil {
+		return nil, err
+	}
+
+	results := make([]StreamUpdatedEvent, len(setMiniblocks))
+	for i, setMiniblock := range setMiniblocks {
+		results[i] = &StreamMiniblockUpdate{
+			SetMiniblock: *setMiniblock,
+			StreamID:     setMiniblock.StreamId,
+			raw:          event.Raw,
+		}
+	}
+
+	return results, nil
 }

--- a/core/node/events/miniblock.go
+++ b/core/node/events/miniblock.go
@@ -172,7 +172,7 @@ func NewMiniblockFromBytesWithOpts(bytes []byte, opts *ParsedMiniblockInfoOpts) 
 	if err != nil {
 		return nil, AsRiverError(err, Err_INVALID_ARGUMENT).
 			Message("Failed to decode miniblock from bytes").
-			Func("NewMiniblockInfoFromBytes")
+			Func("NewMiniblockFromBytesWithOpts")
 	}
 
 	return NewMiniblockInfoFromProto(&pb, opts)

--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -18,7 +18,7 @@ import (
 
 func (s *StreamCache) onStreamCreated(
 	ctx context.Context,
-	event *river.StreamCreated,
+	event *river.StreamState,
 	blockNum crypto.BlockNumber,
 ) {
 	if !slices.Contains(event.Stream.Nodes, s.params.Wallet.Address) {

--- a/core/node/registries/river_registry_contract_test.go
+++ b/core/node/registries/river_registry_contract_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/towns-protocol/towns/core/node/base/test"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	. "github.com/towns-protocol/towns/core/node/protocol"
-	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/testutils"
 )
 
@@ -236,24 +235,24 @@ func TestStreamEvents(t *testing.T) {
 	)
 	require.NoError(err)
 
-	allocatedC := make(chan *river.StreamRegistryV1StreamAllocated, 10)
-	addedC := make(chan *river.StreamRegistryV1StreamCreated, 10)
-	lastMBC := make(chan *river.StreamRegistryV1StreamLastMiniblockUpdated, 10)
-	placementC := make(chan *river.StreamRegistryV1StreamPlacementUpdated, 10)
+	allocatedC := make(chan *river.StreamState, 10)
+	addedC := make(chan *river.StreamState, 10)
+	lastMBC := make(chan *river.StreamMiniblockUpdate, 10)
+	placementC := make(chan *river.StreamState, 10)
 
 	err = rr1.OnStreamEvent(
 		ctx,
 		bc1.InitialBlockNum+1,
-		func(ctx context.Context, event *river.StreamRegistryV1StreamAllocated) {
+		func(ctx context.Context, event *river.StreamState) {
 			allocatedC <- event
 		},
-		func(ctx context.Context, event *river.StreamRegistryV1StreamCreated) {
+		func(ctx context.Context, event *river.StreamState) {
 			addedC <- event
 		},
-		func(ctx context.Context, event *river.StreamRegistryV1StreamLastMiniblockUpdated) {
+		func(ctx context.Context, event *river.StreamMiniblockUpdate) {
 			lastMBC <- event
 		},
-		func(ctx context.Context, event *river.StreamRegistryV1StreamPlacementUpdated) {
+		func(ctx context.Context, event *river.StreamState) {
 			placementC <- event
 		},
 	)
@@ -268,13 +267,18 @@ func TestStreamEvents(t *testing.T) {
 	require.NoError(err)
 
 	allocated := <-allocatedC
+	require.Empty(allocatedC)
+	require.Empty(addedC)
+	require.Empty(lastMBC)
+	require.Empty(placementC)
+
 	require.NotNil(allocated)
-	require.Equal(streamId, StreamId(allocated.StreamId))
+	require.Equal(streamId, allocated.StreamID)
+	require.EqualValues(river.StreamUpdatedEventTypeAllocate, allocated.Reason())
+	require.Equal(genesisHash, common.Hash(allocated.LastMiniblockHash))
+	require.EqualValues(0, allocated.LastMiniblockNum)
 	require.Equal(addrs, allocated.Nodes)
-	require.Equal(genesisHash, common.Hash(allocated.GenesisMiniblockHash))
-	require.Equal(genesisMiniblock, allocated.GenesisMiniblock)
-	require.Len(lastMBC, 0)
-	require.Len(placementC, 0)
+	require.EqualValues(0, allocated.Flags)
 
 	// Update stream placement
 	tx, err := bc1.TxPool.Submit(ctx, "UpdateStreamPlacement",
@@ -289,12 +293,18 @@ func TestStreamEvents(t *testing.T) {
 	require.Equal(crypto.TransactionResultSuccess, receipt.Status)
 
 	placement := <-placementC
+	require.Empty(allocatedC)
+	require.Empty(addedC)
+	require.Empty(lastMBC)
+	require.Empty(placementC)
+
 	require.NotNil(placement)
-	require.Equal(streamId, StreamId(placement.StreamId))
-	require.Equal(nodeAddr2, placement.NodeAddress)
-	require.True(placement.IsAdded)
-	require.Len(allocatedC, 0)
-	require.Len(lastMBC, 0)
+	require.Equal(streamId, placement.StreamID)
+	require.EqualValues(river.StreamUpdatedEventTypePlacementUpdated, placement.Reason())
+	require.EqualValues(genesisHash, placement.LastMiniblockHash)
+	require.EqualValues(0, placement.LastMiniblockNum)
+	require.Equal(append(addrs, nodeAddr2), placement.Nodes)
+	require.EqualValues(0, allocated.Flags)
 
 	// Update last miniblock
 	newMBHash := common.HexToHash("0x456")
@@ -314,13 +324,18 @@ func TestStreamEvents(t *testing.T) {
 	require.Empty(failed)
 
 	lastMB := <-lastMBC
+	require.Empty(allocatedC)
+	require.Empty(addedC)
+	require.Empty(lastMBC)
+	require.Empty(placementC)
+
 	require.NotNil(lastMB)
-	require.Equal(streamId, StreamId(lastMB.StreamId))
-	require.Equal(newMBHash, common.Hash(lastMB.LastMiniblockHash))
-	require.Equal(uint64(1), lastMB.LastMiniblockNum)
+	require.Equal(streamId, lastMB.StreamID)
+	require.EqualValues(newMBHash, lastMB.LastMiniblockHash)
+	require.EqualValues(1, lastMB.LastMiniblockNum)
+	require.EqualValues(genesisHash, lastMB.PrevMiniBlockHash)
+	require.EqualValues(river.StreamUpdatedEventTypeLastMiniblockBatchUpdated, lastMB.Reason())
 	require.False(lastMB.IsSealed)
-	require.Len(allocatedC, 0)
-	require.Len(placementC, 0)
 
 	newMBHash2 := common.HexToHash("0x789")
 	succeeded, invalidMiniblocks, failed, err = rr1.SetStreamLastMiniblockBatch(
@@ -339,13 +354,18 @@ func TestStreamEvents(t *testing.T) {
 	require.Empty(failed)
 
 	lastMB = <-lastMBC
+	require.Empty(allocatedC)
+	require.Empty(addedC)
+	require.Empty(lastMBC)
+	require.Empty(placementC)
+
 	require.NotNil(lastMB)
-	require.Equal(streamId, StreamId(lastMB.StreamId))
+	require.Equal(streamId, lastMB.StreamID)
+	require.EqualValues(river.StreamUpdatedEventTypeLastMiniblockBatchUpdated, lastMB.Reason())
+	require.EqualValues(newMBHash, lastMB.PrevMiniBlockHash)
 	require.Equal(newMBHash2, common.Hash(lastMB.LastMiniblockHash))
-	require.Equal(uint64(2), lastMB.LastMiniblockNum)
+	require.EqualValues(2, lastMB.LastMiniblockNum)
 	require.False(lastMB.IsSealed)
-	require.Len(allocatedC, 0)
-	require.Len(placementC, 0)
 
 	// Add stream
 	streamId = testutils.StreamIdFromBytes([]byte{0xa1, 0x02, 0x04})
@@ -357,11 +377,17 @@ func TestStreamEvents(t *testing.T) {
 	require.NoError(err)
 
 	added := <-addedC
+	require.Empty(allocatedC)
+	require.Empty(addedC)
+	require.Empty(lastMBC)
+	require.Empty(placementC)
+
 	require.NotNil(added)
-	require.Equal(streamId, StreamId(added.StreamId))
+
+	require.Equal(streamId, added.StreamID)
 	require.Equal(addrs, added.Stream.Nodes)
-	require.Equal(genesisHash, common.Hash(added.GenesisMiniblockHash))
-	require.Equal(lastMiniblockHash, common.Hash(added.Stream.LastMiniblockHash))
-	require.Equal(lastMiniblockNum, int64(added.Stream.LastMiniblockNum))
-	require.True(added.Stream.Flags&uint64(StreamFlagSealed) != 0)
+	require.EqualValues(river.StreamUpdatedEventTypeCreate, added.Reason())
+	require.EqualValues(lastMiniblockHash, added.LastMiniblockHash)
+	require.EqualValues(lastMiniblockNum, added.LastMiniblockNum)
+	require.EqualValues(StreamFlagSealed, added.Flags&uint64(StreamFlagSealed))
 }

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -960,43 +960,43 @@ func (a *Archiver) startImpl(ctx context.Context, once bool, metrics infra.Metri
 	return nil
 }
 
-func (a *Archiver) onStreamAllocated(ctx context.Context, event *river.StreamRegistryV1StreamAllocated) {
+func (a *Archiver) onStreamAllocated(ctx context.Context, event *river.StreamState) {
 	a.newStreamAllocated.Add(1)
-	id := StreamId(event.StreamId)
+	id := event.StreamID
 	a.addNewStream(ctx, id, &event.Nodes, 0)
 	a.tasks <- id
 }
 
-func (a *Archiver) onStreamAdded(ctx context.Context, event *river.StreamRegistryV1StreamCreated) {
+func (a *Archiver) onStreamAdded(ctx context.Context, event *river.StreamState) {
 	a.newStreamAllocated.Add(1)
-	id := StreamId(event.StreamId)
+	id := event.StreamID
 	a.addNewStream(ctx, id, &event.Stream.Nodes, 0)
 	a.tasks <- id
 }
 
 func (a *Archiver) onStreamPlacementUpdated(
 	ctx context.Context,
-	event *river.StreamRegistryV1StreamPlacementUpdated,
+	event *river.StreamState,
 ) {
 	a.streamPlacementUpdated.Add(1)
 
-	id := StreamId(event.StreamId)
+	id := event.StreamID
 	record, loaded := a.streams.Load(id)
 	if !loaded {
 		logging.FromCtx(ctx).Errorw("onStreamPlacementUpdated: Stream not found in map", "streamId", id)
 		return
 	}
 	stream := record.(*ArchiveStream)
-	_ = stream.nodes.Update(event, common.Address{})
+	stream.nodes.Reset(event.Nodes, common.Address{})
 }
 
 func (a *Archiver) onStreamLastMiniblockUpdated(
 	ctx context.Context,
-	event *river.StreamRegistryV1StreamLastMiniblockUpdated,
+	event *river.StreamMiniblockUpdate,
 ) {
 	a.streamLastMiniblockUpdated.Add(1)
 
-	id := StreamId(event.StreamId)
+	id := event.StreamID
 	record, loaded := a.streams.Load(id)
 	if !loaded {
 		logging.FromCtx(ctx).Errorw("onStreamLastMiniblockUpdated: Stream not found in map", "streamId", id)

--- a/core/node/track_streams/streams_tracker.go
+++ b/core/node/track_streams/streams_tracker.go
@@ -230,9 +230,9 @@ func (tracker *StreamsTrackerImpl) AddStream(streamId shared.StreamId) error {
 // responsible for it.
 func (tracker *StreamsTrackerImpl) OnStreamAllocated(
 	ctx context.Context,
-	event *river.StreamRegistryV1StreamAllocated,
+	event *river.StreamState,
 ) {
-	streamID := shared.StreamId(event.StreamId)
+	streamID := event.StreamID
 	if !tracker.filter.TrackStream(streamID) {
 		return
 	}
@@ -245,9 +245,9 @@ func (tracker *StreamsTrackerImpl) OnStreamAllocated(
 // responsible for it.
 func (tracker *StreamsTrackerImpl) OnStreamAdded(
 	ctx context.Context,
-	event *river.StreamRegistryV1StreamCreated,
+	event *river.StreamState,
 ) {
-	streamID := shared.StreamId(event.StreamId)
+	streamID := event.StreamID
 	if !tracker.filter.TrackStream(streamID) {
 		return
 	}
@@ -257,14 +257,14 @@ func (tracker *StreamsTrackerImpl) OnStreamAdded(
 
 func (tracker *StreamsTrackerImpl) OnStreamLastMiniblockUpdated(
 	context.Context,
-	*river.StreamRegistryV1StreamLastMiniblockUpdated,
+	*river.StreamMiniblockUpdate,
 ) {
 	// miniblocks are processed when a stream event with a block header is received for the stream
 }
 
 func (tracker *StreamsTrackerImpl) OnStreamPlacementUpdated(
 	context.Context,
-	*river.StreamRegistryV1StreamPlacementUpdated,
+	*river.StreamState,
 ) {
 	// reserved when replacements are introduced
 	// 1. stop existing sync operation


### PR DESCRIPTION
Switches the node over to use the new StreamUpdated event that was introduced in https://github.com/towns-protocol/towns/pull/2578

The StreamUpdated event is a tuple of the type of event it represents and abi.encoded data. The node decodes this data based on the event type. For stream miniblock updates this is an slice of updates (batch) but abi decoding in the node currently fails. A workaround is used that json marshals the decoded input and marshals it back it which works. This workaround is a todo that needs to be fixed.