### PR TITLE
chore: update CODEOWNERS path for contracts directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@
 /.github/CODEOWNERS @sergekh2 @texuf
 /.vscode/ @texuf
 /assets/ @texuf
-/contracts/ @pfives @giuseppecrj @jterzis @shuhuiluo
+/packages/contracts/ @pfives @giuseppecrj @jterzis @shuhuiluo
 /core/ @sergekh2
 /core/node/ @sergekh2 @bas-vk
 /core/node/events/ @sergekh2 @texuf


### PR DESCRIPTION
Adjusted the CODEOWNERS file to reflect the updated path for the contracts directory from `/contracts/` to `/packages/contracts/`. This ensures proper code ownership management for the new directory structure.