### PR TITLE
Fix broken link 

### DIFF
--- a/packages/docs/towns-token/distribution.mdx
+++ b/packages/docs/towns-token/distribution.mdx
@@ -7,7 +7,7 @@ description: Token reward distribution is a key component of the Towns Network t
 
 ## Inflation Schedule
 
-The first year's inflation of Towns token derives from the existing supply. Subsequent inflation occurs annually, starting at 8% and tapering to 2% after 20 years, per the predefined inflation [schedule](https://github.com/towns-protocol/towns/blob/main/contracts/scripts/deployments/DeployTownsMainnet.s.sol#L27-L35).
+The first year's inflation of Towns token derives from the existing supply. Subsequent inflation occurs annually, starting at 8% and tapering to 2% after 20 years, per the predefined inflation [schedule](https://github.com/towns-protocol/towns/blob/main/contracts/scripts/deployments/utils/DeployTownsMainnet.s.sol#L27-L35).
 
 ## Token Inflation
 


### PR DESCRIPTION
Updated the incorrect file path in the inflation schedule reference to point to the correct location in the utils/ directory. Also ensured formatting consistency in the documentation. If there’s a better reference, let me know, and I’ll update it.