### PR TITLE
Create abstraction for handling encrypted ChannelMessage payloads

### DIFF
--- a/packages/sdk/src/streamStateView_Channel.ts
+++ b/packages/sdk/src/streamStateView_Channel.ts
@@ -4,18 +4,21 @@ import { ChannelPayload, ChannelPayload_Snapshot, Snapshot } from '@towns-protoc
 import { StreamStateView_AbstractContent } from './streamStateView_AbstractContent'
 import { check } from '@towns-protocol/dlog'
 import { logNever } from './check'
-import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
+import { StreamEncryptionEvents, StreamEvents, StreamStateEvents } from './streamEvents'
 import { streamIdFromBytes } from './id'
-
+import { StreamStateView_ChannelMessages } from './streamStateView_Common_ChannelMessages'
+import { DecryptedContent } from './encryptedContentTypes'
 export class StreamStateView_Channel extends StreamStateView_AbstractContent {
     readonly streamId: string
     spaceId: string = ''
     readonlytips: { [key: string]: bigint } = {}
     private reachedRenderableContent = false
+    readonly messages: StreamStateView_ChannelMessages
 
     constructor(streamId: string) {
         super()
         this.streamId = streamId
+        this.messages = new StreamStateView_ChannelMessages(streamId, this)
     }
 
     getStreamParentId(): string | undefined {
@@ -51,12 +54,12 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
                 if (!payload.content.value.refEventId) {
                     this.reachedRenderableContent = true
                 }
-                this.decryptEvent(
-                    'channelMessage',
+                this.messages.prependChannelMessage(
                     event,
-                    payload.content.value,
                     cleartext,
                     encryptionEmitter,
+                    undefined,
+                    payload.content.value,
                 )
                 break
             case 'redaction':
@@ -83,12 +86,12 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
                 if (!payload.content.value.refEventId) {
                     this.reachedRenderableContent = true
                 }
-                this.decryptEvent(
-                    'channelMessage',
+                this.messages.appendChannelMessage(
                     event,
-                    payload.content.value,
                     cleartext,
                     encryptionEmitter,
+                    undefined,
+                    payload.content.value,
                 )
                 break
             case 'redaction':
@@ -97,6 +100,16 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
                 break
             default:
                 logNever(payload.content)
+        }
+    }
+
+    onDecryptedContent(
+        eventId: string,
+        content: DecryptedContent,
+        emitter: TypedEmitter<StreamEvents>,
+    ): void {
+        if (content.kind === 'channelMessage') {
+            this.messages.onDecryptedContent(eventId, content, emitter)
         }
     }
 }

--- a/packages/sdk/src/streamStateView_Common_ChannelMessages.ts
+++ b/packages/sdk/src/streamStateView_Common_ChannelMessages.ts
@@ -1,0 +1,42 @@
+import TypedEmitter from 'typed-emitter'
+import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
+import { StreamStateView_AbstractContent } from './streamStateView_AbstractContent'
+import { RemoteTimelineEvent } from './types'
+import { EncryptedData } from '@towns-protocol/proto'
+import { DecryptedContent } from './encryptedContentTypes'
+
+/// place to hold common logic for decrypting "ChannelMessage" payloads
+export class StreamStateView_ChannelMessages {
+    constructor(
+        public readonly streamId: string,
+        private readonly parent: StreamStateView_AbstractContent,
+    ) {}
+
+    onDecryptedContent(
+        _eventId: string,
+        _content: DecryptedContent,
+        _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+    ): void {
+        // pass
+    }
+
+    appendChannelMessage(
+        event: RemoteTimelineEvent,
+        cleartext: Uint8Array | string | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
+        stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        value: EncryptedData,
+    ): void {
+        this.parent.decryptEvent('channelMessage', event, value, cleartext, encryptionEmitter)
+    }
+
+    prependChannelMessage(
+        event: RemoteTimelineEvent,
+        cleartext: Uint8Array | string | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
+        stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        value: EncryptedData,
+    ): void {
+        this.parent.decryptEvent('channelMessage', event, value, cleartext, encryptionEmitter)
+    }
+}

--- a/packages/sdk/src/streamStateView_GDMChannel.ts
+++ b/packages/sdk/src/streamStateView_GDMChannel.ts
@@ -12,10 +12,12 @@ import { StreamEncryptionEvents, StreamEvents, StreamStateEvents } from './strea
 import { StreamStateView_ChannelMetadata } from './streamStateView_ChannelMetadata'
 import { check } from '@towns-protocol/dlog'
 import { logNever } from './check'
+import { StreamStateView_ChannelMessages } from './streamStateView_Common_ChannelMessages'
 
 export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent {
     readonly streamId: string
     readonly channelMetadata: StreamStateView_ChannelMetadata
+    readonly messages: StreamStateView_ChannelMessages
 
     lastEventCreatedAtEpochMs = 0n
 
@@ -23,6 +25,7 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
         super()
         this.channelMetadata = new StreamStateView_ChannelMetadata(streamId)
         this.streamId = streamId
+        this.messages = new StreamStateView_ChannelMessages(streamId, this)
     }
 
     applySnapshot(
@@ -54,12 +57,12 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
                 break
             case 'message':
                 this.updateLastEvent(event.remoteEvent, undefined)
-                this.decryptEvent(
-                    'channelMessage',
+                this.messages.prependChannelMessage(
                     event,
-                    payload.content.value,
                     cleartext,
                     encryptionEmitter,
+                    undefined,
+                    payload.content.value,
                 )
                 break
             case 'channelProperties':
@@ -85,12 +88,12 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
                 this.updateLastEvent(event.remoteEvent, stateEmitter)
                 break
             case 'message':
-                this.decryptEvent(
-                    'channelMessage',
+                this.messages.appendChannelMessage(
                     event,
-                    payload.content.value,
                     cleartext,
                     encryptionEmitter,
+                    stateEmitter,
+                    payload.content.value,
                 )
                 this.updateLastEvent(event.remoteEvent, stateEmitter)
                 break
@@ -111,6 +114,8 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
     ): void {
         if (content.kind === 'channelProperties') {
             this.channelMetadata.onDecryptedContent(eventId, content, emitter)
+        } else if (content.kind === 'channelMessage') {
+            this.messages.onDecryptedContent(eventId, content, emitter)
         }
     }
 


### PR DESCRIPTION
I want to kill the streamstateview timeline and i’m going to need some place to stash events while they are being decrypted. seems as good a place as any for now