### PR TITLE
chore(contract): update contract dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,17 +47,7 @@
   "go.alternateTools": {
     "customFormatter": "${workspaceFolder}/core/fmt.sh",
   },
-  "wake.compiler.solc.remappings": [
-    "@openzeppelin/=node_modules/@openzeppelin/",
-    "account-abstraction/=node_modules/account-abstraction/contracts/",
-    "forge-std/=node_modules/forge-std/src/",
-    "@prb/math/=node_modules/@prb/math/src/",
-    "@prb/test/=node_modules/@prb/test/src/",
-    "solady/=node_modules/solady/src/",
-    "@towns-protocol/diamond/=node_modules/@towns-protocol/diamond/",
-    "crypto-lib/=node_modules/crypto-lib/src/",
-    "@solidity/=node_modules/crypto-lib/src/"
-  ],
+  "wake.compiler.solc.remappings": [],
   "vitest.maximumConfigs": 15,
   "vitest.disableWorkspaceWarning": true
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,12 +24,12 @@
     "prettier:write": "prettier --write \"**/*.{sol,json,js,md,yml,ts}\" --ignore-path \".prettierignore\""
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.2.0",
-    "@openzeppelin/contracts-upgradeable": "^5.2.0",
+    "@openzeppelin/contracts": "^5.3.0",
+    "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@prb/math": "^4.1.0",
-    "@towns-protocol/diamond": "^0.3.5",
+    "@towns-protocol/diamond": "^0.4.0",
     "crypto-lib": "github:towns-protocol/crypto-lib#f40c5f6944a55583a687b672ba680db3bfabb0ef",
-    "solady": "^0.1.12"
+    "solady": "^0.1.14"
   },
   "devDependencies": {
     "@prb/test": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,12 +5153,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts-upgradeable@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@openzeppelin/contracts-upgradeable@npm:5.2.0"
+"@openzeppelin/contracts-upgradeable@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@openzeppelin/contracts-upgradeable@npm:5.3.0"
   peerDependencies:
-    "@openzeppelin/contracts": 5.2.0
-  checksum: 5736d40287899e72e240acdcddd72961f792a0c90a22a96f2a6705aa01286ab99ca96e800567d763d66cf90b40d814fa1f1ff48844dfa0676b96a85edf9854b3
+    "@openzeppelin/contracts": 5.3.0
+  checksum: edc42740c5174a79ff82d99aeb88d4e40e7c3d8aa461c866760d4ba3ab2dcf22182cfd51b8ce950a89c673e66095c760c8e09143cce19217a485774450f150e7
   languageName: node
   linkType: hard
 
@@ -5169,10 +5169,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@openzeppelin/contracts@npm:5.2.0"
-  checksum: badff8c3be46b099c331e90ba27f75e36f7af681279952cf0b123c7448bc53cd541ef447de8e6ebc38e7b29aed8f17dacf0756aac5891eed03fe96a0a4eba1a0
+"@openzeppelin/contracts@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@openzeppelin/contracts@npm:5.3.0"
+  checksum: 1d1629c42d170e070c112779c33b3b81c133995695271bc62a696160b598b56455a3c56d1f976a42ee3dd426c4ad984451b1752139f2b7897c9e1ba56c1947da
   languageName: node
   linkType: hard
 
@@ -7712,11 +7712,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@towns-protocol/contracts@workspace:packages/contracts"
   dependencies:
-    "@openzeppelin/contracts": ^5.2.0
-    "@openzeppelin/contracts-upgradeable": ^5.2.0
+    "@openzeppelin/contracts": ^5.3.0
+    "@openzeppelin/contracts-upgradeable": ^5.3.0
     "@prb/math": ^4.1.0
     "@prb/test": ^0.6.4
-    "@towns-protocol/diamond": ^0.3.5
+    "@towns-protocol/diamond": ^0.4.0
     "@towns-protocol/prettier-config": "workspace:^"
     "@wagmi/cli": ^2.2.0
     account-abstraction: "github:eth-infinitism/account-abstraction"
@@ -7724,21 +7724,21 @@ __metadata:
     forge-std: "github:foundry-rs/forge-std#v1.9.6"
     prettier: ^2.8.8
     prettier-plugin-solidity: ^1.4.2
-    solady: ^0.1.12
+    solady: ^0.1.14
     solhint: ^5.0.5
     turbo: ^2.0.12
   languageName: unknown
   linkType: soft
 
-"@towns-protocol/diamond@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@towns-protocol/diamond@npm:0.3.5"
+"@towns-protocol/diamond@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@towns-protocol/diamond@npm:0.4.0"
   dependencies:
-    "@openzeppelin/contracts": ^5.2.0
+    "@openzeppelin/contracts": ^5.3.0
     "@prb/test": ^0.6.4
     forge-std: "github:foundry-rs/forge-std#v1.9.6"
-    solady: ^0.1.12
-  checksum: 56ee4ad899d8edc94eaf9686fff510947d6dc0cd19f496b095f98f6e955eec270c4f4d54148f8573d7b976fa0c23876e45a29ce12694e7b16de641c906aa3878
+    solady: ^0.1.14
+  checksum: c3840c1d11d666ba82a1c5f053162e61729a9cb8208680826e59843426163ad82dda1221cbff8d8a94761fd618cd5e1dafca8085996d2a017a7dba10fb922031
   languageName: node
   linkType: hard
 
@@ -12257,7 +12257,7 @@ __metadata:
   resolution: "crypto-lib@https://github.com/towns-protocol/crypto-lib.git#commit=f40c5f6944a55583a687b672ba680db3bfabb0ef"
   dependencies:
     forge-std: "github:foundry-rs/forge-std#v1.9.5"
-  checksum: 3c532fcdf54bf202dea49afad7e96dc90653635169cd51694344d83a568806554c7e734f3a73fa5892e10cd69f33ae4805e75cecc53c79dd9f2b9c96d6f81d4b
+  checksum: 4626d553772dbcbce89bc5d0b394bc200702e61ffc8fdee80f651e65c3fe7ab3ed95d9d3c3cd2500c3fa3450022a77a515208e68967547af7f600490ed506e76
   languageName: node
   linkType: hard
 
@@ -26243,10 +26243,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"solady@npm:^0.1.12":
-  version: 0.1.12
-  resolution: "solady@npm:0.1.12"
-  checksum: 1d2ffb9de7bd649018390d67c31fce42364432acdd68fc0aab55dae37a2468905b626431f152535beaa864f5a1c89c8678e4cd13a29024a6b1cda81852468e2b
+"solady@npm:^0.1.14":
+  version: 0.1.14
+  resolution: "solady@npm:0.1.14"
+  checksum: e6f71338251b8e4642bf012355e6f0274345d99cb886075980a7600dc126e3ddacbd5435c56e4d446b0d6248eb9005b62cf6f28672c2033827866620d0c4104e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgraded several package dependencies, including OpenZeppelin contracts (to 5.3.0), Towns Protocol Diamond (to 0.4.0), and Solady (to 0.1.14). Removed unused Solidity compiler remappings from `.vscode/settings.json` to simplify configuration.