### PR TITLE
chore(contract): update RPC and explorer URLs in .env example

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,10 +1,14 @@
 # RPC_URL is the URL of the Ethereum node to use for deployment
+BASE_RPC_URL=
 BASE_SEPOLIA_RPC_URL=
 BASE_ANVIL_RPC_URL="${BASE_ANVIL_RPC_URL:-http://127.0.0.1:8545}"
 RIVER_ANVIL_RPC_URL="${RIVER_ANVIL_RPC_URL:-http://127.0.0.1:8546}"
+RIVER_RPC_URL="https://mainnet.rpc.towns.com/"
+RIVER_DEVNET_RPC_URL="https://testnet.rpc.towns.com/http"
 
 # PRIVATE_KEY is the private key of the account to use for deployment
 LOCAL_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+TESTNET_PRIVATE_KEY=
 PRODUCTION_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 SENDER_ADDRESS=
 HD_PATH="m/44\'/60\'/0\'/0/0"
@@ -16,12 +20,11 @@ BASESCAN_API_KEY=
 BASESCAN_SEPOLIA_API_KEY=
 BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
-RIVERSCAN_API_KEY=
 
 # URLs foundry will use to verify contracts
 BASESCAN_URL="https://api.basescan.org/api"
 BASESCAN_SEPOLIA_URL="https://api-sepolia.basescan.org/api"
 BLOCKSCOUT_BASE_URL="https://base.blockscout.com/api"
 BLOCKSCOUT_SEPOLIA_URL="https://base-sepolia.blockscout.com/api"
-RIVERSCAN_DEVNET_URL=
-RIVERSCAN_URL=
+RIVERSCAN_DEVNET_URL="https://testnet.explorer.towns.com/api"
+RIVERSCAN_URL="https://explorer.towns.com/api"

--- a/contracts/.env.localhost
+++ b/contracts/.env.localhost
@@ -17,12 +17,11 @@ BASESCAN_API_KEY=
 BASESCAN_SEPOLIA_API_KEY=
 BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
-RIVERSCAN_API_KEY=
 
 # URLs foundry will use to verify contracts
 BASESCAN_URL="https://api.basescan.org/api"
 BASESCAN_SEPOLIA_URL="https://api-sepolia.basescan.org/api"
 BLOCKSCOUT_BASE_URL="https://base.blockscout.com/api"
 BLOCKSCOUT_SEPOLIA_URL="https://base-sepolia.blockscout.com/api"
-RIVERSCAN_DEVNET_URL=
-RIVERSCAN_URL=
+RIVERSCAN_DEVNET_URL="https://testnet.explorer.towns.com/api"
+RIVERSCAN_URL="https://explorer.towns.com/api"


### PR DESCRIPTION
Added new RPC URL entries and updated RIVERSCAN URLs in both `.env.example` and `.env.localhost`. This ensures consistency and provides better support for different environments. Removed unused `RIVERSCAN_API_KEY` for cleanup.