### PR TITLE
node: observe chain transactions random to mimic real world scenario during unit tests

### DIFF
--- a/core/node/crypto/chain_monitor_test.go
+++ b/core/node/crypto/chain_monitor_test.go
@@ -589,7 +589,13 @@ func TestContracEventsWithTopicsBeforeStart(t *testing.T) {
 
 	// Create a new chain monitor and start it.
 	chainMonitor := crypto.NewChainMonitor()
-	chainMonitor.Start(ctx, tc.Client(), tc.BlockNum(ctx), 100*time.Millisecond, infra.NewMetricsFactory(nil, "", ""))
+	chainMonitor.StartWithBlockPeriod(
+		ctx,
+		tc.Client(),
+		tc.BlockNum(ctx),
+		100*time.Millisecond,
+		infra.NewMetricsFactory(nil, "", ""),
+	)
 
 	events2C := make(chan types.Log, nodeCount)
 

--- a/core/node/crypto/chain_txpool_test.go
+++ b/core/node/crypto/chain_txpool_test.go
@@ -194,7 +194,7 @@ func TestReplacementTxOnBoot(t *testing.T) {
 	monitor := crypto.NewChainMonitor()
 	blockNum, err := bc.Client.BlockNumber(ctx)
 	require.NoError(err, "unable to get block number")
-	monitor.Start(
+	monitor.StartWithBlockPeriod(
 		ctx, bc.Client, crypto.BlockNumber(blockNum), 100*time.Millisecond,
 		infra.NewMetricsFactory(nil, "", ""))
 

--- a/core/node/crypto/testutil.go
+++ b/core/node/crypto/testutil.go
@@ -2,10 +2,12 @@ package crypto
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
+	"math/rand"
 	"os"
 	"slices"
 	"strings"
@@ -468,6 +470,37 @@ func (c *BlockchainTestContext) GetDeployerWallet() *Wallet {
 	return c.DeployerBlockchain.Wallet
 }
 
+type flakyChainMonitorPollInterval struct {
+	random      *rand.Rand
+	blockPeriod time.Duration
+}
+
+// newFlakyChainMonitorPollInterval creates a chain poll interval calculator that yields random poll intervals
+// in the range of [1ms, blockPeriod). It is intended to simulate that nodes witness chain state transitions on
+// different moments.
+func newFlakyChainMonitorPollInterval(blockPeriod time.Duration) *flakyChainMonitorPollInterval {
+	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic(err)
+	}
+
+	random := rand.New(rand.NewSource(seed.Int64()))
+	return &flakyChainMonitorPollInterval{random, blockPeriod}
+}
+
+func (f *flakyChainMonitorPollInterval) Interval(
+	took time.Duration,
+	gotBlock bool,
+	hitBlockRangeLimit bool,
+	gotErr bool,
+) time.Duration {
+	offset := time.Duration(f.random.Int()) % f.blockPeriod
+	if int(f.random.Int31n(2)) == 1 {
+		offset = -offset
+	}
+	return f.blockPeriod + offset
+}
+
 func makeTestBlockchain(
 	ctx context.Context,
 	wallet *Wallet,
@@ -477,17 +510,20 @@ func makeTestBlockchain(
 	if err != nil {
 		panic(err)
 	}
-	bc, err := NewBlockchainWithClient(
+
+	blockTimeMs := uint64(100)
+	bc, err := NewBlockchainWithClientAndChainMonitorPoll(
 		ctx,
 		&config.ChainConfig{
 			ChainId:                                chainID.Uint64(),
-			BlockTimeMs:                            100,
+			BlockTimeMs:                            blockTimeMs,
 			TransactionPool:                        config.TransactionPoolConfig{}, // use defaults
 			DisableReplacePendingTransactionOnBoot: true,
 		},
 		wallet,
 		client,
 		nil,
+		newFlakyChainMonitorPollInterval(time.Duration(blockTimeMs)*time.Millisecond),
 		infra.NewMetricsFactory(nil, "", ""),
 		nil,
 	)
@@ -691,13 +727,24 @@ type NoopChainMonitor struct{}
 
 var _ ChainMonitor = NoopChainMonitor{}
 
-func (NoopChainMonitor) Start(
+func (NoopChainMonitor) StartWithBlockPeriod(
 	context.Context,
 	BlockchainClient,
 	BlockNumber,
 	time.Duration,
 	infra.MetricsFactory,
 ) {
+	// noop
+}
+
+func (NoopChainMonitor) StartWithPollInterval(
+	context.Context,
+	BlockchainClient,
+	BlockNumber,
+	ChainMonitorPollInterval,
+	infra.MetricsFactory,
+) {
+	// noop
 }
 
 func (NoopChainMonitor) OnHeader(OnChainNewHeader)                                         {}


### PR DESCRIPTION
On local/CI we use an artificial chain that works reliable, stable and predictable. In practice nodes will witness state transitions at different moments due to latencies, RPC differences and internal variances. To mimic this real world behaviour better introduce randomness when watching the chain for transitions. It means that some nodes can be ahead of other nodes but still need to reach (eventually) consensus about the state of the system.

It also reduces the frequency `process chain segment` is logged. When it is now logged it indicates that a node is really lagging in witnessing chain transitions.