### PR TITLE
test(contract): initialize deployment contracts in `setUp` function

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -20,7 +20,7 @@
         "@openzeppelin/contracts": "^5.2.0",
         "@openzeppelin/contracts-upgradeable": "^5.2.0",
         "@prb/math": "^4.1.0",
-        "@towns-protocol/diamond": "^0.2.0",
+        "@towns-protocol/diamond": "^0.3.0",
         "crypto-lib": "github:towns-protocol/crypto-lib#f40c5f6944a55583a687b672ba680db3bfabb0ef",
         "solady": "^0.1.12"
     },
@@ -28,7 +28,7 @@
         "@prb/test": "^0.6.4",
         "@wagmi/cli": "^2.2.0",
         "account-abstraction": "github:eth-infinitism/account-abstraction",
-        "forge-std": "github:foundry-rs/forge-std#v1.9.5",
+        "forge-std": "github:foundry-rs/forge-std#v1.9.6",
         "prettier": "^2.8.8",
         "prettier-plugin-solidity": "^1.4.2",
         "solhint": "^5.0.5",

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -31,8 +31,12 @@ contract RewardsDistributionV2Test is BaseRegistryTest, IOwnableBase, IDiamond {
       "Stake(uint96 amount,address delegatee,address beneficiary,address owner,uint256 nonce,uint256 deadline)"
     );
 
-  DeployRewardsDistributionV2 internal distributionV2Helper =
-    new DeployRewardsDistributionV2();
+  DeployRewardsDistributionV2 internal distributionV2Helper;
+
+  function setUp() public virtual override {
+    super.setUp();
+    distributionV2Helper = new DeployRewardsDistributionV2();
+  }
 
   function test_storageSlot() public pure {
     bytes32 slot = keccak256(

--- a/contracts/test/spaces/BaseSetup.sol
+++ b/contracts/test/spaces/BaseSetup.sol
@@ -53,12 +53,11 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
   bytes32 private constant _LINKED_WALLET_TYPEHASH =
     0x6bb89d031fcd292ecd4c0e6855878b7165cebc3a2f35bc6bbac48c088dd8325c;
 
-  DeployBaseRegistry internal deployBaseRegistry = new DeployBaseRegistry();
-  DeploySpaceFactory internal deploySpaceFactory = new DeploySpaceFactory();
-  DeployTownsBase internal deployTokenBase = new DeployTownsBase();
-  DeployProxyBatchDelegation internal deployProxyBatchDelegation =
-    new DeployProxyBatchDelegation();
-  DeployRiverAirdrop internal deployRiverAirdrop = new DeployRiverAirdrop();
+  DeployBaseRegistry internal deployBaseRegistry;
+  DeploySpaceFactory internal deploySpaceFactory;
+  DeployTownsBase internal deployTokenBase;
+  DeployProxyBatchDelegation internal deployProxyBatchDelegation;
+  DeployRiverAirdrop internal deployRiverAirdrop;
 
   address[] internal operators;
   address[] internal nodes;
@@ -104,6 +103,7 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
   // @notice - This function is called before each test function
   // @dev - It will create a new diamond contract and set the spaceFactory variable to the address of the "diamond" variable
   function setUp() public virtual {
+    vm.pauseGasMetering();
     deployer = getDeployer();
 
     operators = _createAccounts(10);
@@ -112,6 +112,12 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
     simpleAccountFactory = new SimpleAccountFactory(
       IEntryPoint(_randomAddress())
     );
+
+    deployBaseRegistry = new DeployBaseRegistry();
+    deploySpaceFactory = new DeploySpaceFactory();
+    deployTokenBase = new DeployTownsBase();
+    deployProxyBatchDelegation = new DeployProxyBatchDelegation();
+    deployRiverAirdrop = new DeployRiverAirdrop();
 
     // River Token
     townsToken = deployTokenBase.deploy(deployer);
@@ -192,6 +198,7 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
     space = ICreateSpace(spaceFactory).createSpace(spaceInfo);
     everyoneSpace = ICreateSpace(spaceFactory).createSpace(everyoneSpaceInfo);
     vm.stopPrank();
+    vm.resumeGasMetering();
   }
 
   function _registerOperators() internal {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,11 +8597,11 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": ^5.2.0
     "@prb/math": ^4.1.0
     "@prb/test": ^0.6.4
-    "@towns-protocol/diamond": ^0.2.0
+    "@towns-protocol/diamond": ^0.3.0
     "@wagmi/cli": ^2.2.0
     account-abstraction: "github:eth-infinitism/account-abstraction"
     crypto-lib: "github:towns-protocol/crypto-lib#f40c5f6944a55583a687b672ba680db3bfabb0ef"
-    forge-std: "github:foundry-rs/forge-std#v1.9.5"
+    forge-std: "github:foundry-rs/forge-std#v1.9.6"
     prettier: ^2.8.8
     prettier-plugin-solidity: ^1.4.2
     solady: ^0.1.12
@@ -8610,13 +8610,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@towns-protocol/diamond@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@towns-protocol/diamond@npm:0.2.0"
+"@towns-protocol/diamond@npm:^0.3.0":
+  version: 0.3.2
+  resolution: "@towns-protocol/diamond@npm:0.3.2"
   dependencies:
     "@openzeppelin/contracts": ^5.2.0
     solady: ^0.1.12
-  checksum: 3a6aa5453e1ecfeade47374fd840e7c5f4e8d780584f1bab956f26de9a3aa346d934dc2fcf8a5638da503cf1077996ad9edcd54162124b9feccc3de370257c80
+  checksum: 65b1038d37df2ef330f7dfa7b67485a1601b16b41098e2d979cb46a51724b37e01be844be75fa8a56ad58bc1323ddce0a4263429de8fce0a2dc035edcd60ff25
   languageName: node
   linkType: hard
 
@@ -17098,6 +17098,13 @@ __metadata:
   version: 1.9.5
   resolution: "forge-std@https://github.com/foundry-rs/forge-std.git#commit=b93cf4bc34ff214c099dc970b153f85ade8c9f66"
   checksum: 71aead7ca70cc51b46f0336074a9721aa765ba85030080577460c76f2a824abfb26bd1f4a77811c8ffbbce2cb9788f95dc0340926b041a3e2477c9a624f3503b
+  languageName: node
+  linkType: hard
+
+"forge-std@github:foundry-rs/forge-std#v1.9.6":
+  version: 1.9.6
+  resolution: "forge-std@https://github.com/foundry-rs/forge-std.git#commit=3b20d60d14b343ee4f908cb8079495c07f5e8981"
+  checksum: 09083036e38d0f0cf5721f8788330b815b3c6c2369b84c4ee95e0047a5bff5d8a46ff59d3dd1aa89dfc97b3d85bb42579fb11b27d4f05b4ae416cf5b6f783bdc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Moved contract initializations into the `setUp` function to ensure proper configuration before each test. This improves test reliability and reduces redundancy by centralizing setup logic. Additionally, updated dependencies in `package.json` and `yarn.lock` for compatibility.