### PR TITLE
Downgrade GetStreamSince warning to debug

### DIFF
--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -916,7 +916,7 @@ func (r *StreamView) GetStreamSince(
 	miniblockIndex, err := r.indexOfMiniblockWithNum(cookie.MinipoolGen)
 	if err != nil {
 		// The user's sync cookie is out of date. Send a sync reset and return an up-to-date StreamAndCookie.
-		log.Warnw("GetStreamSince: out of date cookie.MiniblockNum. Sending sync reset.",
+		log.Debugw("GetStreamSince: out of date cookie.MiniblockNum. Sending sync reset.",
 			"stream", r.streamId, "error", err.Error())
 
 		return &StreamAndCookie{


### PR DESCRIPTION

the sync resets are expected. the space stream updates so much that people checking in once a day will have an out of date cookie for large space.