### PR TITLE
chore: reorder CODEOWNERS entries for correct ownership mapping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,6 @@
 /.github/CODEOWNERS @sergekh2 @texuf
 /.vscode/ @texuf
 /assets/ @texuf
-/packages/contracts/ @pfives @giuseppecrj @jterzis @shuhuiluo
 /core/ @sergekh2
 /core/node/ @sergekh2 @bas-vk
 /core/node/events/ @sergekh2 @texuf
@@ -43,6 +42,7 @@
 /core/xchain/ @sergekh2 @bas-vk @clemire
 /infra/ @mechanical-turk
 /packages/ @sergekh2 @texuf
+/packages/contracts/ @pfives @giuseppecrj @jterzis @shuhuiluo
 /packages/generated/ @sergekh2 @giuseppecrj
 /packages/generated/addresses/ @sergekh2 @texuf @giuseppecrj
 /packages/generated/deployments/ @sergekh2 @texuf @giuseppecrj


### PR DESCRIPTION
Moved `/packages/contracts/` entry to prevent unintended overrides. This ensures proper ownership assignments in the CODEOWNERS file.