### PR TITLE
Fix Flaky streamRpcClientGetSince test

### DIFF
--- a/packages/sdk/src/tests/multi_ne/streamRpcClientGetSince.test.ts
+++ b/packages/sdk/src/tests/multi_ne/streamRpcClientGetSince.test.ts
@@ -101,7 +101,7 @@ describe('streamRpcClientGetSince', () => {
             streamId: bobsSettingsStreamId,
             syncCookie: cookie,
         })
-        expect(streamSince.stream?.events.length).toBe(3) // all events since last cookie
+        expect(streamSince.stream?.events.length).toBeGreaterThanOrEqual(3) // all events since last cookie
         expect(streamSince.stream?.miniblocks.length).toBe(0)
         expect(streamSince.stream?.syncReset).toBe(false)
     })


### PR DESCRIPTION
Not sure when this started happening, but it makes sense that we can have a new block header here 
Example failure: https://github.com/towns-protocol/towns/actions/runs/14257837404/job/39963612469?pr=2740