### PR TITLE
don't apply stream mb updates for non-local streams

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -222,7 +222,7 @@ func (s *StreamCache) onBlockWithLogs(ctx context.Context, blockNum crypto.Block
 					events = events[i:]
 
 					if stream, ok := s.cache.Load(streamID); ok {
-						stream.applyStreamEvents(ctx, eventsToApply, blockNum)
+						stream.applyStreamMiniblockUpdates(ctx, eventsToApply, blockNum)
 					}
 				}
 			}


### PR DESCRIPTION
The stream node tracks the streams registry for emitted logs, parses these into events and processes them. Currently it also tries to process miniblock update for non-local streams causing log pollution; `onStreamLastMiniblockUpdated: failed to promote candidate`.