### PR TITLE
node: use ForAllStreamsOnNode instead of ForAllStreams

### DIFF
--- a/core/cmd/registry_cmd.go
+++ b/core/cmd/registry_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -413,10 +412,8 @@ func getStreamsForNode(ctx context.Context, node common.Address) error {
 	fmt.Printf("#Streams:\n")
 	fmt.Printf("#========\n")
 
-	if err := registryContract.ForAllStreams(ctx, blockNum, func(result *river.StreamWithId) bool {
-		if slices.Contains(result.Nodes(), node) {
-			fmt.Println(result.StreamId().String())
-		}
+	if err := registryContract.ForAllStreamsOnNode(ctx, blockNum, node, func(result *river.StreamWithId) bool {
+		fmt.Println(result.StreamId().String())
 		return true
 	}); err != nil {
 		return err

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -127,13 +127,12 @@ func (s *StreamCache) Start(ctx context.Context) error {
 	// schedule sync tasks for all streams that are local to this node.
 	// these tasks sync up the local db with the latest block in the registry.
 	var localStreamResults []*river.StreamWithId
-	err := s.params.Registry.ForAllStreams(
+	err := s.params.Registry.ForAllStreamsOnNode(
 		ctx,
 		s.params.AppliedBlockNum,
+		s.params.Wallet.Address,
 		func(stream *river.StreamWithId) bool {
-			if slices.Contains(stream.Nodes(), s.params.Wallet.Address) {
-				localStreamResults = append(localStreamResults, stream)
-			}
+			localStreamResults = append(localStreamResults, stream)
 			return true
 		},
 	)


### PR DESCRIPTION
Use `StreamRegistry::getPaginatedStreamsOnNode` instead of `StreamRegistry::getPaginatedStreams` where possible. This will only load streams from the current node instead of iterating over all streams and grab streams on the local node.