### PR TITLE
simplify the syncstreams test

### DIFF
--- a/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
+++ b/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
@@ -46,11 +46,15 @@ describe('syncStreams', () => {
         // globals setup
         const stubPersistenceStore = new StubPersistenceStore()
         const done1 = makeDonePromise()
+        let userInboxDeviceSummaryUpdatedCount = 0
         const mockClientEmitter = new EventEmitter() as TypedEmitter<StreamEvents>
         mockClientEmitter.on('streamSyncActive', (isActive: boolean) => {
             if (isActive) {
                 done1.done()
             }
+        })
+        mockClientEmitter.on('userInboxDeviceSummaryUpdated', () => {
+            userInboxDeviceSummaryUpdatedCount++
         })
         // alice setup
         const rpcClient = await makeTestRpcClient()
@@ -114,6 +118,8 @@ describe('syncStreams', () => {
                 ),
             })
         }
+        // assert assumptions
+        expect(userInboxDeviceSummaryUpdatedCount).toBe(0)
 
         // post an ack (easiest way to put a string in a stream)
         await addEvent(
@@ -124,16 +130,9 @@ describe('syncStreams', () => {
         )
 
         // make sure it shows up
-        await waitFor(() =>
-            expect(
-                userInboxStream.view.timeline.find(
-                    (e) =>
-                        e.remoteEvent?.event.payload.case === 'userInboxPayload' &&
-                        e.remoteEvent?.event.payload.value.content.case === 'ack' &&
-                        e.remoteEvent?.event.payload.value.content.value.deviceKey === 'numero uno',
-                ),
-            ).toBeDefined(),
-        )
+        await waitFor(() => {
+            expect(userInboxDeviceSummaryUpdatedCount).toBe(1)
+        })
         const sendPing = async () => {
             if (!alicesSyncedStreams.pingInfo) {
                 throw new Error('syncId not set')
@@ -183,6 +182,9 @@ describe('syncStreams', () => {
             debug: ['drop_stream', alicesSyncedStreams.getSyncId()!, alicesUserInboxStreamIdStr],
         })
 
+        // assert assumptions
+        expect(userInboxDeviceSummaryUpdatedCount).toBe(1)
+
         // add second event
         await addEvent(
             make_UserInboxPayload_Ack({
@@ -192,16 +194,7 @@ describe('syncStreams', () => {
         )
 
         // make sure it shows up
-        await waitFor(() =>
-            expect(
-                userInboxStream.view.timeline.find(
-                    (e) =>
-                        e.remoteEvent?.event.payload.case === 'userInboxPayload' &&
-                        e.remoteEvent?.event.payload.value.content.case === 'ack' &&
-                        e.remoteEvent?.event.payload.value.content.value.deviceKey === 'numero dos',
-                ),
-            ).toBeDefined(),
-        )
+        await waitFor(() => expect(userInboxDeviceSummaryUpdatedCount).toBe(2))
 
         await alicesSyncedStreams.stopSync()
     })


### PR DESCRIPTION
it was using user inbox stream acks to test subscriptions, i don’t want to save them in the timeline any more, just use the listener