### PR TITLE
Add quotes around schema name for stats query function

### DIFF
--- a/core/node/storage/pg_metrics.go
+++ b/core/node/storage/pg_metrics.go
@@ -109,13 +109,13 @@ func setupPostgresMetrics(ctx context.Context, pool PgxPoolInfo, factory infra.M
 		ctx,
 		fmt.Sprintf(
 			`
-			CREATE OR REPLACE FUNCTION %v.safe_table_count(tablename text, schemaname text default 'public')
+			CREATE OR REPLACE FUNCTION "%s".safe_table_count(tablename text, schemaname text default 'public')
 			RETURNS integer AS $$
 			DECLARE
 				total integer := 0;
 			BEGIN
-				IF to_regclass(format('%%I.%%I', schemaname, tablename)) IS NOT NULL THEN
-					EXECUTE format('SELECT COUNT(*) FROM %%I.%%I', schemaname, tablename)
+				IF to_regclass(format('"%%I".%%I', schemaname, tablename)) IS NOT NULL THEN
+					EXECUTE format('SELECT COUNT(*) FROM "%%I".%%I', schemaname, tablename)
 					INTO total;
 				END IF;
 				RETURN total;


### PR DESCRIPTION
Uniquely generated random node ids for tests sometimes contain hyphens, and these node ids are used to compose schema names for the database. If the schema name contains a hyphen, then the schema must be quoted in double quotes wherever  it's referenced directly in queries.

This change updates the statistics calculation function to quote the schema in double quotes everywhere it occurs.