### PR TITLE
node: fetch latest miniblock during reconcile for to-repl-streams migration

### DIFF
--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -12,7 +12,6 @@ import (
 	"github.com/towns-protocol/towns/core/contracts/river"
 	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/logging"
-	"github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/shared"
 )
@@ -242,7 +241,7 @@ func (s *StreamCache) syncStreamFromPeers(
 			if err != nil {
 				continue
 			}
-			resp, err := client.GetLastMiniblockHash(ctx, connect.NewRequest(&protocol.GetLastMiniblockHashRequest{
+			resp, err := client.GetLastMiniblockHash(ctx, connect.NewRequest(&GetLastMiniblockHashRequest{
 				StreamId: stream.streamId[:],
 			}))
 			if err != nil {

--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -224,7 +224,7 @@ func (s *StreamCache) syncStreamFromPeers(
 	stream.mu.Unlock()
 
 	fromInclusive := lastMiniblockNum + 1
-	toExclusive := streamRecord.LastMbNum() + 1 // incorrect, during migration stream isn't replicated so registry might not have the latest miniblock
+	toExclusive := streamRecord.LastMbNum() + 1
 
 	remotes, _ := stream.GetRemotesAndIsLocal()
 	if len(remotes) == 0 {


### PR DESCRIPTION
For non-replicated streams nodes only register miniblocks periodically to save on transaction costs. That means that the stream update event as emitted during stream (re)placement contains a miniblock number that might not be the latest and the node managing the stream at the moment may have newer miniblocks.

In that case ask the existing quorum node for the latest block and reconcile to that block.