### PR TITLE
Move the notification service call out of the stress test demo

### DIFF
--- a/packages/stress/esbuild.config.mjs
+++ b/packages/stress/esbuild.config.mjs
@@ -5,6 +5,7 @@ build({
     entryPoints: {
         start: './src/start.ts',
         demo: './src/demo.ts',
+        notifications: './src/notifications.ts',
     },
     bundle: true,
     sourcemap: 'inline',

--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -7,6 +7,7 @@
         "build": "yarn typecheck && yarn build-esbuild",
         "build-esbuild": "node esbuild.config.mjs",
         "demo": "node --enable-source-maps ./dist/demo.cjs",
+        "notifications": "node --enable-source-maps ./dist/notifications.cjs",
         "lint": "eslint . --ext .ts",
         "start": "node --enable-source-maps ./dist/start.cjs",
         "test:ci:with-entitlements": "vitest run --config ./vitest.config.entitlements.ts --silent",

--- a/packages/stress/src/demo.ts
+++ b/packages/stress/src/demo.ts
@@ -2,20 +2,11 @@ import 'fake-indexeddb/auto' // used to mock indexdb in dexie, don't remove
 import {
     isDecryptedEvent,
     makeRiverConfig,
-    makeSignerContext,
     makeStreamRpcClient,
-    NotificationService,
     randomUrlSelector,
 } from '@towns-protocol/sdk'
 import { check } from '@towns-protocol/dlog'
-import {
-    DmChannelSettingValue,
-    GdmChannelSettingValue,
-    InfoRequestSchema,
-    GetSettingsRequestSchema,
-    GetSettingsResponseSchema,
-    SetDmGdmSettingsRequestSchema,
-} from '@towns-protocol/proto'
+import { InfoRequestSchema } from '@towns-protocol/proto'
 import { EncryptionDelegate } from '@towns-protocol/encryption'
 import { makeStressClient } from './utils/stressClient'
 import { expect, isSet } from './utils/expect'
@@ -25,7 +16,7 @@ import { ethers, Wallet } from 'ethers'
 import { RedisStorage } from './utils/storage'
 import { createRiverRegistry } from '@towns-protocol/web3'
 import { getLogger } from './utils/logger'
-import { create, toJson } from '@bufbuild/protobuf'
+import { create } from '@bufbuild/protobuf'
 
 check(isSet(process.env.RIVER_ENV), 'process.env.RIVER_ENV')
 
@@ -149,41 +140,9 @@ async function demoExternalStoreage() {
     }
 }
 
-const registerNotificationService = async () => {
-    // demo connecting to the notification service
-    const notificationServiceUrl = 'https://river-notification-service-alpha.towns.com/' // ?? 'http://localhost:4040
-    if (!notificationServiceUrl) {
-        logger.info('NOTIFICATION_SERVICE_URL is not set')
-        return
-    }
-
-    const wallet = ethers.Wallet.createRandom()
-    const delegateWallet = ethers.Wallet.createRandom()
-    const signerContext = await makeSignerContext(wallet, delegateWallet, { days: 1 })
-
-    const { startResponse, finishResponse, notificationRpcClient } =
-        await NotificationService.authenticate(signerContext, notificationServiceUrl)
-    logger.info({ startResponse, finishResponse }, 'authenticated')
-
-    let settings = await notificationRpcClient.getSettings(create(GetSettingsRequestSchema, {}))
-    logger.info(toJson(GetSettingsResponseSchema, settings), 'settings')
-
-    const response = await notificationRpcClient.setDmGdmSettings(
-        create(SetDmGdmSettingsRequestSchema, {
-            dmGlobal: DmChannelSettingValue.DM_MESSAGES_NO,
-            gdmGlobal: GdmChannelSettingValue.GDM_MESSAGES_NO,
-        }),
-    )
-    logger.info(response, 'set settings response')
-    settings = await notificationRpcClient.getSettings(create(GetSettingsRequestSchema, {}))
-    logger.info(toJson(GetSettingsResponseSchema, settings), 'new settings')
-}
-
 logger.info(getSystemInfo(), 'system info')
 
 const run = async () => {
-    logger.debug('========================registerNotificationService========================')
-    await registerNotificationService()
     logger.debug('========================storage========================')
     await demoExternalStoreage()
     logger.debug('==========================spamInfo==========================')

--- a/packages/stress/src/notifications.ts
+++ b/packages/stress/src/notifications.ts
@@ -1,0 +1,61 @@
+import 'fake-indexeddb/auto' // used to mock indexdb in dexie, don't remove
+import { makeRiverConfig, makeSignerContext, NotificationService } from '@towns-protocol/sdk'
+import { check } from '@towns-protocol/dlog'
+import {
+    DmChannelSettingValue,
+    GdmChannelSettingValue,
+    GetSettingsRequestSchema,
+    GetSettingsResponseSchema,
+    SetDmGdmSettingsRequestSchema,
+} from '@towns-protocol/proto'
+import { isSet } from './utils/expect'
+import { ethers } from 'ethers'
+import { getLogger } from './utils/logger'
+import { create, toJson } from '@bufbuild/protobuf'
+
+check(isSet(process.env.RIVER_ENV), 'process.env.RIVER_ENV')
+
+const logger = getLogger('stress:index')
+const config = makeRiverConfig(process.env.RIVER_ENV)
+logger.info(config, 'config')
+
+const registerNotificationService = async () => {
+    // demo connecting to the notification service
+    const notificationServiceUrl = 'https://river-notification-service-alpha.towns.com/' // ?? 'http://localhost:4040
+    if (!notificationServiceUrl) {
+        logger.info('NOTIFICATION_SERVICE_URL is not set')
+        return
+    }
+
+    const wallet = ethers.Wallet.createRandom()
+    const delegateWallet = ethers.Wallet.createRandom()
+    const signerContext = await makeSignerContext(wallet, delegateWallet, { days: 1 })
+
+    const { startResponse, finishResponse, notificationRpcClient } =
+        await NotificationService.authenticate(signerContext, notificationServiceUrl)
+    logger.info({ startResponse, finishResponse }, 'authenticated')
+
+    let settings = await notificationRpcClient.getSettings(create(GetSettingsRequestSchema, {}))
+    logger.info(toJson(GetSettingsResponseSchema, settings), 'settings')
+
+    const response = await notificationRpcClient.setDmGdmSettings(
+        create(SetDmGdmSettingsRequestSchema, {
+            dmGlobal: DmChannelSettingValue.DM_MESSAGES_NO,
+            gdmGlobal: GdmChannelSettingValue.GDM_MESSAGES_NO,
+        }),
+    )
+    logger.info(response, 'set settings response')
+    settings = await notificationRpcClient.getSettings(create(GetSettingsRequestSchema, {}))
+    logger.info(toJson(GetSettingsResponseSchema, settings), 'new settings')
+}
+
+const run = async () => {
+    logger.debug('========================registerNotificationService========================')
+    await registerNotificationService()
+    process.exit(0)
+}
+
+run().catch((e) => {
+    logger.error(e, 'unhandled error:')
+    process.exit(1)
+})


### PR DESCRIPTION
This was testing code that lasted for about 6 months without issue.
If we run ci while the notification service is deploying this will fail.