### PR TITLE
chore: add access public to lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,10 @@
     "$schema": "node_modules/lerna/schemas/lerna-schema.json",
     "version": "0.0.190",
     "packages": ["packages/*", "protocol"],
-    "npmClient": "yarn"
+    "npmClient": "yarn",
+    "command": {
+        "publish": {
+            "access": "public"
+        }
+    }
 }


### PR DESCRIPTION
Still trying to identify the root cause, but this started to happen in our [publish to npm CI action](https://github.com/towns-protocol/towns/actions/runs/14268868159/job/39997218322)

```
lerna WARN notice Package failed to publish: @towns-protocol/prettier-config
lerna ERR! E402 You must sign up for private packages
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
lerna WARN notice Package failed to publish: @towns-protocol/proto-source
lerna ERR! E402 You must sign up for private packages
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
lerna WARN notice Package failed to publish: @towns-protocol/eslint-config
lerna ERR! E402 You must sign up for private packages
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
lerna WARN notice Package failed to publish: @towns-protocol/generated
lerna ERR! E402 You must sign up for private packages
```
This setting should fix it.