### PR TITLE
Fix potential erroneous false entitlement check result

### DIFF
--- a/core/xchain/entitlement/entitlement.go
+++ b/core/xchain/entitlement/entitlement.go
@@ -27,11 +27,10 @@ func (e *Evaluator) EvaluateRuleData(
 	return e.evaluateOp(ctx, opTree, linkedWallets)
 }
 
-// isNoncancelationError returns true iff the error is the result of a failure when evaluating
-// an entitlement. It ignores context cancellations, which can occur when a operation evaluation
-// short-circuits because the other child returned a definitive answer.
+// isNoncancelationError returns true iff the error is non-nil and is also not due to a
+// context cancelation or timeout.
 func isNoncancelationError(err error) bool {
-	return err != nil && !errors.Is(err, context.Canceled)
+	return err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 // logIfEntitlementError conditionally logs an error if it was not a context cancellation.
@@ -43,7 +42,8 @@ func logIfEntitlementError(ctx context.Context, err error) {
 
 // composeEntitlementEvaluationError returns a composed error type that incorporates the error of
 // either child as long as that error is not a context cancellation, which we ignore because we
-// introduce it ourselves.
+// may introduce a single cancellation ourselves when short-circuiting. However, in the case that
+// both errors are cancellations, we consider this a true error.
 func composeEntitlementEvaluationError(leftErr error, rightErr error) error {
 	if isNoncancelationError(leftErr) && isNoncancelationError(rightErr) {
 		return fmt.Errorf("%w; %w", leftErr, rightErr)
@@ -55,15 +55,17 @@ func composeEntitlementEvaluationError(leftErr error, rightErr error) error {
 		return rightErr
 	}
 
-	// If both contexts were cancelled, assume this is due to rpc timeout and return this as an error.
-	// Note: for nested entitlements, we only manually trigger a cancellation if one of the entitlement
-	// checks resulted in a definitive answer, so we should never see two cancellations unless the parent
-	// context was itself cancelled.
-	if errors.Is(leftErr, context.Canceled) && errors.Is(rightErr, context.Canceled) {
-		return fmt.Errorf("%w; %w", leftErr, rightErr)
+	// If either error is nil, allow the other error to dictate the response
+	if leftErr == nil {
+		return rightErr
 	}
 
-	return nil
+	if rightErr == nil {
+		return leftErr
+	}
+
+	// If both errors are due to some type of cancellation, compose them.
+	return fmt.Errorf("%w; %w", leftErr, rightErr)
 }
 
 // evaluateAndOperation evaluates the results of it's two child operations, ANDs them, and
@@ -119,7 +121,11 @@ func (e *Evaluator) evaluateAndOperation(
 
 	// Evaluate definitive results and return them without error, logging if an evaluation error occurred.
 	// 1. Both checks are true - return true
-	// 2. If either check is false, was not cancelled, and did not fail - return false, as the user is not entitled.
+	// 2. If either check is false and produced no error - return false, as the user is not entitled.
+	// 3. If one of the errors was non-nil and not a cancellation or timeout, return it as the true cause of the
+	//    entitlement evaluation failure.
+	// 4. If both checks were cancelations/timeouts, consider this a true timeout, as the context cancellation cause
+	//    must have propogated from the parent.
 	if leftResult && rightResult {
 		return true, nil
 	}
@@ -195,6 +201,10 @@ func (e *Evaluator) evaluateOrOperation(
 		return true, nil
 	}
 
+	// -  If one of the errors was non-nil and not a cancellation or timeout, return it as the true cause of the
+	//    entitlement evaluation failure.
+	// -  If both checks were cancelations/timeouts, consider this a true timeout, as the context cancellation cause
+	//    must have propogated from the parent.
 	return false, composeEntitlementEvaluationError(leftErr, rightErr)
 }
 

--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -1,6 +1,7 @@
 package entitlement
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -22,8 +23,10 @@ import (
 )
 
 const (
-	slow = 500
-	fast = 10
+	verySlow     = 5000
+	checkTimeout = 1000
+	slow         = 500
+	fast         = 10
 )
 
 var (
@@ -36,7 +39,11 @@ var (
 	slowThresholdParams  = ThresholdParams{
 		Threshold: big.NewInt(slow),
 	}
-	slowEncodedParams, _ = slowThresholdParams.AbiEncode()
+	slowEncodedParams, _    = slowThresholdParams.AbiEncode()
+	verySlowThresholdParams = ThresholdParams{
+		Threshold: big.NewInt(verySlow),
+	}
+	verySlowEncodedParams, _ = verySlowThresholdParams.AbiEncode()
 )
 
 var fastTrueCheck = CheckOperation{
@@ -85,6 +92,15 @@ var slowErrorCheck = CheckOperation{
 	ChainID:         big.NewInt(0),
 	ContractAddress: common.HexToAddress("2"),
 	Params:          slowEncodedParams,
+}
+
+// This mock check will result in an error, but not until 5s have passed.
+var verySlowErrorCheck = CheckOperation{
+	OpType:          CHECK,
+	CheckType:       CheckOperationType(MOCK),
+	ChainID:         big.NewInt(0),
+	ContractAddress: common.HexToAddress("3"),
+	Params:          verySlowEncodedParams,
 }
 
 var (
@@ -359,8 +375,9 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	errSlow = fmt.Errorf("intentional failure (02)")
-	errFast = fmt.Errorf("intentional failure (01)")
+	errSlow    = fmt.Errorf("intentional failure (02)")
+	errFast    = fmt.Errorf("intentional failure (01)")
+	errTimeout = fmt.Errorf("operation cancelled: context deadline exceeded")
 )
 
 func TestAndOperation(t *testing.T) {
@@ -391,6 +408,7 @@ func TestAndOperation(t *testing.T) {
 		// Error handling
 		// For (error, true) - expect an error returned with the maximum execution time of both operations.
 		// For (error, false) - expect false returned with timing of false operation.
+
 		{"slow true, fast error", &slowTrueCheck, &fastErrorCheck, false, slow, errFast},
 		{"fast true, fast error", &fastTrueCheck, &fastErrorCheck, false, fast, errFast},
 		{"slow true, slow error", &slowTrueCheck, &slowErrorCheck, false, slow, errSlow},
@@ -415,6 +433,62 @@ func TestAndOperation(t *testing.T) {
 			slow,
 			fmt.Errorf("%w; %w", errFast, errSlow),
 		},
+		{
+			"fast error, timeout",
+			&fastErrorCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			errFast,
+		},
+		{
+			"timeout, fast error",
+			&verySlowErrorCheck,
+			&fastErrorCheck,
+			false,
+			checkTimeout,
+			errFast,
+		},
+		{
+			"fast true, timeout",
+			&fastTrueCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			errTimeout,
+		},
+		{
+			"timeout, fast true",
+			&verySlowErrorCheck,
+			&fastTrueCheck,
+			false,
+			checkTimeout,
+			errTimeout,
+		},
+		{
+			"fast false, timeout",
+			&fastFalseCheck,
+			&verySlowErrorCheck,
+			false,
+			fast,
+			nil,
+		},
+		{
+			"timeout, fast false",
+			&verySlowErrorCheck,
+			&fastFalseCheck,
+			false,
+			fast,
+			nil,
+		},
+		{
+			"timeout, timeout",
+			&verySlowErrorCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			fmt.Errorf("%w; %w", errTimeout, errTimeout),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -429,7 +503,9 @@ func TestAndOperation(t *testing.T) {
 
 			callerAddress := common.Address{}
 
-			result, actualErr := evaluator.evaluateOp(ctx, tree, []common.Address{callerAddress})
+			timeoutCtx, cancel := context.WithTimeout(ctx, checkTimeout*time.Millisecond)
+			defer cancel()
+			result, actualErr := evaluator.evaluateOp(timeoutCtx, tree, []common.Address{callerAddress})
 			elapsedTime := time.Since(startTime)
 			if tc.expectedErr != nil {
 				require.EqualError(t, actualErr, tc.expectedErr.Error(), "Expected error was not found")
@@ -501,6 +577,62 @@ func TestOrOperation(t *testing.T) {
 			slow,
 			fmt.Errorf("%w; %w", errFast, errSlow),
 		},
+		{
+			"fast error, timeout",
+			&fastErrorCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			errFast,
+		},
+		{
+			"timeout, fast error",
+			&verySlowErrorCheck,
+			&fastErrorCheck,
+			false,
+			checkTimeout,
+			errFast,
+		},
+		{
+			"fast true, timeout",
+			&fastTrueCheck,
+			&verySlowErrorCheck,
+			true,
+			fast,
+			nil,
+		},
+		{
+			"timeout, fast true",
+			&verySlowErrorCheck,
+			&fastTrueCheck,
+			true,
+			fast,
+			nil,
+		},
+		{
+			"fast false, timeout",
+			&fastFalseCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			errTimeout,
+		},
+		{
+			"timeout, fast false",
+			&verySlowErrorCheck,
+			&fastFalseCheck,
+			false,
+			checkTimeout,
+			errTimeout,
+		},
+		{
+			"timeout, timeout",
+			&verySlowErrorCheck,
+			&verySlowErrorCheck,
+			false,
+			checkTimeout,
+			fmt.Errorf("%w; %w", errTimeout, errTimeout),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -515,7 +647,9 @@ func TestOrOperation(t *testing.T) {
 
 			callerAddress := common.Address{}
 
-			result, actualErr := evaluator.evaluateOp(ctx, tree, []common.Address{callerAddress})
+			timeoutCtx, cancel := context.WithTimeout(ctx, checkTimeout*time.Millisecond)
+			defer cancel()
+			result, actualErr := evaluator.evaluateOp(timeoutCtx, tree, []common.Address{callerAddress})
 			elapsedTime := time.Since(startTime)
 			if tc.expectedErr != nil {
 				require.EqualError(t, actualErr, tc.expectedErr.Error(), "Expected error was not found")


### PR DESCRIPTION
If a nested entitlement contains two on-chain checks and chain unavailability causes rpc requests to lag until the context times out, these could have erroneously come back as a false entitlement result instead of an error result. I think it's very likely this would happen any time a chain or rpc provider is partially unavailable. This PR repairs the error for both AND and OR operators in entitlement trees.