### PR TITLE
remove jest from eslint rules in metrics discovery package

### DIFF
--- a/packages/metrics-discovery/.eslintrc.json
+++ b/packages/metrics-discovery/.eslintrc.json
@@ -6,13 +6,12 @@
         "plugin:import/typescript",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:prettier/recommended",
-        "plugin:jest/recommended"
+        "plugin:prettier/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": { "project": ["./tsconfig.json"] },
     "plugins": ["@typescript-eslint", "import"],
-    "ignorePatterns": ["dist/**", ".turbo/**", "node_modules/**", "jest.config.ts"],
+    "ignorePatterns": ["dist/**", ".turbo/**", "node_modules/**"],
     "rules": {
         "import/no-extraneous-dependencies": [
             "error",
@@ -55,10 +54,6 @@
         {
             "files": ["**/*.test.*", "**/*.test_util.*"],
             "rules": {
-                "jest/no-standalone-expect": "error",
-                "jest/expect-expect": "error",
-                "jest/no-conditional-expect": "off",
-                "jest/no-disabled-tests": "off",
                 "@typescript-eslint/no-unsafe-call": "error",
                 "@typescript-eslint/no-non-null-assertion": "error",
                 "@typescript-eslint/no-unsafe-argument": "error"


### PR DESCRIPTION
We dont have tests on metrics-discovery package, and we're not using jest anymore. 

Removing it from eslint rules to fix CI