### PR TITLE
Update start_dev script to work with contracts under packages.

### DIFF
--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -75,7 +75,7 @@ tmux send-keys -t $SESSION_NAME:'BlockChains_river' "./scripts/start-local-river
 
 
 # Start contract build in background
-pushd contracts
+pushd packages/contracts
 set -a
 . .env.localhost
 set +a


### PR DESCRIPTION
The start_dev script broke after contracts were moved. Here is a one-line change that repairs local dev.