### PR TITLE
fix(sync-agent): timeline event replace

### DIFF
--- a/packages/sdk/src/sync-agent/timeline/timeline.ts
+++ b/packages/sdk/src/sync-agent/timeline/timeline.ts
@@ -181,7 +181,7 @@ export class MessageTimeline {
             return
         }
         const newEvent = toReplacedMessageEvent(oldEvent, event)
-        this.events.replace(event, eventIndex, this.events.value)
+        this.events.replace(newEvent, eventIndex, this.events.value)
         this.replacedEvents.add(event.eventId, oldEvent, newEvent)
         this.reactions.removeEvent(oldEvent)
         this.reactions.addEvent(newEvent)


### PR DESCRIPTION
Typo...

Events wasn't getting properly replaced
Previously, if I had edited a message, the `eventId` of message in timeline would change, and that's not the desired behavior.
We would like keep the original eventId, since it can hold reaction references, and only update the `latestEventId` to be the new one from the latest edit