### PR TITLE
[BUGFIX] Switch app registry service to reading session id from the session_id_bytes field of channel messages

### DIFF
--- a/core/node/app_registry/event_processor.go
+++ b/core/node/app_registry/event_processor.go
@@ -56,7 +56,10 @@ func (p *MessageToAppProcessor) OnMessageEvent(
 	message := event.GetEncryptedMessage()
 	// Ignore membership changes, etc, and focus only on channel content.
 	if message != nil {
-		if err := p.cache.DispatchOrEnqueueMessages(ctx, appIds, hex.EncodeToString(message.SessionIdBytes), channelId, streamEnvelope); err != nil {
+		// Session ids are stored in key solicitations and responses as encoded hex strings, but are sent
+		// as raw bytes in channel messages. Here, we encode and store as a hex string for convenience.
+		encodedSessionId := hex.EncodeToString(message.SessionIdBytes)
+		if err := p.cache.DispatchOrEnqueueMessages(ctx, appIds, encodedSessionId, channelId, streamEnvelope); err != nil {
 			log.Errorw(
 				"Error enqueueing messages for stream event",
 				"event",

--- a/core/node/app_registry/event_processor.go
+++ b/core/node/app_registry/event_processor.go
@@ -2,6 +2,7 @@ package app_registry
 
 import (
 	"context"
+	"encoding/hex"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,7 +56,7 @@ func (p *MessageToAppProcessor) OnMessageEvent(
 	message := event.GetEncryptedMessage()
 	// Ignore membership changes, etc, and focus only on channel content.
 	if message != nil {
-		if err := p.cache.DispatchOrEnqueueMessages(ctx, appIds, message.SessionId, channelId, streamEnvelope); err != nil {
+		if err := p.cache.DispatchOrEnqueueMessages(ctx, appIds, hex.EncodeToString(message.SessionIdBytes), channelId, streamEnvelope); err != nil {
 			log.Errorw(
 				"Error enqueueing messages for stream event",
 				"event",

--- a/core/node/app_registry/testutil.go
+++ b/core/node/app_registry/testutil.go
@@ -15,6 +15,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang-jwt/jwt/v4"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/towns-protocol/towns/core/node/app_registry/app_client"
@@ -42,6 +43,7 @@ type TestAppServer struct {
 	encryptionDevice app_client.EncryptionDevice
 	client           protocolconnect.StreamServiceClient
 	frameworkVersion int32
+	enableLogging    bool
 }
 
 // validateSignature verifies that the incoming request has a HS256-encoded jwt auth token stored
@@ -94,15 +96,17 @@ func NewTestAppServer(
 	t *testing.T,
 	appWallet *crypto.Wallet,
 	client protocolconnect.StreamServiceClient,
+	enableLogging bool,
 ) *TestAppServer {
 	listener, url := testcert.MakeTestListener(t)
 
 	b := &TestAppServer{
-		t:         t,
-		listener:  listener,
-		url:       url,
-		appWallet: appWallet,
-		client:    client,
+		t:             t,
+		listener:      listener,
+		url:           url,
+		appWallet:     appWallet,
+		client:        client,
+		enableLogging: enableLogging,
 	}
 
 	return b
@@ -135,6 +139,7 @@ func (b *TestAppServer) Close() {
 
 func (b *TestAppServer) solicitKeys(ctx context.Context, data *protocol.EventPayload_SolicitKeys) error {
 	log := logging.FromCtx(ctx).With("func", "TestAppServer.solicitKeys")
+
 	streamId, err := shared.StreamIdFromBytes(data.StreamId)
 	if err != nil {
 		return logAndReturnErr(log, fmt.Errorf("failed to parse stream for key solicitation: %w", err))
@@ -231,8 +236,8 @@ func (b *TestAppServer) respondToSendMessages(
 	data *protocol.EventPayload_Messages,
 ) error {
 	log := logging.FromCtx(ctx)
-	// Swap with above to enable debug logs
-	// log := logging.DefaultZapLogger(zapcore.DebugLevel)
+	// Swap with above to enable debug logs for this method only
+	// log := logging.DefaultLogger(zapcore.DebugLevel)
 	log.Debugw(
 		"respondToSendMessages",
 		"numMessages",
@@ -276,13 +281,13 @@ func (b *TestAppServer) respondToSendMessages(
 			continue
 		}
 
-		sessions, ok := sessionIdToEncryptionMaterial[message.Message.SessionId]
+		sessions, ok := sessionIdToEncryptionMaterial[hex.EncodeToString(message.Message.GetSessionIdBytes())]
 		if !ok {
 			return logAndReturnErr(
 				log,
 				fmt.Errorf(
 					"did not find sessionId %v in group encryption sessions for sent messages",
-					message.Message.SessionId,
+					hex.EncodeToString(message.Message.SessionIdBytes),
 				),
 			)
 		}
@@ -303,8 +308,10 @@ func (b *TestAppServer) respondToSendMessages(
 			"respondToSendMessages message details",
 			"m.m.SenderKey",
 			message.Message.SenderKey,
-			"m.m.SessionId",
-			message.Message.SessionId,
+			"m.m.SessionIdBytes",
+			message.Message.SessionIdBytes,
+			"m.m.SessionIdBytes (encoded)",
+			hex.EncodeToString(message.Message.SessionIdBytes),
 			"m.m.Ciphertext",
 			message.Message.Ciphertext,
 		)
@@ -326,14 +333,14 @@ func (b *TestAppServer) respondToSendMessages(
 
 		envelope, err := events.MakeEnvelopeWithPayload(
 			b.appWallet,
-			events.Make_ChannelPayload_Message_WithSession(
+			events.Make_ChannelPayload_Message_WithSessionBytes(
 				fmt.Sprintf(
 					"%v %v reply (%v)",
-					message.Message.SessionId,
+					hex.EncodeToString(message.Message.SessionIdBytes),
 					message.Message.Ciphertext,
 					sessions.Ciphertexts[b.encryptionDevice.DeviceKey],
 				),
-				message.Message.SessionId,
+				message.Message.SessionIdBytes,
 			),
 			&shared.MiniblockRef{
 				Hash: common.Hash(resp.Msg.Hash),
@@ -365,9 +372,12 @@ func (b *TestAppServer) respondToSendMessages(
 
 func (b *TestAppServer) rootHandler(w http.ResponseWriter, r *http.Request) {
 	// Ensure that the request method is POST.
-	// Uncomment to unconditionally enable logging
-	// log := logging.DefaultZapLogger(zapcore.DebugLevel)
-	log := logging.FromCtx(r.Context())
+	var log *logging.Log
+	if b.enableLogging {
+		log = logging.DefaultLogger(zapcore.DebugLevel)
+	} else {
+		log = logging.FromCtx(r.Context())
+	}
 	ctx := logging.CtxWithLog(r.Context(), log)
 	if r.Method != http.MethodPost {
 		log.Errorw("method not allowed", "method", r.Method)
@@ -426,7 +436,7 @@ func (b *TestAppServer) rootHandler(w http.ResponseWriter, r *http.Request) {
 
 				case *protocol.EventPayload_Solicitation:
 					log.Infow("request includes solicitation", "sessionIds", event.GetSolicitation().SessionIds, "streamId", event.GetSolicitation().StreamId)
-					if err := b.solicitKeys(logging.CtxWithLog(r.Context(), log), event.GetSolicitation()); err != nil {
+					if err := b.solicitKeys(ctx, event.GetSolicitation()); err != nil {
 						log.Errorw("solicit keys request failed", "error", err, "data", data)
 						http.Error(w, fmt.Sprintf("TestAppServer unable to solicit keys: %v", err), http.StatusBadRequest)
 						return

--- a/core/node/events/events.go
+++ b/core/node/events/events.go
@@ -342,13 +342,13 @@ func Make_ChannelPayload_Message(content string) *StreamEvent_ChannelPayload {
 	}
 }
 
-func Make_ChannelPayload_Message_WithSession(content string, sessionId string) *StreamEvent_ChannelPayload {
+func Make_ChannelPayload_Message_WithSessionBytes(content string, sessionIdBytes []byte) *StreamEvent_ChannelPayload {
 	return &StreamEvent_ChannelPayload{
 		ChannelPayload: &ChannelPayload{
 			Content: &ChannelPayload_Message{
 				Message: &EncryptedData{
-					Ciphertext: content,
-					SessionId:  sessionId,
+					Ciphertext:     content,
+					SessionIdBytes: sessionIdBytes,
 				},
 			},
 		},

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -422,7 +422,7 @@ func TestAppRegistry_ForwardsChannelEvents(t *testing.T) {
 		})
 		assert.NoError(c, err)
 		assert.True(c, findMessageReply(c, res.Msg.Stream, testMessageText, testSession, testCiphertexts))
-	}, 1*time.Second, 100*time.Millisecond, "App server did not respond to the participant sending keys")
+	}, 10*time.Second, 100*time.Millisecond, "App server did not respond to the participant sending keys")
 }
 
 // invalidAddressBytes is a slice of bytes that cannot be parsed into an address, because


### PR DESCRIPTION
The session_id field is actually deprecated and I just missed that from the doc reading. I believe this should fix the issue and make the service compatible with the client.