### PR TITLE
refactor(contract): shift `streamIdsByNode` by one slot

### DIFF
--- a/contracts/src/river/registry/facets/stream/StreamRegistry.sol
+++ b/contracts/src/river/registry/facets/stream/StreamRegistry.sol
@@ -12,7 +12,6 @@ import {
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-
 import {RiverRegistryErrors} from "contracts/src/river/registry/libraries/RegistryErrors.sol";
 import {CustomRevert} from "contracts/src/utils/libraries/CustomRevert.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
@@ -252,11 +251,7 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
             for (; start < end; ++start) {
                 bytes32 streamId = ds.streams.at(start);
                 Stream storage stream = ds.streamById[streamId];
-                address[] storage nodes = stream.nodes;
-                uint256 nodeCount = nodes.length;
-                for (uint256 i; i < nodeCount; ++i) {
-                    ds.streamIdsByNode[nodes[i]].add(streamId);
-                }
+                _addStreamIdToNodes(streamId, stream.nodes);
             }
         }
     }
@@ -281,16 +276,10 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
             Stream storage stream = ds.streamById[req.streamId];
 
             // remove the stream from the existing set of nodes
-            uint256 oldStreamNodesLength = stream.nodes.length;
-            for (uint256 j; j < oldStreamNodesLength; ++j) {
-                ds.streamIdsByNode[stream.nodes[j]].remove(req.streamId);
-            }
+            _removeStreamIdFromNodes(req.streamId, stream.nodes);
 
             // place stream on the new set of nodes
-            uint256 newStreamNodesLength = req.nodes.length;
-            for (uint256 j; j < newStreamNodesLength; ++j) {
-                ds.streamIdsByNode[req.nodes[j]].add(req.streamId);
-            }
+            _addStreamIdToNodes(req.streamId, req.nodes);
 
             (stream.nodes, stream.reserved0) =
                 (req.nodes, _calculateStreamReserved0(stream.reserved0, req.replicationFactor));
@@ -403,9 +392,26 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
     /*                          INTERNAL                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
+    /// @dev Adds a stream id to the nodes
+    function _addStreamIdToNodes(bytes32 streamId, address[] storage nodes) internal {
+        uint256 nodeCount = nodes.length;
+        for (uint256 i; i < nodeCount; ++i) {
+            ds.streamIdsByNode[nodes[i]].add(streamId);
+        }
+    }
+
+    /// @dev Adds a stream id to the nodes
     function _addStreamIdToNodes(bytes32 streamId, address[] calldata nodes) internal {
         for (uint256 i; i < nodes.length; ++i) {
             ds.streamIdsByNode[nodes[i]].add(streamId);
+        }
+    }
+
+    /// @dev Removes a stream id from the nodes
+    function _removeStreamIdFromNodes(bytes32 streamId, address[] storage nodes) internal {
+        uint256 nodeCount = nodes.length;
+        for (uint256 i; i < nodeCount; ++i) {
+            ds.streamIdsByNode[nodes[i]].remove(streamId);
         }
     }
 

--- a/contracts/src/river/registry/libraries/RegistryStorage.sol
+++ b/contracts/src/river/registry/libraries/RegistryStorage.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.23;
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-
 import {RiverRegistryErrors} from "contracts/src/river/registry/libraries/RegistryErrors.sol";
 import {CustomRevert} from "contracts/src/utils/libraries/CustomRevert.sol";
 
@@ -85,6 +84,8 @@ struct AppStorage {
     mapping(bytes32 => Setting[]) configuration;
     // Set of addresses of all configuration managers
     EnumerableSet.AddressSet configurationManagers;
+    // Deprecated slot. Do not use.
+    uint256 deprecatedSlot;
     // Map of node address to its stream ids
     mapping(address => EnumerableSet.Bytes32Set) streamIdsByNode;
 }


### PR DESCRIPTION
Replaced repetitive node-iteration logic with `_addStreamIdToNodes` and `_removeStreamIdFromNodes` utility functions to improve code reuse and readability. Additionally, deprecated an unused storage slot by introducing `deprecatedSlot` as a placeholder in `RegistryStorage.sol`.