### PR TITLE
Jt/update docker compose subgraph

### DIFF
--- a/packages/subgraph/.env.gamma
+++ b/packages/subgraph/.env.gamma
@@ -1,5 +1,5 @@
 PONDER_RPC_URL_1=https://base-sepolia.drpc.org
 # block as of 2025-04-02
-PONDER_START_BLOCK=8108862
+PONDER_START_BLOCK=9378183
 PONDER_ENVIRONMENT=gamma
 PONDER_CONFIG=ponder.config.gamma.ts

--- a/packages/subgraph/docker-compose-gamma.yml
+++ b/packages/subgraph/docker-compose-gamma.yml
@@ -12,13 +12,14 @@ services:
         environment:
             - POSTGRES_USER=postgres
             - POSTGRES_PASSWORD=postgres
-            - POSTGRES_DB=ponder
+            - POSTGRES_DB=postgres
         ports:
             - '5432:5432'
         volumes:
             - subgraph-db:/var/lib/postgresql/data
 
     subgraph:
+        # image: public.ecr.aws/h5v6m2x1/subgraph:dc7f113
         build:
             context: ../../
             dockerfile: packages/subgraph/Dockerfile
@@ -28,9 +29,12 @@ services:
         env_file:
             - .env.gamma
         environment:
-            - NODE_ENV=production
+            - NODE_ENV=development
             - DATABASE_SCHEMA=public
-            - DATABASE_URL=postgresql://postgres:postgres@subgraph-db:5432/ponder
+            - DB_HOST=subgraph-db
+            - DB_PORT=5432
+            - DB_USER=postgres
+            - DB_PASSWORD=postgres
         ports:
             - '42069:42069'
 

--- a/packages/subgraph/docker-entrypoint.sh
+++ b/packages/subgraph/docker-entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 set -u
 set -o pipefail
 
+# Default NODE_ENV to development if not set
+export NODE_ENV=${NODE_ENV:-development}
+echo "Using NODE_ENV=$NODE_ENV"
+
 # Check if DB_HOST is set
 if [ -z "${DB_HOST}" ]; then
   echo "DB_HOST is not set. Please set it to the database host."
@@ -31,4 +35,10 @@ fi
 # Build the pg db url:
 export DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres"
 
