### PR TITLE
chore: exclude .idea directory in git clean

### DIFF
--- a/scripts/yarn-clean.sh
+++ b/scripts/yarn-clean.sh
@@ -44,7 +44,7 @@ popd > /dev/null
 echo ""
 
 # remove files not tracked by git, but keep dev files
-git clean -fdx -e .DS_Store -e '.env.*' -e '.env.*.*' -e '*.yaml' -e .vscode -e '*.pem' -e '*.crt' -e '*.key' -e .keys -e *_key -e *_address -e .wrangler -e .dev.* -e test-config.json
+git clean -fdx -e .DS_Store -e '.env.*' -e '.env.*.*' -e '*.yaml' -e .vscode -e .idea -e '*.pem' -e '*.crt' -e '*.key' -e .keys -e *_key -e *_address -e .wrangler -e .dev.* -e test-config.json
 
 # remove empty directories and directories that only contain .DS_Store files
 find . -type d -not -path "./.git/*" -print0 | while IFS= read -r -d '' dir; do


### PR DESCRIPTION
Updated the yarn-clean script to retain the .idea directory during cleaning. This change prevents accidental deletion of IDE files, enhancing convenience for developers using IntelliJ-based tools.