### PR TITLE
simplify client solicitation test

### DIFF
--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -379,6 +379,7 @@ describe('clientTest', () => {
                 .get(bobsClient.userId)
                 ?.solicitations.find((x) => x.deviceKey === 'foo')
             expect(solicitation).toBeDefined()
+            expect(solicitation?.isNewDevice).toEqual(true)
         })
 
         // fulfillment should resolve
@@ -397,7 +398,8 @@ describe('clientTest', () => {
             const solicitation = stream?.view.membershipContent.joined
                 .get(bobsClient.userId)
                 ?.solicitations.find((x) => x.deviceKey === 'foo')
-            expect(solicitation).toBeUndefined()
+            expect(solicitation).toBeDefined()
+            expect(solicitation?.isNewDevice).toEqual(false)
         })
 
         // fulfillment with empty session ids should now fail

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -372,6 +372,15 @@ describe('clientTest', () => {
             bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),
         ).resolves.not.toThrow()
 
+        // see solicitation in view
+        await waitFor(() => {
+            const stream = bobsClient.streams.get(bobsClient.userSettingsStreamId!)
+            const solicitation = stream?.view.membershipContent.joined
+                .get(bobsClient.userId)
+                ?.solicitations.find((x) => x.deviceKey === 'foo')
+            expect(solicitation).toBeDefined()
+        })
+
         // fulfillment should resolve
         payload = make_MemberPayload_KeyFulfillment({
             deviceKey: 'foo',
@@ -383,17 +392,11 @@ describe('clientTest', () => {
         ).resolves.not.toThrow()
 
         await waitFor(() => {
-            const lastEvent = bobsClient.streams
-                .get(bobsClient.userSettingsStreamId!)
-                ?.view.timeline.filter((x) => x.remoteEvent?.event.payload.case === 'memberPayload')
-                .at(-1)
-            expect(lastEvent).toBeDefined()
-            check(lastEvent?.remoteEvent?.event.payload.case === 'memberPayload', '??')
-            check(
-                lastEvent?.remoteEvent?.event.payload.value.content.case === 'keyFulfillment',
-                '??',
-            )
-            expect(lastEvent?.remoteEvent?.event.payload.value.content.value.deviceKey).toBe('foo')
+            const stream = bobsClient.streams.get(bobsClient.userSettingsStreamId!)
+            const solicitation = stream?.view.membershipContent.joined
+                .get(bobsClient.userId)
+                ?.solicitations.find((x) => x.deviceKey === 'foo')
+            expect(solicitation).toBeDefined()
         })
 
         // fulfillment with empty session ids should now fail

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -391,12 +391,13 @@ describe('clientTest', () => {
             bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),
         ).resolves.not.toThrow()
 
+        // fullfillment should remove solicitation from view
         await waitFor(() => {
             const stream = bobsClient.streams.get(bobsClient.userSettingsStreamId!)
             const solicitation = stream?.view.membershipContent.joined
                 .get(bobsClient.userId)
                 ?.solicitations.find((x) => x.deviceKey === 'foo')
-            expect(solicitation).toBeDefined()
+            expect(solicitation).toBeUndefined()
         })
 
         // fulfillment with empty session ids should now fail


### PR DESCRIPTION
check the actual solicitations instead of the raw events