-yarn ponder start --config "${PONDER_CONFIG}"
+if [ "$NODE_ENV" = "development" ]; then
+  echo "Starting Ponder in development mode"
+  yarn ponder dev --config "${PONDER_CONFIG}"
+else
+  echo "Starting Ponder in production mode"
+  yarn ponder start --config "${PONDER_CONFIG}"
+fi

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -48,7 +48,7 @@ export default createConfig({
             startBlock,
             network: 'gamma',
         },
-        TokenPausableFacet: {
+        PausableFacet: {
             abi: tokenPausableFacetAbi,
             address: spaceFactory,
             startBlock,

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -1,4 +1,4 @@
-import { createConfig } from 'ponder'
+import { createConfig, mergeAbis } from 'ponder'
 import { http } from 'viem'
 
 // import abis
@@ -42,14 +42,8 @@ export default createConfig({
         },
     },
     contracts: {
-        CreateSpace: {
-            abi: createSpaceFacetAbi,
-            address: spaceFactory,
-            startBlock,
-            network: 'gamma',
-        },
-        PausableFacet: {
-            abi: tokenPausableFacetAbi,
+        SpaceFactory: {
+            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi]),
             address: spaceFactory,
             startBlock,
             network: 'gamma',

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -23,6 +23,11 @@ if (!spaceFactory) {
     throw new Error('Space factory address not found')
 }
 
+const spaceOwner = getContractAddress('spaceOwner')
+if (!spaceOwner) {
+    throw new Error('Space owner address not found')
+}
+
 export default createConfig({
     networks: {
         anvil: {
@@ -51,7 +56,7 @@ export default createConfig({
         },
         SpaceOwner: {
             abi: spaceOwnerAbi,
-            address: spaceFactory,
+            address: spaceOwner,
             startBlock,
             network: 'gamma',
         },

--- a/packages/subgraph/ponder.config.ts
+++ b/packages/subgraph/ponder.config.ts
@@ -22,6 +22,10 @@ const spaceFactory = getContractAddress('spaceFactory')
 if (!spaceFactory) {
     throw new Error('Space factory address not found')
 }
+const spaceOwner = getContractAddress('spaceOwner')
+if (!spaceOwner) {
+    throw new Error('Space owner address not found')
+}
 
 export default createConfig({
     networks: {
@@ -51,7 +55,7 @@ export default createConfig({
         },
         SpaceOwner: {
             abi: spaceOwnerAbi,
-            address: spaceFactory,
+            address: spaceOwner,
             startBlock,
             network: 'anvil',
         },

--- a/packages/subgraph/ponder.config.ts
+++ b/packages/subgraph/ponder.config.ts
@@ -1,4 +1,4 @@
-import { createConfig } from 'ponder'
+import { createConfig, mergeAbis } from 'ponder'
 import { http } from 'viem'
 
 // import abis
@@ -41,14 +41,8 @@ export default createConfig({
         },
     },
     contracts: {
-        CreateSpace: {
-            abi: createSpaceFacetAbi,
-            address: spaceFactory,
-            startBlock,
-            network: 'anvil',
-        },
-        PausableFacet: {
-            abi: tokenPausableFacetAbi,
+        SpaceFactory: {
+            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi]),
             address: spaceFactory,
             startBlock,
             network: 'anvil',

--- a/packages/subgraph/ponder.config.ts
+++ b/packages/subgraph/ponder.config.ts
@@ -47,7 +47,7 @@ export default createConfig({
             startBlock,
             network: 'anvil',
         },
-        TokenPausableFacet: {
+        PausableFacet: {
             abi: tokenPausableFacetAbi,
             address: spaceFactory,
             startBlock,

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -11,17 +11,17 @@ async function getLatestBlockNumber() {
     return await publicClient.getBlockNumber()
 }
 
-ponder.on('CreateSpace:SpaceCreated', async ({ event, context }) => {
+ponder.on('SpaceFactory:SpaceCreated', async ({ event, context }) => {
     // Get latest block number
     const blockNumber = await getLatestBlockNumber()
-    const { SpaceOwner, PausableFacet } = context.contracts
+    const { SpaceFactory, SpaceOwner } = context.contracts
 
     let paused = false
 
     try {
         paused = await context.client.readContract({
-            abi: PausableFacet.abi,
-            address: PausableFacet.address,
+            abi: SpaceFactory.abi,
+            address: SpaceFactory.address,
             functionName: 'paused',
             args: [],
             blockNumber, // Use the latest block number
@@ -59,7 +59,7 @@ ponder.on('CreateSpace:SpaceCreated', async ({ event, context }) => {
 ponder.on('SpaceOwner:SpaceOwner__UpdateSpace', async ({ event, context }) => {
     // Get latest block number
     const blockNumber = await getLatestBlockNumber()
-    const { SpaceOwner, PausableFacet } = context.contracts
+    const { SpaceFactory, SpaceOwner } = context.contracts
 
     const space = await context.db.sql.query.space.findFirst({
         where: eq(schema.space.id, event.args.space),
@@ -72,8 +72,8 @@ ponder.on('SpaceOwner:SpaceOwner__UpdateSpace', async ({ event, context }) => {
 
     try {
         paused = await context.client.readContract({
-            abi: PausableFacet.abi,
-            address: PausableFacet.address,
+            abi: SpaceFactory.abi,
+            address: SpaceFactory.address,
             functionName: 'paused',
             args: [],
             blockNumber, // Use the latest block number

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -16,22 +16,15 @@ ponder.on('SpaceFactory:SpaceCreated', async ({ event, context }) => {
     const blockNumber = await getLatestBlockNumber()
     const { SpaceFactory, SpaceOwner } = context.contracts
 
-    let paused = false
-
     try {
-        paused = await context.client.readContract({
+        const paused = await context.client.readContract({
             abi: SpaceFactory.abi,
             address: SpaceFactory.address,
             functionName: 'paused',
             args: [],
             blockNumber, // Use the latest block number
         })
-    } catch (pausedError) {
-        console.error(`Error fetching paused status at blockNumber ${blockNumber}:`, pausedError)
-        console.log(`Defaulting paused status to false for space ${event.args.space}`)
-    }
 
-    try {
         const space = await context.client.readContract({
             abi: SpaceOwner.abi,
             address: SpaceOwner.address,
@@ -52,7 +45,10 @@ ponder.on('SpaceFactory:SpaceCreated', async ({ event, context }) => {
             paused: paused,
         })
     } catch (error) {
-        console.error(`Error fetching space info at blockNumber ${blockNumber}:`, error)
+        console.error(
+            `Error processing SpaceFactory:SpaceCreated at blockNumber ${blockNumber}:`,
+            error,
+        )
     }
 })
 
@@ -65,25 +61,19 @@ ponder.on('SpaceOwner:SpaceOwner__UpdateSpace', async ({ event, context }) => {
         where: eq(schema.space.id, event.args.space),
     })
     if (!space) {
+        console.warn(`Space not found for SpaceOwner:SpaceOwner__UpdateSpace`, event.args.space)
         return
     }
 
-    let paused = false
-
     try {
-        paused = await context.client.readContract({
+        const paused = await context.client.readContract({
             abi: SpaceFactory.abi,
             address: SpaceFactory.address,
             functionName: 'paused',
             args: [],
             blockNumber, // Use the latest block number
         })
-    } catch (pausedError) {
-        console.error(`Error fetching paused status at blockNumber ${blockNumber}:`, pausedError)
-        console.log(`Defaulting paused status to false for space ${event.args.space}`)
-    }
 
-    try {
         const spaceInfo = await context.client.readContract({
             abi: SpaceOwner.abi,
             address: SpaceOwner.address,
@@ -103,6 +93,9 @@ ponder.on('SpaceOwner:SpaceOwner__UpdateSpace', async ({ event, context }) => {
             })
             .where(eq(schema.space.id, event.args.space))
     } catch (error) {
-        console.error(`Error fetching space info at blockNumber ${blockNumber}:`, error)
+        console.error(
+            `Error processing SpaceOwner:SpaceOwner__UpdateSpace at blockNumber ${blockNumber}:`,
+            error,
+        )
     }
 })


### PR DESCRIPTION
- fixes docker-compose file that did not inject correct DB vars
- fixes abi read bug. Facets need to have their abi merged given we're addressing them by their diamond address.
- try...catch blocks added to handlers with logging
- when NODE_ENV=development starts development server which does not have strict requirements on schema uniqueness per instance.