### PR TITLE
web3: Optimize Banned Wallet Checks with Caching and Multicall

### DIFF
--- a/packages/sdk/src/tests/multi/entitlements/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/channelsWithEntitlements.test.ts
@@ -53,6 +53,27 @@ describe('channelsWithEntitlements', () => {
             ),
         ).resolves.toBeFalsy()
 
+        // unban alice
+        const unbanTx = await bobSpaceDapp.unbanWalletAddress(
+            spaceId,
+            alicesWallet.address,
+            bobProvider.wallet,
+        )
+        await unbanTx.wait()
+
+        // Wait 5 seconds for the caches to expire
+        await new Promise((f) => setTimeout(f, 5000))
+
+        await expect(
+            aliceSpaceDapp.isEntitledToChannel(
+                spaceId,
+                channelId!,
+                alice.userId,
+                Permission.Read,
+                getXchainConfigForTesting(),
+            ),
+        ).resolves.toBeTruthy()
+
         const doneStart = Date.now()
         // kill the clients
         await bob.stopSync()

--- a/packages/sdk/src/tests/multi/entitlements/spaceWithEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/spaceWithEntitlements.test.ts
@@ -64,6 +64,25 @@ describe('spaceWithEntitlements', () => {
         )
         expect(entitledWallet).toBeUndefined()
 
+        // unban alice
+        const unbanTx = await bobSpaceDapp.unbanWalletAddress(
+            spaceId,
+            alicesWallet.address,
+            bobProvider.wallet,
+        )
+        await unbanTx.wait()
+
+        // Wait 5 seconds for the caches to expire
+        await new Promise((f) => setTimeout(f, 5000))
+
+        // Alice is entitled to join the space again
+        const entitledWallet2 = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
+            spaceId,
+            alicesWallet.address,
+            getXchainConfigForTesting(),
+        )
+        expect(entitledWallet2).toBeDefined()
+
         const doneStart = Date.now()
         // kill the clients
         await bob.stopSync()

--- a/packages/web3/src/EntitlementCache.test.ts
+++ b/packages/web3/src/EntitlementCache.test.ts
@@ -2,7 +2,9 @@
  * @group main
  */
 
