### PR TITLE
Place streams on a new set of nodes

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -198,7 +198,6 @@ $ ./env/alpha/run.sh stream place status /tmp/streams.not_migrated.initiated
 $ cat /tmp/streams.not_migrated.initiated.status
 {"stream_id":"20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","Nodes":{"0x4dc8baa00e26c4a15549321375f6173ad281b60a":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x4dC8bAa00E26c4A15549321375f6173aD281b60A\n    nodeUrl = \n    handler = GetStream\n    elapsed = 186.078µs\n    streamId = 20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x7cf83341f5b41345e23df4074c307b7642db9556":{"status":"success","minipool_gen":4},"0xa0be273b3660171e24b315e0d95ef328e49d2860":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0xA0BE273b3660171E24b315e0d95ef328E49D2860\n    nodeUrl = \n    handler = GetStream\n    elapsed = 68.767µs\n    streamId = 20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"}}}
 {"stream_id":"10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","Nodes":{"0x49ea67dc4b5bb19624f0fd1843a7242f2df35cb2":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x49EA67dC4B5bB19624f0Fd1843a7242F2DF35cb2\n    nodeUrl = \n    handler = GetStream\n    elapsed = 61.718µs\n    streamId = 10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x4dc8baa00e26c4a15549321375f6173ad281b60a":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x4dC8bAa00E26c4A15549321375f6173aD281b60A\n    nodeUrl = \n    handler = GetStream\n    elapsed = 55.995µs\n    streamId = 10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x8d57ffc1a7ae49f845935756f54090465fca44bd":{"status":"success","minipool_gen":232}}}
-
 ```
 
 If enough nodes have synced the stream into their local storage and are ready to join the streams quorum use
@@ -206,6 +205,6 @@ the `finilize` subcommand. This will set the stream replication factor in the st
 length. This is the signal for streams that all nodes in the node list will start participating in quorum.
 
 ```sh
