### PR TITLE
Fix subgraph dockerfile build

### DIFF
--- a/packages/subgraph/Dockerfile
+++ b/packages/subgraph/Dockerfile
@@ -9,6 +9,11 @@ ARG VER_BRANCH=branch_unset
 ARG VER_COMMIT=commit_unset
 ARG GIT_SHA
 
+# Create and set proper permissions for node user's cache directory
+RUN mkdir -p /home/node/.cache/node/corepack/v1 && \
+    chown -R node:node /home/node/.cache && \
+    chmod -R 775 /home/node/.cache
+
 # Install curl and other required packages for Foundry installation
 RUN apt-get update && \
     apt-get install -y curl build-essential git make && \
@@ -21,9 +26,6 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
 
 # Add Foundry binaries to PATH
 ENV PATH="/root/.foundry/bin:${PATH}"
-
-RUN mkdir -p /home/node/.cache/node/corepack/v1 && \
-    chown -R node:node /home/node
 
 # Enable Corepack for Yarn 3.x support
 RUN corepack enable
@@ -54,12 +56,17 @@ RUN yarn workspace @towns-protocol/contracts typings
 # Set working directory to subgraph package
 WORKDIR /river/packages/subgraph
 
+# Fix permissions for the node user
+RUN chown -R node:node /river
+
 # Expose the default Ponder port
 EXPOSE 42069
 
 # Set environment variables
 ENV NODE_ENV=production
 ENV DATABASE_SCHEMA=public
+
+USER node
 
 # Use entrypoint script
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/packages/subgraph/Dockerfile
+++ b/packages/subgraph/Dockerfile
@@ -22,6 +22,9 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
 # Add Foundry binaries to PATH
 ENV PATH="/root/.foundry/bin:${PATH}"
 
+RUN mkdir -p /home/node/.cache/node/corepack/v1 && \
+    chown -R node:node /home/node
+
 # Enable Corepack for Yarn 3.x support
 RUN corepack enable
 
@@ -42,7 +45,7 @@ RUN yarn install
 
 # Build contracts
 WORKDIR /river/packages/contracts
-RUN make build
+RUN script -q -c "make build"
 WORKDIR /river
 
 # Generate contract typings

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -2,7 +2,7 @@ import { createConfig } from 'ponder'
 import { http } from 'viem'
 
 // import abis
-import { createSpaceFacetAbi } from '@towns-protocol/contracts/typings'
+import { createSpaceFacetAbi } from '../contracts/typings'
 
 // Import our contract address utility
 import { getContractAddress } from './utils/contractAddresses'


### PR DESCRIPTION
Fixes docker build for runtime error seen in K8s pod:


```
│ node:fs:1372                                                                             │
│   const result = binding.mkdir(                                                          │
│                          ^                                                               │
│                                                                                          │
│ Error: ENOENT: no such file or directory, mkdir '/home/node/.cache/node/corepack/v1'     │
│     at mkdirSync (node:fs:1372:26)                                                       │
│     at getTemporaryFolder (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21 │
│     at download (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21767:21)    │
│     at installVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21861: │
│     at async Engine.ensurePackageManager (/usr/local/lib/node_modules/corepack/dist/lib/ │
│     at async Engine.executePackageManagerRequest (/usr/local/lib/node_modules/corepack/d │
│     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs: │
│   errno: -2,                                                                             │
│   code: 'ENOENT',                                                                        │
│   syscall: 'mkdir',                                                                      │
│   path: '/home/node/.cache/node/corepack/v1'                                             │
│ }                                                                                        │
│                                                                                          │
│ Node.js v20.19.0                                                                         │
│ stream closed EOF for default/subgraph-6c9fdc7d79-qbklz (subgraph)    
```

Also fixes associated typings import break in docker image and runs make target in a separate shell to improve image build performance. 
