### PR TITLE
Explicitly check for a nil envelope in parseEvent and return an error

### DIFF
--- a/core/node/events/parsed_event.go
+++ b/core/node/events/parsed_event.go
@@ -34,6 +34,9 @@ func (e *ParsedEvent) GetEnvelopeBytes() ([]byte, error) {
 }
 
 func ParseEvent(envelope *Envelope) (*ParsedEvent, error) {
+	if envelope == nil {
+		return nil, RiverError(Err_BAD_EVENT, "Nil envelope provided").Func("ParseEvent")
+	}
 	hash := TownsHashForEvents.Hash(envelope.Event)
 	if !bytes.Equal(hash[:], envelope.Hash) {
 		return nil, RiverError(Err_BAD_EVENT_HASH, "Bad hash provided", "computed", hash, "got", envelope.Hash)

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -44,7 +44,11 @@ func MakeStreamView(streamData *storage.ReadStreamFromLastSnapshotResult) (*Stre
 			Snapshot: mb.Snapshot,
 		})
 		if err != nil {
-			return nil, err
+			return nil, AsRiverError(
+				err,
+				Err_BAD_BLOCK,
+			).Message("Unable to parse miniblock from descriptor").
+				Func("MakeStreamView")
 		}
 		miniblocks[i] = miniblock
 		lastMiniblockNumber = miniblock.Header().MiniblockNum


### PR DESCRIPTION
This error should bubble up and log from the sync_stream_task when it's parsing stream miniblocks that are behind on startup, and we should be able to use this information to capture the stream id of the stream that was causing reconciliation to panic with a nil pointer exception because of a badly formatted miniblock.