### PR TITLE
Remove unused channel metadata abstraction

### DIFF
--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -48,7 +48,6 @@ import { StreamStateView_UserInbox } from './streamStateView_UserInbox'
 import { DecryptedContent } from './encryptedContentTypes'
 import { StreamStateView_UnknownContent } from './streamStateView_UnknownContent'
 import { StreamStateView_MemberMetadata } from './streamStateView_MemberMetadata'
-import { StreamStateView_ChannelMetadata } from './streamStateView_ChannelMetadata'
 import { StreamEvents, StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 import isEqual from 'lodash/isEqual'
 import { DecryptionSessionError } from '@towns-protocol/encryption'
@@ -83,7 +82,6 @@ export interface IStreamStateView {
     get mediaContent(): StreamStateView_Media
     getMembers(): StreamStateView_Members
     getMemberMetadata(): StreamStateView_MemberMetadata
-    getChannelMetadata(): StreamStateView_ChannelMetadata | undefined
     getContent(): StreamStateView_AbstractContent
     userIsEntitledToKeyExchange(userId: string): boolean
     getUsersEntitledToKeyExchange(): Set<string>
@@ -762,10 +760,6 @@ export class StreamStateView implements IStreamStateView {
 
     getMemberMetadata(): StreamStateView_MemberMetadata {
         return this.membershipContent.memberMetadata
-    }
-
-    getChannelMetadata(): StreamStateView_ChannelMetadata | undefined {
-        return this.getContent().getChannelMetadata()
     }
 
     getContent(): StreamStateView_AbstractContent {

--- a/packages/sdk/src/streamStateView_AbstractContent.ts
+++ b/packages/sdk/src/streamStateView_AbstractContent.ts
@@ -2,7 +2,6 @@ import TypedEmitter from 'typed-emitter'
 import { EncryptedData } from '@towns-protocol/proto'
 import { ConfirmedTimelineEvent, RemoteTimelineEvent, StreamTimelineEvent } from './types'
 import { DecryptedContent, EncryptedContent, toDecryptedContent } from './encryptedContentTypes'
-import { StreamStateView_ChannelMetadata } from './streamStateView_ChannelMetadata'
 import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 import { streamIdToBytes } from './id'
 
@@ -59,10 +58,6 @@ export abstract class StreamStateView_AbstractContent {
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
         //
-    }
-
-    getChannelMetadata(): StreamStateView_ChannelMetadata | undefined {
-        return undefined
     }
 
     getStreamParentId(): string | undefined {

--- a/packages/sdk/src/streamStateView_GDMChannel.ts
+++ b/packages/sdk/src/streamStateView_GDMChannel.ts
@@ -130,10 +130,6 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
         stateEmitter?.emit('streamLatestTimestampUpdated', this.streamId)
     }
 
-    getChannelMetadata(): StreamStateView_ChannelMetadata | undefined {
-        return this.channelMetadata
-    }
-
     private updateLastEvent(
         event: ParsedEvent,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,

--- a/packages/sdk/src/sync-agent/dms/models/dm.ts
+++ b/packages/sdk/src/sync-agent/dms/models/dm.ts
@@ -147,12 +147,11 @@ export class Dm extends PersistedObservable<DmModel> {
             logger.log('Dm stream initialized', streamId)
             const stream = this.riverConnection.client?.stream(streamId)
             check(isDefined(stream), 'stream is not defined')
-            const view = stream.view.dmChannelContent
             const hasJoined = stream.view.getMembers().isMemberJoined(this.riverConnection.userId)
             this.setData({
                 initialized: true,
                 isJoined: hasJoined,
-                metadata: view.getChannelMetadata()?.channelProperties,
+                metadata: undefined,
             })
             this.timeline.initialize(stream)
         }

--- a/packages/sdk/src/tests/multi/transactions_SpaceReview.test.ts
+++ b/packages/sdk/src/tests/multi/transactions_SpaceReview.test.ts
@@ -376,7 +376,7 @@ describe('transaction_SpaceReview', () => {
         const unauthenticatedClient = new UnauthenticatedClient(
             alice.riverConnection.client!.rpcClient,
         )
-        await unauthenticatedClient.scrollbackByMs(streamView, 5000)
+        await unauthenticatedClient.scrollback(streamView)
         expect(streamView.membershipContent.spaceReviews.length).toBe(1)
     })
 })

--- a/packages/sdk/src/tests/multi_ne/gdms.test.ts
+++ b/packages/sdk/src/tests/multi_ne/gdms.test.ts
@@ -240,7 +240,7 @@ describe('gdmsTests', () => {
                     expect(updatedStreamId).toEqual(streamId)
                     const stream = client.streams.get(streamId)
 
-                    const channelMetadata = stream?.view.getChannelMetadata()
+                    const channelMetadata = stream?.view.gdmChannelContent.channelMetadata
                     const channelProperties = channelMetadata?.channelProperties
                     expect(channelProperties).toBeDefined()
 

--- a/packages/sdk/src/unauthenticatedClient.ts
+++ b/packages/sdk/src/unauthenticatedClient.ts
@@ -4,10 +4,9 @@ import { hasElements, isDefined } from './check'
 import { StreamRpcClient, getMiniblocks } from './makeStreamRpcClient'
 import { UnpackEnvelopeOpts, unpackStream } from './sign'
 import { StreamStateView } from './streamStateView'
-import { ParsedMiniblock, StreamTimelineEvent } from './types'
+import { ParsedMiniblock } from './types'
 import { streamIdAsString, streamIdAsBytes, userIdFromAddress, makeUserStreamId } from './id'
 
-const SCROLLBACK_MAX_COUNT = 20
 const SCROLLBACK_MULTIPLIER = 4n
 export class UnauthenticatedClient {
     readonly rpcClient: StreamRpcClient
@@ -98,42 +97,9 @@ export class UnauthenticatedClient {
         }
     }
 
-    /**
-     * @deprecated please use scrollbackByMs()
-     **/
-    async scrollbackToDate(streamView: StreamStateView, toDate: number): Promise<void> {
-        return this.scrollbackByMs(streamView, toDate)
-    }
-
-    async scrollbackByMs(streamView: StreamStateView, ms: number): Promise<void> {
-        this.logCall('scrollbackToDate', { streamId: streamView.streamId, ms })
-        const firstEvent = streamView.timeline.at(0)
-        // skip scrollback if limit is already reached
-        if (firstEvent?.createdAtEpochMs && !this.isWithin(firstEvent?.createdAtEpochMs, ms)) {
-            return
-        }
-        // scrollback to get events till max scrollback, toDate or till no events are left
-        for (let i = 0; i < SCROLLBACK_MAX_COUNT; i++) {
-            const result = await this.scrollback(streamView)
-            if (result.terminus) {
-                break
-            }
-            const currentOldestEvent = result.firstEvent
-            this.logCall('scrollbackToDate result', {
-                oldest: currentOldestEvent?.createdAtEpochMs,
-                ms,
-            })
-            if (currentOldestEvent) {
-                if (!this.isWithin(currentOldestEvent.createdAtEpochMs, ms)) {
-                    break
-                }
-            }
-        }
-    }
-
-    private async scrollback(
+    async scrollback(
         streamView: StreamStateView,
-    ): Promise<{ terminus: boolean; firstEvent?: StreamTimelineEvent }> {
+    ): Promise<{ terminus: boolean; fromInclusiveMiniblockNum: bigint }> {
         const currentRequest = this.getScrollbackRequests.get(streamView.streamId)
         if (currentRequest) {
             return currentRequest
@@ -141,7 +107,7 @@ export class UnauthenticatedClient {
 
         const _scrollback = async (): Promise<{
             terminus: boolean
-            firstEvent?: StreamTimelineEvent
+            fromInclusiveMiniblockNum: bigint
         }> => {
             check(
                 isDefined(streamView.miniblockInfo),
@@ -149,7 +115,10 @@ export class UnauthenticatedClient {
             )
             if (streamView.miniblockInfo.terminusReached) {
                 this.logCall('scrollback', streamView.streamId, 'terminus reached')
-                return { terminus: true, firstEvent: streamView.timeline.at(0) }
+                return {
+                    terminus: true,
+                    fromInclusiveMiniblockNum: streamView.miniblockInfo.min,
+                }
             }
             check(streamView.miniblockInfo.min >= streamView.prevSnapshotMiniblockNum)
             this.logCall('scrollback', {
@@ -170,7 +139,7 @@ export class UnauthenticatedClient {
 
             // a race may occur here: if the state view has been reinitialized during the scrollback
             // request, we need to discard the new miniblocks.
-            if ((streamView.miniblockInfo?.min ?? -1n) === toExclusive) {
+            if (streamView.miniblockInfo.min === toExclusive) {
                 streamView.prependEvents(
                     response.miniblocks,
                     undefined,
@@ -178,9 +147,15 @@ export class UnauthenticatedClient {
                     undefined,
                     undefined,
                 )
-                return { terminus: response.terminus, firstEvent: streamView.timeline.at(0) }
+                return {
+                    terminus: response.terminus,
+                    fromInclusiveMiniblockNum: streamView.miniblockInfo.min,
+                }
             }
-            return { terminus: false, firstEvent: streamView.timeline.at(0) }
+            return {
+                terminus: false,
+                fromInclusiveMiniblockNum: streamView.miniblockInfo.min,
+            }
         }
 
         try {


### PR DESCRIPTION
Really it’s just GDM metadata.