-$ ./env/delta/run.sh stream place finilize /tmp/non_replicated_streams_1.txt
+$ ./env/delta/run.sh stream place enter-quorum <wallet-file> /tmp/streams.not_migrated.initiated.status
 ```
 

--- a/core/README.md
+++ b/core/README.md
@@ -155,3 +155,57 @@ Clean build artifacts and rebuild:
 
     yarn csb:clean
     yarn csb:build
+
+# Migrate stream from non-repl to replicated stream
+
+Obtain a list of streams that have not been migrated and migration hasn't started. The `not-migrated`
+command accepts an optional count that limits the number of streams written to file allowing migration
+batches. In the example only 2 streams are migrated.
+
+**_NOTE:_** all steps assume that the streams replication factor and node list haven't been altered in
+between steps.
+
+```sh
+$ ./env/alpha/run.sh stream not-migrated /tmp/streams.not_migrated 2
+
+$ cat /tmp/streams.not_migrated
+{"stream_id":"10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","replication_factor":1,"status":"not_migrated","node_addresses":["0x8d57ffc1a7ae49f845935756f54090465fca44bd"]}
+{"stream_id":"20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","replication_factor":1,"status":"not_migrated","node_addresses":["0x7cf83341f5b41345e23df4074c307b7642db9556"]}
+```
+
+The next step is to place the stream on multiple nodes. This is done by specifying the file with streams id's
+generated in the previous step and providing the replication factor. If the streams node list already contains
+the given replication factor the command panics before making any alterations. If the node list length equals
+the given replication factor nothing is done for the stream. If the replication factor is smaller than the streams
+node list random nodes from different operators are selected and added to the nodes list.
+
+```sh
+$ ./env/alpha/run.sh stream place initiate <full-path-to-wallet-file> /tmp/streams.not_migrated 3
+
+$ cat /tmp/streams.not_migrated.initiated
+{"stream_id":"10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","status":"success","tx_hash":"0xc95af321282dd268221b4ae843d414482ce7dd57e1ebc4311427c0c83516091f","node_addresses":["0x8d57ffc1a7ae49f845935756f54090465fca44bd","0x4dc8baa00e26c4a15549321375f6173ad281b60a","0x49ea67dc4b5bb19624f0fd1843a7242f2df35cb2"]}
+{"stream_id":"20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","status":"success","tx_hash":"0xc95af321282dd268221b4ae843d414482ce7dd57e1ebc4311427c0c83516091f","node_addresses":["0x7cf83341f5b41345e23df4074c307b7642db9556","0xa0be273b3660171e24b315e0d95ef328e49d2860","0x4dc8baa00e26c4a15549321375f6173ad281b60a"]}
+```
+This will set the replication factor for all streams in `/tmp/streams.not_migrated` to 1 in the streams registry
+and ensures that the node list contains 3 nodes. This is an indication for the nodes that are added to the streams
+node list to sync the stream into their local state in anticipation of participating in the streams quorum.
+
+To get an overview how far nodes have synced streams into their local state use the `status` subcommand.
+
+```sh
+$ ./env/alpha/run.sh stream place status /tmp/streams.not_migrated.initiated
+
+$ cat /tmp/streams.not_migrated.initiated.status
+{"stream_id":"20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","Nodes":{"0x4dc8baa00e26c4a15549321375f6173ad281b60a":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x4dC8bAa00E26c4A15549321375f6173aD281b60A\n    nodeUrl = \n    handler = GetStream\n    elapsed = 186.078µs\n    streamId = 20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x7cf83341f5b41345e23df4074c307b7642db9556":{"status":"success","minipool_gen":4},"0xa0be273b3660171e24b315e0d95ef328e49d2860":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0xA0BE273b3660171E24b315e0d95ef328E49D2860\n    nodeUrl = \n    handler = GetStream\n    elapsed = 68.767µs\n    streamId = 20958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"}}}
+{"stream_id":"10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000","Nodes":{"0x49ea67dc4b5bb19624f0fd1843a7242f2df35cb2":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x49EA67dC4B5bB19624f0Fd1843a7242F2DF35cb2\n    nodeUrl = \n    handler = GetStream\n    elapsed = 61.718µs\n    streamId = 10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x4dc8baa00e26c4a15549321375f6173ad281b60a":{"status":"failed","error":"unavailable: GetStream: (14:UNAVAILABLE) Forwarding disabled by request header\n    nodeAddress = 0x4dC8bAa00E26c4A15549321375f6173aD281b60A\n    nodeUrl = \n    handler = GetStream\n    elapsed = 55.995µs\n    streamId = 10958f1b91c1092792d1cbf172a4cb400b7d7215070000000000000000000000"},"0x8d57ffc1a7ae49f845935756f54090465fca44bd":{"status":"success","minipool_gen":232}}}
+
+```
+
+If enough nodes have synced the stream into their local storage and are ready to join the streams quorum use
+the `finilize` subcommand. This will set the stream replication factor in the streams registry to the nodes list
+length. This is the signal for streams that all nodes in the node list will start participating in quorum.
+
+```sh
+$ ./env/delta/run.sh stream place finilize /tmp/non_replicated_streams_1.txt
+```
+

--- a/core/cmd/registry_cmd.go
+++ b/core/cmd/registry_cmd.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	"github.com/towns-protocol/towns/core/node/registries"
+	"github.com/towns-protocol/towns/core/node/rpc"
 	. "github.com/towns-protocol/towns/core/node/shared"
 
 	"github.com/spf13/cobra"
@@ -118,12 +119,12 @@ func validateStream(
 	}
 
 	streamServiceClient := NewStreamServiceClient(httpClient, nodeRecord.Url, connect.WithGRPC())
-	response, err := streamServiceClient.GetStream(
-		ctx,
-		connect.NewRequest(&GetStreamRequest{
-			StreamId: streamId[:],
-		}),
-	)
+	req := connect.NewRequest(&GetStreamRequest{
+		StreamId: streamId[:],
+	})
+	req.Header().Set(rpc.RiverAllowNoQuorumHeader, rpc.RiverHeaderTrueValue)
+	req.Header().Set(rpc.RiverNoForwardHeader, rpc.RiverHeaderTrueValue)
+	response, err := streamServiceClient.GetStream(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/core/cmd/registry_cmd.go
+++ b/core/cmd/registry_cmd.go
@@ -236,6 +236,7 @@ func srStream(cfg *config.Config, streamId string, validate bool) error {
 
 	fmt.Printf("StreamId: %s\n", stream.StreamId().String())
 	fmt.Printf("Miniblock: %d %s\n", stream.LastMbNum(), stream.LastMbHash().Hex())
+	fmt.Printf("ReplFactor: %d\n", stream.ReplicationFactor())
 	fmt.Println("IsSealed: ", stream.IsSealed())
 	fmt.Println("Nodes:")
 	err = nil

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -692,7 +692,7 @@ type StreamNotMigrated struct {
 	NodeAddresses     []common.Address `json:"node_addresses"`
 }
 
-type StreamPlacementTxResult struct {
+type streamPlacementTxResult struct {
 	StreamID      shared.StreamId  `json:"stream_id"`
 	Status        string           `json:"status"`
 	TxHash        common.Hash      `json:"tx_hash"`
@@ -984,9 +984,9 @@ func runStreamPlaceInitiateCmd(cfg *config.Config, args []string) error {
 			return err
 		}
 
-		var results []*StreamPlacementTxResult
+		var results []*streamPlacementTxResult
 		for _, req := range requests {
-			results = append(results, &StreamPlacementTxResult{
+			results = append(results, &streamPlacementTxResult{
 				Status:        "pending",
 				StreamID:      req.StreamId,
 				NodeAddresses: req.Nodes,
@@ -1072,9 +1072,9 @@ func runStreamPlaceStatusCmd(cfg *config.Config, args []string) error {
 	defer inputFile.Close()
 
 	input := json.NewDecoder(inputFile)
-	var streamPlacementTxResults []*StreamPlacementTxResult
+	var streamPlacementTxResults []*streamPlacementTxResult
 	for {
-		var result StreamPlacementTxResult
+		var result streamPlacementTxResult
 		if err := input.Decode(&result); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -1087,7 +1087,7 @@ func runStreamPlaceStatusCmd(cfg *config.Config, args []string) error {
 	var (
 		wp        = workerpool.New(32)
 		results   = make(chan *streamSyncStatus, 32)
-		getStatus = func(stream *StreamPlacementTxResult) func() {
+		getStatus = func(stream *streamPlacementTxResult) func() {
 			return func() {
 				status := &streamSyncStatus{
 					StreamID: stream.StreamID,
@@ -1285,9 +1285,9 @@ func runStreamPlaceEnterQuorumCmd(cfg *config.Config, args []string) error {
 			return err
 		}
 
-		var results []*StreamPlacementTxResult
+		var results []*streamPlacementTxResult
 		for _, req := range requests {
-			results = append(results, &StreamPlacementTxResult{
+			results = append(results, &streamPlacementTxResult{
 				Status:        "pending",
 				StreamID:      req.StreamId,
 				NodeAddresses: req.Nodes,

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -4,24 +4,38 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"slices"
 	"strconv"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	eth_crypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/gammazero/workerpool"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/towns-protocol/towns/core/config"
+	"github.com/towns-protocol/towns/core/contracts/river"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	"github.com/towns-protocol/towns/core/node/events"
+	"github.com/towns-protocol/towns/core/node/http_client"
 	"github.com/towns-protocol/towns/core/node/infra"
 	"github.com/towns-protocol/towns/core/node/nodes"
 	"github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	"github.com/towns-protocol/towns/core/node/registries"
+	"github.com/towns-protocol/towns/core/node/rpc"
 	"github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/storage"
 )
@@ -671,6 +685,641 @@ func runStreamGetCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+type StreamNotMigrated struct {
+	StreamID          shared.StreamId  `json:"stream_id"`
+	ReplicationFactor uint8            `json:"replication_factor"`
+	Status            string           `json:"status"`
+	NodeAddresses     []common.Address `json:"node_addresses"`
+}
+
+type StreamPlacementTxResult struct {
+	StreamID      shared.StreamId  `json:"stream_id"`
+	Status        string           `json:"status"`
+	TxHash        common.Hash      `json:"tx_hash"`
+	NodeAddresses []common.Address `json:"node_addresses"`
+}
+
+type streamSyncNodeStatus struct {
+	Status      string `json:"status"`
+	MinipoolGen int64  `json:"minipool_gen,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+type streamSyncStatus struct {
+	StreamID shared.StreamId `json:"stream_id"`
+	Nodes    map[common.Address]streamSyncNodeStatus
+}
+
+func runStreamMigrationListCmd(cmd *cobra.Command, args []string) error {
+	limit := -1
+	if len(args) == 2 {
+		n, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			return err
+		}
+		limit = int(n)
+	}
+
+	outputFile, err := os.OpenFile(args[0], os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	output := json.NewEncoder(outputFile)
+
+	ctx := context.Background() // lint:ignore context.Background() is fine here
+
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cmdConfig.RiverChain,
+		nil,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cmdConfig.RegistryContract,
+		&cmdConfig.RiverRegistry,
+	)
+	if err != nil {
+		return err
+	}
+
+	dumped := 0
+	registryContract.ForAllStreams(ctx, blockchain.InitialBlockNum, func(streamWithID *river.StreamWithId) bool {
+		stream := streamWithID.Stream
+		if len(stream.Nodes) == 1 {
+			streamNotMigrated := &StreamNotMigrated{
+				StreamID:          streamWithID.Id,
+				ReplicationFactor: uint8(stream.StreamReplicationFactor()),
+				Status:            "not_migrated",
+				NodeAddresses:     stream.Nodes,
+			}
+
+			if err := output.Encode(streamNotMigrated); err != nil {
+				panic(err)
+			}
+
+			dumped++
+		}
+		return limit == -1 || dumped < limit
+	})
+
+	return nil
+}
+
+func runStreamPlaceInitiateCmd(cfg *config.Config, args []string) error {
+	walletFileContents, err := os.ReadFile(args[0])
+	if err != nil {
+		return err
+	}
+
+	key, err := keystore.DecryptKey(walletFileContents, "")
+	if err != nil {
+		return err
+	}
+
+	wallet := &crypto.Wallet{
+		PrivateKeyStruct: key.PrivateKey,
+		PrivateKey:       eth_crypto.FromECDSA(key.PrivateKey),
+		Address:          eth_crypto.PubkeyToAddress(key.PrivateKey.PublicKey),
+	}
+
+	n, err := strconv.ParseInt(args[2], 10, 8)
+	if err != nil {
+		return err
+	}
+	targetReplicationFactor := int(n)
+
+	if targetReplicationFactor == 0 || targetReplicationFactor > 5 {
+		return fmt.Errorf("invalid replication factor: %d", targetReplicationFactor)
+	}
+
+	ctx := context.Background() // lint:ignore context.Background() is fine here
+
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cmdConfig.RiverChain,
+		wallet,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	configCaller, err := river.NewRiverConfigV1Caller(cfg.RegistryContract.Address, blockchain.Client)
+	if err != nil {
+		return err
+	}
+
+	isConfigurationManager, err := configCaller.IsConfigurationManager(nil, wallet.Address)
+	if err != nil {
+		return err
+	}
+
+	if !isConfigurationManager {
+		return fmt.Errorf("address %s is not a configuration manager", wallet.Address)
+	}
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cfg.RegistryContract,
+		&cfg.RiverRegistry,
+	)
+	if err != nil {
+		return err
+	}
+
+	httpClient, err := http_client.GetHttpClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	onChainConfig, err := crypto.NewOnChainConfig(
+		ctx,
+		blockchain.Client,
+		registryContract.Address,
+		blockchain.InitialBlockNum,
+		blockchain.ChainMonitor,
+	)
+	if err != nil {
+		return err
+	}
+
+	nodeRegistry, err := nodes.LoadNodeRegistry(ctx, registryContract, common.Address{}, blockchain.InitialBlockNum,
+		blockchain.ChainMonitor, onChainConfig, httpClient, nil)
+	if err != nil {
+		return err
+	}
+
+	nodesToOperator := make(map[common.Address]common.Address)
+	operatorToNodes := make(map[common.Address][]common.Address)
+	for _, node := range nodeRegistry.GetAllNodes() {
+		nodesToOperator[node.Address()] = node.Operator()
+		if operator, found := operatorToNodes[node.Operator()]; found {
+			operatorToNodes[node.Operator()] = append(operator, node.Address())
+		} else {
+			operatorToNodes[node.Operator()] = []common.Address{node.Address()}
+		}
+	}
+
+	inputFile, err := os.ReadFile(args[1])
+	if err != nil {
+		return err
+	}
+
+	// decode input file and ensure that all stream node lists are max targetReplicationFactor length
+	var (
+		streamSetReplicationFactorRequests []river.SetStreamReplicationFactor
+		inputJSON                          = json.NewDecoder(bytes.NewReader(inputFile))
+	)
+
+	for {
+		var record StreamNotMigrated
+
+		err := inputJSON.Decode(&record)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		allStreamOperators := make(map[common.Address]struct{})
+
+		if len(record.NodeAddresses) > targetReplicationFactor {
+			return fmt.Errorf(
+				"Invalid number of nodes for stream %s: %d, replication factor: %d",
+				record.StreamID,
+				len(record.NodeAddresses),
+				targetReplicationFactor,
+			)
+		}
+
+		// add random nodes to ensure that the number of stream nodes is the targeted replication factor
+		// ensure that newly added nodes are from different operators
+		choosenStreamNodes, err := nodeRegistry.ChooseStreamNodes(ctx, record.StreamID, targetReplicationFactor)
+		if err != nil {
+			return err
+		}
+
+		for _, newNode := range choosenStreamNodes {
+			operator, found := nodesToOperator[newNode]
+			if !found {
+				return fmt.Errorf("Unable to find operator for node %s", newNode)
+			}
+
+			if len(record.NodeAddresses) < targetReplicationFactor {
+				if _, found := allStreamOperators[operator]; !found {
+					record.NodeAddresses = append(record.NodeAddresses, newNode)
+					allStreamOperators[operator] = struct{}{}
+				}
+			}
+		}
+
+		if allowedMultipleNodesFromSameOperator := len(record.NodeAddresses) < targetReplicationFactor; allowedMultipleNodesFromSameOperator {
+			for _, node := range choosenStreamNodes {
+				if len(record.NodeAddresses) < targetReplicationFactor && !slices.Contains(record.NodeAddresses, node) {
+					record.NodeAddresses = append(record.NodeAddresses, node)
+				}
+			}
+		}
+
+		if len(record.NodeAddresses) != targetReplicationFactor {
+			return fmt.Errorf("Unable to add enough nodes to stream %s", record.StreamID)
+		}
+
+		streamSetReplicationFactorRequests = append(
+			streamSetReplicationFactorRequests,
+			river.SetStreamReplicationFactor{
+				StreamId:          record.StreamID,
+				Nodes:             record.NodeAddresses,
+				ReplicationFactor: record.ReplicationFactor,
+			},
+		)
+	}
+
+	outputFile, err := os.OpenFile(args[1]+".initiated", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	output := json.NewEncoder(outputFile)
+
+	decoder, err := crypto.NewEVMErrorDecoder(
+		river.StreamRegistryV1MetaData,
+		river.RiverConfigV1MetaData,
+		river.NodeRegistryV1MetaData,
+		river.StreamRegistryV1MetaData)
+	if err != nil {
+		return err
+	}
+
+	for requests := range slices.Chunk(streamSetReplicationFactorRequests, 500) {
+		pendingTx, err := blockchain.TxPool.Submit(
+			ctx,
+			"StreamRegistry::SetStreamReplicationFactor",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return registryContract.StreamRegistry.SetStreamReplicationFactor(opts, requests)
+			},
+		)
+		if err != nil {
+			cs, st, err := decoder.DecodeEVMError(err)
+			fmt.Printf("submit err: %v %v %v\n", cs, st, err)
+			return err
+		}
+
+		receipt, err := pendingTx.Wait(ctx)
+		if err != nil {
+			return err
+		}
+
+		var results []*StreamPlacementTxResult
+		for _, req := range requests {
+			results = append(results, &StreamPlacementTxResult{
+				Status:        "pending",
+				StreamID:      req.StreamId,
+				NodeAddresses: req.Nodes,
+			})
+		}
+
+		switch receipt.Status {
+		case types.ReceiptStatusSuccessful:
+			for _, result := range results {
+				result.Status = "success"
+				result.TxHash = receipt.TxHash
+				if err := output.Encode(result); err != nil {
+					return err
+				}
+			}
+		case types.ReceiptStatusFailed:
+			for _, result := range results {
+				result.Status = "failed"
+				result.TxHash = receipt.TxHash
+				if err := output.Encode(result); err != nil {
+					return err
+				}
+			}
+			return fmt.Errorf("transaction %s failed", receipt.TxHash)
+		default:
+			return fmt.Errorf("invalid transaction status: %d", receipt.Status)
+		}
+	}
+
+	return nil
+}
+
+func runStreamPlaceStatusCmd(cfg *config.Config, args []string) error {
+	ctx := context.Background() // lint:ignore context.Background() is fine here
+
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cmdConfig.RiverChain,
+		nil,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cfg.RegistryContract,
+		&cfg.RiverRegistry,
+	)
+	if err != nil {
+		return err
+	}
+
+	httpClient, err := http_client.GetHttpClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	onChainConfig, err := crypto.NewOnChainConfig(
+		ctx,
+		blockchain.Client,
+		registryContract.Address,
+		blockchain.InitialBlockNum,
+		blockchain.ChainMonitor,
+	)
+	if err != nil {
+		return err
+	}
+
+	nodeRegistry, err := nodes.LoadNodeRegistry(ctx, registryContract, common.Address{}, blockchain.InitialBlockNum,
+		blockchain.ChainMonitor, onChainConfig, httpClient, nil)
+	if err != nil {
+		return err
+	}
+
+	inputFile, err := os.Open(args[0])
+	if err != nil {
+		return err
+	}
+	defer inputFile.Close()
+
+	input := json.NewDecoder(inputFile)
+	var streamPlacementTxResults []*StreamPlacementTxResult
+	for {
+		var result StreamPlacementTxResult
+		if err := input.Decode(&result); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		streamPlacementTxResults = append(streamPlacementTxResults, &result)
+	}
+
+	var (
+		wp        = workerpool.New(32)
+		results   = make(chan *streamSyncStatus, 32)
+		getStatus = func(stream *StreamPlacementTxResult) func() {
+			return func() {
+				status := &streamSyncStatus{
+					StreamID: stream.StreamID,
+					Nodes:    make(map[common.Address]streamSyncNodeStatus),
+				}
+
+				for _, nodeAddress := range stream.NodeAddresses {
+					if stream.Status != "success" {
+						status.Nodes[nodeAddress] = streamSyncNodeStatus{
+							Status: "failed",
+							Error:  "initiate tx failed",
+						}
+						continue
+					}
+
+					streamServiceClient, err := nodeRegistry.GetStreamServiceClientForAddress(nodeAddress)
+					if err != nil {
+						status.Nodes[nodeAddress] = streamSyncNodeStatus{
+							Status: "failed",
+							Error:  err.Error(),
+						}
+						continue
+					}
+
+					request := connect.NewRequest(&protocol.GetStreamRequest{StreamId: stream.StreamID[:]})
+					request.Header().Set(rpc.RiverNoForwardHeader, rpc.RiverHeaderTrueValue)
+					request.Header().Set(rpc.RiverAllowNoQuorumHeader, rpc.RiverHeaderTrueValue)
+
+					response, err := streamServiceClient.GetStream(ctx, request)
+					if err != nil {
+						status.Nodes[nodeAddress] = streamSyncNodeStatus{
+							Status: "failed",
+							Error:  err.Error(),
+						}
+						continue
+					}
+
+					status.Nodes[nodeAddress] = streamSyncNodeStatus{
+						Status:      "success",
+						MinipoolGen: response.Msg.GetStream().GetNextSyncCookie().GetMinipoolGen(),
+					}
+				}
+
+				results <- status
+			}
+		}
+	)
+
+	go func() {
+		for _, stream := range streamPlacementTxResults {
+			wp.Submit(getStatus(stream))
+		}
+		wp.StopWait()
+		close(results)
+	}()
+
+	outputSink, err := os.OpenFile(args[0]+".status", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		outputSink = os.Stdout
+	}
+	output := json.NewEncoder(outputSink)
+
+	for result := range results {
+		output.Encode(result)
+	}
+
+	return nil
+}
+
+func runStreamPlaceEnterQuorumCmd(cfg *config.Config, args []string) error {
+	walletFileContents, err := os.ReadFile(args[0])
+	if err != nil {
+		return err
+	}
+
+	key, err := keystore.DecryptKey(walletFileContents, "")
+	if err != nil {
+		return err
+	}
+
+	wallet := &crypto.Wallet{
+		PrivateKeyStruct: key.PrivateKey,
+		PrivateKey:       eth_crypto.FromECDSA(key.PrivateKey),
+		Address:          eth_crypto.PubkeyToAddress(key.PrivateKey.PublicKey),
+	}
+
+	ctx := context.Background() // lint:ignore context.Background() is fine here
+
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cmdConfig.RiverChain,
+		wallet,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	configCaller, err := river.NewRiverConfigV1Caller(cfg.RegistryContract.Address, blockchain.Client)
+	if err != nil {
+		return err
+	}
+
+	isConfigurationManager, err := configCaller.IsConfigurationManager(nil, wallet.Address)
+	if err != nil {
+		return err
+	}
+
+	if !isConfigurationManager {
+		return fmt.Errorf("address %s is not a configuration manager", wallet.Address)
+	}
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cfg.RegistryContract,
+		&cfg.RiverRegistry,
+	)
+	if err != nil {
+		return err
+	}
+
+	inputFile, err := os.ReadFile(args[1])
+	if err != nil {
+		return err
+	}
+
+	// decode input file and ensure that all stream node lists are max targetReplicationFactor length
+	var (
+		streamSetReplicationFactorRequests []river.SetStreamReplicationFactor
+		inputJSON                          = json.NewDecoder(bytes.NewReader(inputFile))
+	)
+
+	for {
+		var record streamSyncStatus
+
+		err := inputJSON.Decode(&record)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		nodes := make([]common.Address, 0, len(record.Nodes))
+		for node := range record.Nodes {
+			nodes = append(nodes, node)
+		}
+
+		streamSetReplicationFactorRequests = append(
+			streamSetReplicationFactorRequests,
+			river.SetStreamReplicationFactor{
+				StreamId:          record.StreamID,
+				Nodes:             nodes,
+				ReplicationFactor: uint8(len(nodes)),
+			},
+		)
+	}
+
+	outputFile, err := os.OpenFile(args[1]+".enter_quorum", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	output := json.NewEncoder(outputFile)
+
+	decoder, err := crypto.NewEVMErrorDecoder(
+		river.StreamRegistryV1MetaData,
+		river.RiverConfigV1MetaData,
+		river.NodeRegistryV1MetaData,
+		river.StreamRegistryV1MetaData)
+	if err != nil {
+		return err
+	}
+
+	for requests := range slices.Chunk(streamSetReplicationFactorRequests, 500) {
+		pendingTx, err := blockchain.TxPool.Submit(
+			ctx,
+			"StreamRegistry::SetStreamReplicationFactor",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return registryContract.StreamRegistry.SetStreamReplicationFactor(opts, requests)
+			},
+		)
+		if err != nil {
+			cs, st, err := decoder.DecodeEVMError(err)
+			fmt.Printf("submit err: %v %v %v\n", cs, st, err)
+			return err
+		}
+
+		receipt, err := pendingTx.Wait(ctx)
+		if err != nil {
+			return err
+		}
+
+		var results []*StreamPlacementTxResult
+		for _, req := range requests {
+			results = append(results, &StreamPlacementTxResult{
+				Status:        "pending",
+				StreamID:      req.StreamId,
+				NodeAddresses: req.Nodes,
+			})
+		}
+
+		switch receipt.Status {
+		case types.ReceiptStatusSuccessful:
+			for _, result := range results {
+				result.Status = "success"
+				result.TxHash = receipt.TxHash
+				if err := output.Encode(result); err != nil {
+					return err
+				}
+			}
+		case types.ReceiptStatusFailed:
+			for _, result := range results {
+				result.Status = "failed"
+				result.TxHash = receipt.TxHash
+				if err := output.Encode(result); err != nil {
+					return err
+				}
+			}
+			return fmt.Errorf("transaction %s failed", receipt.TxHash)
+		default:
+			return fmt.Errorf("invalid transaction status: %d", receipt.Status)
+		}
+	}
+
+	return nil
+}
+
 func runStreamPartitionCmd(cmd *cobra.Command, args []string) error {
 	streamID, err := shared.StreamIdFromString(args[0])
 	if err != nil {
@@ -732,6 +1381,50 @@ max-block-range is optional and limits the number of blocks to consider (default
 		RunE:  runStreamNodeDumpCmd,
 	}
 
+	cmdStreamMigrationList := &cobra.Command{
+		Use:   "not-migrated <output-stream-id-file> [max-streams]",
+		Short: "Dump non-replicated streams to file",
+		Long: `Dump streams that are not replicated nor the migration to replicated streams was started
+to a file, optionally the number of streams is limited by max-streams.`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: runStreamMigrationListCmd,
+	}
+
+	cmdStreamPlace := &cobra.Command{
+		Use:   "place",
+		Short: "Place streams on nodes",
+	}
+
+	cmdStreamPlaceInitiate := &cobra.Command{
+		Use:   "initiate",
+		Short: "Initiate stream placement <wallet-file> <input-stream-id-file> <replication-factor>",
+		Long:  `Initiate stream placement for streams in the given file.`,
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStreamPlaceInitiateCmd(cmdConfig, args)
+		},
+	}
+
+	cmdStreamPlaceStatus := &cobra.Command{
+		Use:   "status",
+		Short: "Status stream placement <input-stream-id-file>",
+		Long:  `Get overview of stream placement status for streams in the given file.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStreamPlaceStatusCmd(cmdConfig, args)
+		},
+	}
+
+	cmdStreamPlaceEnterQuorum := &cobra.Command{
+		Use:   "enter-quorum",
+		Short: "Enter quorum <wallet-file> <input-stream-id-file>",
+		Long:  `Let all nodes enter quorum for streams in the given file.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStreamPlaceEnterQuorumCmd(cmdConfig, args)
+		},
+	}
+
 	cmdStreamGet := &cobra.Command{
 		Use:   "get <stream-id>",
 		Short: "Get stream contents",
@@ -739,6 +1432,7 @@ max-block-range is optional and limits the number of blocks to consider (default
 		Args:  cobra.ExactArgs(1),
 		RunE:  runStreamGetCmd,
 	}
+
 	cmdStreamGetPartition := &cobra.Command{
 		Use:   "part <stream-id>",
 		Short: "Get stream stream database partition",
@@ -747,11 +1441,16 @@ max-block-range is optional and limits the number of blocks to consider (default
 		RunE:  runStreamPartitionCmd,
 	}
 
+	cmdStreamPlace.AddCommand(cmdStreamPlaceInitiate)
+	cmdStreamPlace.AddCommand(cmdStreamPlaceStatus)
+	cmdStreamPlace.AddCommand(cmdStreamPlaceEnterQuorum)
 	cmdStream.AddCommand(cmdStreamGetMiniblock)
 	cmdStream.AddCommand(cmdStreamGetMiniblockNum)
 	cmdStream.AddCommand(cmdStreamGetEvent)
 	cmdStream.AddCommand(cmdStreamDump)
 	cmdStream.AddCommand(cmdStreamNodeDump)
+	cmdStream.AddCommand(cmdStreamMigrationList)
+	cmdStream.AddCommand(cmdStreamPlace)
 	cmdStream.AddCommand(cmdStreamGet)
 	cmdStream.AddCommand(cmdStreamGetPartition)
 	rootCmd.AddCommand(cmdStream)

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -1144,12 +1144,13 @@ func runStreamPlaceStatusCmd(cfg *config.Config, args []string) error {
 		close(results)
 	}()
 
-	outputSink, err := os.OpenFile(args[0]+".status", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	outputSink, err := os.OpenFile(args[0]+".status", os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		outputSink = os.Stdout
 	}
-	output := json.NewEncoder(outputSink)
+	defer outputSink.Close()
 
+	output := json.NewEncoder(outputSink)
 	for result := range results {
 		output.Encode(result)
 	}

--- a/core/node/events/miniblock_job.go
+++ b/core/node/events/miniblock_job.go
@@ -145,7 +145,7 @@ func (j *mbJob) processRemoteProposals(ctx context.Context) ([]*mbProposal, *Str
 		return nil, nil, RiverError(
 			Err_MINIBLOCK_TOO_OLD,
 			"mbJob.processRemoteProposals: stream advanced in the meantime (1)",
-		)
+		).Tags("minipool.gen", view.minipool.generation, "req.newminiblocknum", request.NewMiniblockNum)
 	}
 
 	// Apply received MissingEvents, even if there are not enough quorum of proposals.

--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -166,6 +166,7 @@ func (p *miniblockProducer) onNewBlock(ctx context.Context, blockNum crypto.Bloc
 	if !p.onNewBlockMutex.TryLock() {
 		return
 	}
+
 	// don't block the chain monitor
 	go func() {
 		defer p.onNewBlockMutex.Unlock()
@@ -191,6 +192,7 @@ func (p *miniblockProducer) scheduleCandidates(ctx context.Context, blockNum cry
 			)
 			continue
 		}
+
 		j := p.trySchedule(ctx, stream)
 		if j != nil {
 			scheduled = append(scheduled, j)

--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -38,7 +38,6 @@ func (s *StreamCache) submitSyncStreamTaskToPool(
 	} else {
 		s.submitReconciliationTask(pool, stream, streamRecord)
 	}
-
 }
 
 func (s *StreamCache) submitToPool(
@@ -77,7 +76,8 @@ func (s *StreamCache) getRecordTask(
 
 	streamRecord, err := s.params.Registry.GetStreamOnLatestBlock(ctx, stream.streamId)
 	if err != nil {
-		logging.FromCtx(ctx).Errorw("getRecordTask: Unable to get stream record", "stream", stream.streamId, "error", err)
+		logging.FromCtx(ctx).
+			Errorw("getRecordTask: Unable to get stream record", "stream", stream.streamId, "error", err)
 		return
 	}
 
@@ -115,7 +115,6 @@ func (s *StreamCache) submitReconciliationTask(
 			s.reconciliationTask(pool, stream.StreamId())
 		})
 	}
-
 }
 
 func (s *StreamCache) reconciliationTask(
@@ -176,7 +175,8 @@ func (s *StreamCache) reconciliationTask(
 		},
 	)
 	if corrupt {
-		logging.FromCtx(s.params.ServerCtx).Errorw("reconciliationTask: Corrupt task 2", "stream", streamId, "record", streamRecord)
+		logging.FromCtx(s.params.ServerCtx).
+			Errorw("reconciliationTask: Corrupt task 2", "stream", streamId, "record", streamRecord)
 		return
 	}
 

--- a/core/node/shared/stream_id.go
+++ b/core/node/shared/stream_id.go
@@ -194,3 +194,15 @@ func (id *StreamId) ScanText(v pgtype.Text) error {
 func (id StreamId) MarshalJSON() ([]byte, error) {
 	return []byte("\"" + id.String() + "\""), nil
 }
+
+func (id *StreamId) UnmarshalJSON(b []byte) error {
+	if len(b) > 1 && b[0] == '"' && b[len(b)-1] == '"' {
+		b = b[1 : len(b)-1]
+	}
+
+	_, err := hex.Decode(id[:], b)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/node/shared/stream_id.go
+++ b/core/node/shared/stream_id.go
@@ -196,7 +196,11 @@ func (id StreamId) MarshalJSON() ([]byte, error) {
 }
 
 func (id *StreamId) UnmarshalJSON(b []byte) error {
-	if len(b) > 1 && b[0] == '"' && b[len(b)-1] == '"' {
+	if len(b) >= 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		b = b[1 : len(b)-1]
+	}
+
+	if len(b) >= 2 && b[0] == '0' && (b[len(b)-1] == 'x' || b[len(b)-1] == 'X') {
 		b = b[1 : len(b)-1]
 	}
 


### PR DESCRIPTION
Add subcommands to dump non-replicated streams and place streams on a new set of nodes.