### PR TITLE
simplify some token tests

### DIFF
--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -55,6 +55,23 @@ export interface Pin {
     event: StreamTimelineEvent
 }
 
+export interface MemberTokenTransfer {
+    address: Uint8Array
+    amount: bigint
+    isBuy: boolean
+    chainId: string
+    userId: string
+    sender: Uint8Array
+    createdAtEpochMs: bigint
+    messageId: string
+}
+
+export interface MemberSpaceReview {
+    review: SpaceReviewEventObject
+    createdAtEpochMs: bigint
+    eventHashStr: string
+}
+
 export class StreamStateView_Members extends StreamStateView_AbstractContent {
     readonly streamId: string
     readonly joined = new Map<string, StreamMember>()
@@ -65,21 +82,9 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
     tips: { [key: string]: bigint } = {}
     tipsCount: { [key: string]: bigint } = {}
     encryptionAlgorithm?: string = undefined
-    spaceReviews: {
-        review: SpaceReviewEventObject
-        createdAtEpochMs: bigint
-        eventHashStr: string
-    }[] = []
+    spaceReviews: MemberSpaceReview[] = []
 
-    tokenTransfers: {
-        address: Uint8Array
-        amount: bigint
-        isBuy: boolean
-        chainId: string
-        userId: string
-        createdAtEpochMs: bigint
-        messageId: string
-    }[] = []
+    tokenTransfers: MemberTokenTransfer[] = []
 
     constructor(streamId: string) {
         super()
@@ -616,6 +621,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
         const transferData = {
             address: transferContent.address,
             userId: userIdFromAddress(payload.fromUserAddress),
+            sender: transferContent.sender,
             chainId: receipt
                 ? receipt.chainId.toString()
                 : solanaReceipt
@@ -625,7 +631,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
             isBuy: transferContent.isBuy,
             messageId: bin_toHexString(transferContent.messageId),
             amount: BigInt(transferContent.amount),
-        }
+        } satisfies MemberTokenTransfer
         if (prepend) {
             this.tokenTransfers.unshift(transferData)
         } else {

--- a/packages/sdk/src/streamStateView_User.ts
+++ b/packages/sdk/src/streamStateView_User.ts
@@ -1,6 +1,7 @@
 import TypedEmitter from 'typed-emitter'
 import { RemoteTimelineEvent } from './types'
 import {
+    BlockchainTransaction_TokenTransfer,
     MembershipOp,
     Snapshot,
     UserPayload,
@@ -21,6 +22,7 @@ export class StreamStateView_User extends StreamStateView_AbstractContent {
     tipsReceived: { [key: string]: bigint } = {}
     tipsSentCount: { [key: string]: bigint } = {}
     tipsReceivedCount: { [key: string]: bigint } = {}
+    tokenTransfers: BlockchainTransaction_TokenTransfer[] = []
 
     constructor(streamId: string) {
         super()
@@ -59,6 +61,16 @@ export class StreamStateView_User extends StreamStateView_AbstractContent {
             case 'userMembershipAction':
                 break
             case 'blockchainTransaction':
+                {
+                    const transactionContent = payload.content.value.content
+                    switch (transactionContent?.case) {
+                        case 'tokenTransfer':
+                            this.tokenTransfers.unshift(transactionContent.value)
+                            break
+                        default:
+                            break
+                    }
+                }
                 break
             case 'receivedBlockchainTransaction':
                 break
@@ -102,6 +114,7 @@ export class StreamStateView_User extends StreamStateView_AbstractContent {
                         break
                     }
                     case 'tokenTransfer':
+                        this.tokenTransfers.push(transactionContent.value)
                         break
                     case 'spaceReview': {
                         // user left a review on a space

--- a/packages/sdk/src/tests/multi_ne/trading.test.ts
+++ b/packages/sdk/src/tests/multi_ne/trading.test.ts
@@ -1,7 +1,6 @@
 import { Client } from '../../client'
 import { makeUniqueChannelStreamId } from '../../id'
 import {
-    extractBlockchainTransactionTransferEvents,
     extractMemberBlockchainTransactions,
     getXchainConfigForTesting,
     makeDonePromise,
@@ -293,7 +292,7 @@ describe('Trading', () => {
             const stream = aliceClient.streams.get(streamId)
             if (!stream) throw new Error('no stream found')
 
-            const transferEvents = extractBlockchainTransactionTransferEvents(stream.view.timeline)
+            const transferEvents = stream.view.userContent.tokenTransfers
             expect(transferEvents.length).toBe(1)
             const event0 = transferEvents[0]
             expect(BigInt(event0.amount)).toBe(amountToTransfer)
@@ -306,7 +305,7 @@ describe('Trading', () => {
             const stream = bobClient.streams.get(streamId)
             if (!stream) throw new Error('no stream found')
 
-            const transferEvents = extractBlockchainTransactionTransferEvents(stream.view.timeline)
+            const transferEvents = stream.view.userContent.tokenTransfers
             expect(transferEvents.length).toBe(1)
             const event0 = transferEvents[0]
             expect(BigInt(event0.amount)).toBe(amountToTransfer)
@@ -320,10 +319,10 @@ describe('Trading', () => {
             expect(transferEvents.length).toBe(2)
             const [event0, event1] = [transferEvents[0], transferEvents[1]]
             expect(BigInt(event0.amount)).toBe(amountToTransfer)
-            expect(new Uint8Array(event0.sender)).toEqual(bin_fromHexString(bobClient.userId))
+            expect(event0.userId).toEqual(bobClient.userId)
             expect(event0.isBuy).toBe(false)
             expect(BigInt(event1.amount)).toBe(amountToTransfer)
-            expect(new Uint8Array(event1.sender)).toEqual(bin_fromHexString(aliceClient.userId))
+            expect(event1.userId).toEqual(aliceClient.userId)
             expect(event1.isBuy).toBe(true)
         })
     })

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -91,6 +91,7 @@ import {
 import { SyncState } from '../syncedStreamsLoop'
 import { RpcOptions } from '../rpcCommon'
 import { isDefined } from '../check'
+import { MemberTokenTransfer } from '../streamStateView_Members'
 
 const log = dlog('csb:test:util')
 
@@ -1527,21 +1528,8 @@ export function extractBlockchainTransactionTransferEvents(
 export function extractMemberBlockchainTransactions(
     client: Client,
     channelId: string,
-): BlockchainTransaction_TokenTransfer[] {
+): MemberTokenTransfer[] {
     const stream = client.streams.get(channelId)
     if (!stream) throw new Error('no stream found')
-
-    return stream.view.timeline
-        .map((e) => {
-            if (
-                e.remoteEvent?.event.payload.case === 'memberPayload' &&
-                e.remoteEvent?.event.payload.value.content.case === 'memberBlockchainTransaction' &&
-                e.remoteEvent.event.payload.value.content.value.transaction?.content.case ===
-                    'tokenTransfer'
-            ) {
-                return e.remoteEvent.event.payload.value.content.value.transaction.content.value
-            }
-            return undefined
-        })
-        .filter(isDefined)
+    return stream.view.getMembers().tokenTransfers
 }


### PR DESCRIPTION
use the view data instead of the raw events in the token tests
i want to stop retaining the raw events