-import { EntitlementCache, Keyable, CacheResult } from './EntitlementCache'
+import { Keyable } from 'Keyable'
+import { EntitlementCache, CacheResult } from './EntitlementCache'
+
 
 class Key implements Keyable {
     private readonly key: string

--- a/packages/web3/src/EntitlementCache.test.ts
+++ b/packages/web3/src/EntitlementCache.test.ts
@@ -2,7 +2,7 @@
  * @group main
  */
 
-import { Keyable } from 'Keyable'
+import { Keyable } from './Keyable'
 import { EntitlementCache, CacheResult } from './EntitlementCache'
 
 class Key implements Keyable {

--- a/packages/web3/src/EntitlementCache.test.ts
+++ b/packages/web3/src/EntitlementCache.test.ts
@@ -5,7 +5,6 @@
 import { Keyable } from 'Keyable'
 import { EntitlementCache, CacheResult } from './EntitlementCache'
 
-
 class Key implements Keyable {
     private readonly key: string
     toKey(): string {

--- a/packages/web3/src/EntitlementCache.ts
+++ b/packages/web3/src/EntitlementCache.ts
@@ -1,9 +1,5 @@
 import TTLCache from '@isaacs/ttlcache'
 
-export interface Keyable {
-    toKey(): string
-}
-
 export interface CacheResult<V> {
     value: V
     cacheHit: boolean

--- a/packages/web3/src/EntitlementCache.ts
+++ b/packages/web3/src/EntitlementCache.ts
@@ -1,4 +1,5 @@
 import TTLCache from '@isaacs/ttlcache'
+import { Keyable } from './Keyable'
 
 export interface CacheResult<V> {
     value: V

--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -374,4 +374,5 @@ export interface ISpaceDapp {
         receipt: ContractReceipt,
         senderAddress: string,
     ) => TipEventObject | undefined
+    updateCacheAfterBanOrUnBan: (spaceId: string, tokenId: ethers.BigNumber) => void
 }

--- a/packages/web3/src/Keyable.ts
+++ b/packages/web3/src/Keyable.ts
@@ -1,4 +1,4 @@
-import { Permission } from 'ContractTypes'
+import { Permission } from './ContractTypes'
 import { ethers } from 'ethers'
 export interface Keyable {
     toKey(): string

--- a/packages/web3/src/Keyable.ts
+++ b/packages/web3/src/Keyable.ts
@@ -1,0 +1,43 @@
+import { Permission } from 'ContractTypes'
+import { ethers } from 'ethers'
+export interface Keyable {
+    toKey(): string
+}
+
+export class BannedTokenIdsRequest implements Keyable {
+    spaceId: string
+    constructor(spaceId: string) {
+        this.spaceId = spaceId
+    }
+    toKey(): string {
+        return `bannedTokenIds:${this.spaceId}`
+    }
+}
+
+export class OwnerOfTokenRequest implements Keyable {
+    spaceId: string
+    tokenId: ethers.BigNumber
+    constructor(spaceId: string, tokenId: ethers.BigNumber) {
+        this.spaceId = spaceId
+        this.tokenId = tokenId
+    }
+    toKey(): string {
+        return `ownerOfToken:${this.spaceId}:${this.tokenId.toString()}`
+    }
+}
+
+export class EntitlementRequest implements Keyable {
+    spaceId: string
+    channelId: string
+    userId: string
+    permission: Permission
+    constructor(spaceId: string, channelId: string, userId: string, permission: Permission) {
+        this.spaceId = spaceId
+        this.channelId = channelId
+        this.userId = userId
+        this.permission = permission
+    }
+    toKey(): string {
+        return `{spaceId:${this.spaceId},channelId:${this.channelId},userId:${this.userId},permission:${this.permission}}`
+    }
+}

--- a/packages/web3/src/Keyable.ts
+++ b/packages/web3/src/Keyable.ts
@@ -26,6 +26,18 @@ export class OwnerOfTokenRequest implements Keyable {
     }
 }
 
+export class IsTokenBanned implements Keyable {
+    spaceId: string
+    tokenId: ethers.BigNumber
+    constructor(spaceId: string, tokenId: ethers.BigNumber) {
+        this.spaceId = spaceId
+        this.tokenId = tokenId
+    }
+    toKey(): string {
+        return `isBanned:${this.spaceId}:${this.tokenId.toString()}`
+    }
+}
+
 export class EntitlementRequest implements Keyable {
     spaceId: string
     channelId: string

--- a/packages/web3/src/SimpleCache.test.ts
+++ b/packages/web3/src/SimpleCache.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @group main
+ */
+
+import { SimpleCache } from './SimpleCache'
+import { Keyable } from './Keyable'
+
+class TestKey implements Keyable {
+    private readonly key: string
+    toKey(): string {
+        return this.key
+    }
+    constructor(key: string) {
+        this.key = key
+    }
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('SimpleCacheTests', () => {
+    it('should cache and retrieve values', async () => {
+        const cache = new SimpleCache<TestKey, string>()
+        let fetchCount = 0
+        const fetchFn = async (_key: TestKey): Promise<string> => {
+            fetchCount++
+            return 'test-value'
+        }
+
+        const key = new TestKey('key1')
+
+        // First call: should fetch
+        const value1 = await cache.executeUsingCache(key, fetchFn)
+        expect(value1).toBe('test-value')
+        expect(fetchCount).toBe(1)
+
+        // Second call: should hit cache
+        const value2 = await cache.executeUsingCache(key, fetchFn)
+        expect(value2).toBe('test-value')
+        expect(fetchCount).toBe(1) // Fetch count should not increase
+
+        // Direct get: should hit cache
+        const value3 = cache.get(key)
+        expect(value3).toBe('test-value')
+    })
+
+    it('should expire values after TTL', async () => {
+        const ttlSeconds = 1
+        const cache = new SimpleCache<TestKey, number>({ ttlSeconds })
+        let fetchCount = 0
+        const fetchFn = async (_key: TestKey): Promise<number> => {
+            fetchCount++
+            return Date.now()
+        }
+
+        const key = new TestKey('key-ttl')
+
+        // First call: should fetch
+        const value1 = await cache.executeUsingCache(key, fetchFn)
+        expect(fetchCount).toBe(1)
+
+        // Immediate get: should hit cache
+        const value2 = cache.get(key)
+        expect(value2).toBe(value1)
+
+        // Wait for TTL to expire (plus a buffer)
+        await wait(ttlSeconds * 1000 + 500)
+
+        // Get after expiration: should be undefined
+        const value3 = cache.get(key)
+        expect(value3).toBeUndefined()
+
+        // Execute after expiration: should fetch again
+        const value4 = await cache.executeUsingCache(key, fetchFn)
+        expect(fetchCount).toBe(2)
+        expect(value4).not.toBe(value1) // Should be a new timestamp
+    })
+
+    it('should not expire values without TTL', async () => {
+        const cache = new SimpleCache<TestKey, number>() // No TTL
+        let fetchCount = 0
+        const fetchFn = async (_key: TestKey): Promise<number> => {
+            fetchCount++
+            return 123
+        }
+
+        const key = new TestKey('key-no-ttl')
+
+        // First call: should fetch
+        const value1 = await cache.executeUsingCache(key, fetchFn)
+        expect(value1).toBe(123)
+        expect(fetchCount).toBe(1)
+
+        await wait(1000)
+
+        // Get after waiting: should still be cached
+        const value2 = cache.get(key)
+        expect(value2).toBe(123)
+
+        // Execute after waiting: should hit cache
+        const value3 = await cache.executeUsingCache(key, fetchFn)
+        expect(value3).toBe(123)
+        expect(fetchCount).toBe(1) // Fetch count should not increase
+    })
+
+    it('should remove values using remove()', async () => {
+        const cache = new SimpleCache<TestKey, string>()
+        const key = new TestKey('key-remove')
+        const value = 'value-to-remove'
+
+        // Add value directly
+        cache.add(key, value)
+
+        // Verify it's cached
+        expect(cache.get(key)).toBe(value)
+
+        // Remove the value
+        cache.remove(key)
+
+        // Verify it's removed
+        expect(cache.get(key)).toBeUndefined()
+
+        // Test remove via executeUsingCache
+        let fetchCount = 0
+        const fetchFn = async (_key: TestKey): Promise<string> => {
+            fetchCount++
+            return 'fetched-after-remove'
+        }
+        await cache.executeUsingCache(key, fetchFn) // Add it back via execute
+        expect(cache.get(key)).toBe('fetched-after-remove')
+        expect(fetchCount).toBe(1)
+
+        cache.remove(key)
+        expect(cache.get(key)).toBeUndefined()
+
+        // Execute again, should fetch
+        await cache.executeUsingCache(key, fetchFn)
+        expect(fetchCount).toBe(2)
+        expect(cache.get(key)).toBe('fetched-after-remove')
+    })
+
+    it('should clear all values using clear()', async () => {
+        const cache = new SimpleCache<TestKey, number>()
+        const key1 = new TestKey('key-clear-1')
+        const key2 = new TestKey('key-clear-2')
+
+        cache.add(key1, 1)
+        cache.add(key2, 2)
+
+        // Verify items are cached
+        expect(cache.get(key1)).toBe(1)
+        expect(cache.get(key2)).toBe(2)
+
+        // Clear the cache
+        cache.clear()
+
+        // Verify items are removed
+        expect(cache.get(key1)).toBeUndefined()
+        expect(cache.get(key2)).toBeUndefined()
+    })
+})

--- a/packages/web3/src/SimpleCache.ts
+++ b/packages/web3/src/SimpleCache.ts
@@ -1,0 +1,74 @@
+import TTLCache from '@isaacs/ttlcache'
+import { Keyable } from './Keyable'
+
+export class SimpleCache<K extends Keyable, V> {
+    private cache: TTLCache<string, V>
+    private pendingFetches: Map<string, Promise<V>> = new Map()
+
+    /**
+     * @param ttlSeconds Optional time-to-live for cache entries in seconds. If not provided, cache entries do not expire.
+     * @param maxSize Optional maximum number of entries in the cache.
+     */
+    constructor(args: { ttlSeconds?: number; maxSize?: number } = {}) {
+        const ttlSeconds = args.ttlSeconds !== undefined ? args.ttlSeconds * 1000 : Infinity
+        const maxSize = args.maxSize ?? 10_000
+        this.cache = new TTLCache({
+            ttl: ttlSeconds,
+            max: maxSize,
+        })
+    }
+
+    get(key: K): V | undefined {
+        return this.cache.get(key.toKey())
+    }
+
+    add(key: K, value: V): void {
+        this.cache.set(key.toKey(), value)
+    }
+
+    remove(key: K): void {
+        this.cache.delete(key.toKey())
+    }
+
+    clear(): void {
+        this.cache.clear()
+    }
+
+    /**
+     * Executes a function to fetch a value if it's not in the cache,
+     * stores the result, and returns it.
+     */
+    async executeUsingCache(key: K, fetchFn: (key: K) => Promise<V>): Promise<V> {
+        const cacheKey = key.toKey()
+
+        // 1. Check main cache
+        const cachedValue = this.cache.get(cacheKey)
+        if (cachedValue !== undefined) {
+            return cachedValue
+        }
+
+        // 2. Check for pending fetch
+        const pendingPromise = this.pendingFetches.get(cacheKey)
+        if (pendingPromise) {
+            return pendingPromise // Return existing promise
+        }
+
+        // 3. No cached value, no pending fetch: Initiate fetch
+        const fetchPromise = fetchFn(key).catch((err) => {
+            this.pendingFetches.delete(cacheKey)
+            throw err
+        })
+
+        this.pendingFetches.set(cacheKey, fetchPromise)
+
+        try {
+            const fetchedValue = await fetchPromise
+            // Add to main cache only on successful fetch
+            this.cache.set(cacheKey, fetchedValue)
+            return fetchedValue
+        } finally {
+            // Remove from pending fetches regardless of success or failure
+            this.pendingFetches.delete(cacheKey)
+        }
+    }
+}


### PR DESCRIPTION
This PR significantly optimizes the performance of checking and retrieving banned wallet information in `SpaceDapp` by introducing caching and utilizing multicall.

Before this PR, loading AX1 would result in ~1300 rpc calls related to banned wallets. Now, dependent on the user and their linked wallets, it will make a maximum of 10 calls.

Can probably further clean up banning/tokenId logic across this package and consumers in harmony, but this is enough for now imo.

**Key Changes:**

*   **Added Caching:** Implemented `SimpleCache` for:
    *   `bannedTokenIds`: Caches the list of banned token IDs for a space.
    *   `ownerOfToken`: Caches the owner address for a specific token ID.
    *   `isBannedToken`: Caches the banned status of a specific token ID.
*   **Optimized `bannedWalletAddresses`:**
    *   Refactored to first check caches (`bannedTokenIdsCache`, `ownerOfTokenCache`).
    *   Uses `multicall` to efficiently fetch owners for any uncached banned token IDs.
    *   Updates the `ownerOfTokenCache` after fetching.
*   **Optimized `walletAddressIsBanned`:**
    *   Now uses `isBannedTokenCache` for faster lookups.
*   **Cache Invalidation:**
    *   Added `updateCacheAfterBanOrUnBan` helper method.
    *   `banWalletAddress` and `unbanWalletAddress` now call this helper to clear relevant cache entries after performing the action.
*   **Optimized Entitlement Checks:**
    *   `getEntitledWalletForJoiningSpaceUncached` and `isEntitledToChannelUncached` now use the cached `walletAddressIsBanned` check via `Promise.any` for faster checks on linked wallets, avoiding fetching the full banned list unnecessarily.
*   **Refactoring:**
    *   Moved cache key classes (`EntitlementRequest`, `BannedTokenIdsRequest`, `OwnerOfTokenRequest`, `IsTokenBanned`) to `Keyable.ts`.