### PR TITLE
Update audit tool to examine stream disk usage

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -39,6 +39,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.37.0
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 	golang.org/x/net v0.38.0
 	golang.org/x/text v0.24.0
 	golang.org/x/tools v0.31.0
@@ -70,7 +71,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	google.golang.org/grpc v1.68.0 // indirect
@@ -132,7 +132,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/core/tools/audit_db/README.md
+++ b/core/tools/audit_db/README.md
@@ -44,6 +44,8 @@ To find the total size in bytes of stream data stored for each stream, run:
 
 Be sure to have your schema specified in the environment.
 
+If you see any concerning streams, they can be manually inspected using the migrate tool. See the `target inspect` command in `core/tools/migrate_db`.
+
 ## Run audit tool to check for and repair streams with >> miniblock candidates
 
 To find streams that have at least one candidate in storage, run

--- a/core/tools/audit_db/README.md
+++ b/core/tools/audit_db/README.md
@@ -54,7 +54,6 @@ Concerning streams can be further examined with
 
     ./river_audit_db inspect stream <stream-id>
 
-
 ## Run audit tool to check for and repair streams with >> miniblock candidates
 
 To find streams that have at least one candidate in storage, run

--- a/core/tools/audit_db/README.md
+++ b/core/tools/audit_db/README.md
@@ -8,10 +8,11 @@ Update `river_audit_db.env` with correct parameters.
 
 The DB can be live while the tool is running.
 
-go build -o river_audit_db .
+    # Build tool
+    go build -o river_audit_db .
 
-./river_audit_db help
-./river_audit_db test -- test db connection
+    # See help message
+    ./river_audit_db help
 
 ### Help
 
@@ -25,15 +26,33 @@ List of env vars or settings in `river_audit_db.env`:
     RIVER_DB_PASSWORD  # if unset here or in URL, read from .pgpass
     RIVER_DB_SCHEMA
 
+## Tool setup
+
+To test environment settings, run
+
+    ./river_audit_db test
+
+To list schemas, run
+
+    ./river_audit_db list
+
+## Run audit tool to examine stream disk usage
+
+To find the total size in bytes of stream data stored for each stream, run:
+
+    ./river_audit_db usage
+
+Be sure to have your schema specified in the environment.
+
 ## Run audit tool to check for and repair streams with >> miniblock candidates
 
 To find streams that have at least one candidate in storage, run
 
-./river_audit_db check candidates > streams_with_candidates.txt
+    ./river_audit_db check candidates > streams_with_candidates.txt
 
 To repair these streams: from the `core` directory, run
 
-`./scripts/get_gamma_streams.py tools/audit_db/streams_with_candidates.txt`
+    ./scripts/get_gamma_streams.py tools/audit_db/streams_with_candidates.txt
 
 in order to call the GetStream rpc on each stream with a candidate. This tool will print out which streams have successfully advanced, and which have failed to advance. Call the script at least twice in order to provoke the node to make new miniblocks for all streams with high candidate count, and then again to confirm that all streams are advancing.
 

--- a/core/tools/audit_db/README.md
+++ b/core/tools/audit_db/README.md
@@ -44,7 +44,16 @@ To find the total size in bytes of stream data stored for each stream, run:
 
 Be sure to have your schema specified in the environment.
 
-If you see any concerning streams, they can be manually inspected using the migrate tool. See the `target inspect` command in `core/tools/migrate_db`.
+## List all streams in a schema
+
+    ./river_audit_db list streams
+
+## Manually inspect streams
+
+Concerning streams can be further examined with
+
+    ./river_audit_db inspect stream <stream-id>
+
 
 ## Run audit tool to check for and repair streams with >> miniblock candidates
 

--- a/core/tools/audit_db/inspect.go
+++ b/core/tools/audit_db/inspect.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/storage"
+)
+
+func getStreamIds(ctx context.Context, pool *pgxpool.Pool) ([]string, []int64, []bool, error) {
+	rows, _ := pool.Query(ctx, "SELECT stream_id, latest_snapshot_miniblock, migrated FROM es ORDER BY stream_id")
+
+	var ids []string
+	var miniblocks []int64
+	var migrateds []bool
+	var id string
+	var miniblock int64
+	var migrated bool
+	_, err := pgx.ForEachRow(rows, []any{&id, &miniblock, &migrated}, func() error {
+		ids = append(ids, id)
+		miniblocks = append(miniblocks, miniblock)
+		migrateds = append(migrateds, migrated)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, wrapError("Failed to read es table", err)
+	}
+	return ids, miniblocks, migrateds, nil
+}
+
+var listStreamsCmd = &cobra.Command{
+	Use:   "streams",
+	Short: "List database streams",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		pool, _, err := getDbPool(ctx, true)
+		if err != nil {
+			return err
+		}
+
+		streamIds, _, _, err := getStreamIds(ctx, pool)
+		if err != nil {
+			fmt.Println("Error reading stream ids:", err)
+			os.Exit(1)
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(
+			[]string{
+				"Stream ID",
+			},
+		)
+		for _, id := range streamIds {
+			table.Append([]string{id})
+		}
+		table.Render()
+		return nil
+	},
+}
+
+func getPartitionSuffix(streamId string) string {
+	sharedStreamId, err := shared.StreamIdFromString(streamId)
+	if err != nil {
+		fmt.Println("Bad stream id: ", streamId)
+		os.Exit(1)
+	}
+	return fmt.Sprintf("_%v", storage.CreatePartitionSuffix(sharedStreamId, 256))
+}
+
+func inspectStream(ctx context.Context, pool *pgxpool.Pool, streamId string) error {
+	var migrated bool
+	var latestSnapshotMiniblock int
+
+	err := pool.QueryRow(
+		ctx,
+		"SELECT latest_snapshot_miniblock, migrated from es where stream_id = $1",
+		streamId,
+	).Scan(&latestSnapshotMiniblock, &migrated)
+	if err != nil {
+		fmt.Println("Error reading stream from es table:", err)
+		os.Exit(1)
+	}
+
+	suffix := getPartitionSuffix(streamId)
+	rows, err := pool.Query(
+		ctx,
+		escapeSql(
+			`SELECT stream_id, seq_num, blockdata from {{miniblocks}}
+			WHERE stream_id = $1 order by seq_num `,
+			suffix,
+		),
+		streamId,
+	)
+	if err != nil {
+		fmt.Println("Error reading stream miniblocks:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Miniblocks (seq_num, blockdata)")
+	fmt.Println("==========================================")
+	for rows.Next() {
+		var id string
+		var seqNum int64
+		var blockData []byte
+		if err := rows.Scan(&id, &seqNum, &blockData); err != nil {
+			fmt.Println("Error scanning miniblock row:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%v %v\n", seqNum, hex.EncodeToString(blockData))
+	}
+	fmt.Println()
+
+	rows, err = pool.Query(
+		ctx,
+		escapeSql(
+			`SELECT stream_id, seq_num, block_hash, blockdata from {{miniblock_candidates}}
+			WHERE stream_id = $1 order by seq_num, block_hash`,
+			suffix,
+		),
+		streamId,
+	)
+	if err != nil {
+		fmt.Println("Error reading stream miniblock candidates :", err)
+	} else {
+		fmt.Println("Miniblock Candidates (seq_num, block_hash, block_data)")
+		fmt.Println("==================================================================")
+		for rows.Next() {
+			var id string
+			var seqNum int64
+			var hashStr string
+			var blockData []byte
+			if err := rows.Scan(&id, &seqNum, &hashStr, &blockData); err != nil {
+				fmt.Println("Error scanning miniblock candidate row:", err)
+				os.Exit(1)
+			}
+			fmt.Printf("%v %v %v\n", seqNum, hashStr, hex.EncodeToString(blockData))
+		}
+		fmt.Println()
+	}
+
+	rows, err = pool.Query(
+		ctx,
+		escapeSql(
+			`SELECT stream_id, generation, slot_num, envelope from {{minipools}}
+			WHERE stream_id = $1 order by generation, slot_num`,
+			suffix,
+		),
+		streamId,
+	)
+	if err != nil {
+		fmt.Println("Error reading stream minipools:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Minipools (stream_id, generation, slot_num, envelope)")
+	fmt.Println("=====================================================")
+	for rows.Next() {
+		var id string
+		var generation int64
+		var slotNum int64
+		var envelope []byte
+		if err := rows.Scan(&id, &generation, &slotNum, &envelope); err != nil {
+			fmt.Println("Error scanning miniblock row:", err)
+			os.Exit(1)
+		}
+		envelopeString := hex.EncodeToString(envelope)
+		if envelopeString == "" {
+			envelopeString = "<empty>"
+		}
+		fmt.Printf("%v %v %v\n", generation, slotNum, envelopeString)
+	}
+	fmt.Println()
+
+	return nil
+}
+
+var inspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Inspect stream data on database",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		// Valid stream id?
+		streamId, err := shared.StreamIdFromString(args[0])
+		if err != nil {
+			return fmt.Errorf("could not parse streamId: %w", err)
+		}
+
+		pool, _, err := getDbPool(ctx, true)
+		if err != nil {
+			return wrapError("Failed to initialize target database pool", err)
+		}
+
+		return inspectStream(ctx, pool, streamId.String())
+	},
+}
+
+func init() {
+	listCmd.AddCommand(listStreamsCmd)
+	rootCmd.AddCommand(inspectCmd)
+}

--- a/core/tools/audit_db/river_audit_db.go
+++ b/core/tools/audit_db/river_audit_db.go
@@ -156,6 +156,11 @@ func init() {
 
 var listCmd = &cobra.Command{
 	Use:   "list",
+	Short: "List database contents",
+}
+
+var listSchemasCmd = &cobra.Command{
+	Use:   "schemas",
 	Short: "List database schemas",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -184,6 +189,7 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
+	listCmd.AddCommand(listSchemasCmd)
 	rootCmd.AddCommand(listCmd)
 }
 

--- a/core/tools/audit_db/river_audit_db.go
+++ b/core/tools/audit_db/river_audit_db.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -49,13 +50,15 @@ func getPgxDbPool(
 	if err != nil {
 		return nil, err
 	}
-
+	cfg.ConnConfig.OnNotice = func(c *pgconn.PgConn, n *pgconn.Notice) {
+		fmt.Printf("NOTICE: %s\n", n.Message)
+	}
 	if password != "" {
 		cfg.ConnConfig.Password = password
 	}
 
 	if db.schema != "" {
-		cfg.ConnConfig.RuntimeParams["search_path"] = db.schema
+		cfg.ConnConfig.RuntimeParams["search_path"] = fmt.Sprintf("pg_temp, %v, public", db.schema)
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)

--- a/core/tools/audit_db/stream_disk_usage.go
+++ b/core/tools/audit_db/stream_disk_usage.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// Format this with the desired schema name
+// This query uses temporary tables that may be written to disk, but they should not last beyond
+// the length of the session.
+const generateReportSql = `
+DO $$
+DECLARE
+    tbl RECORD;
+    r RECORD;
+    schema_name TEXT := '{{schemaName}}';
+
+    -- Prefixes, result table names, and size columns
+    table_patterns TEXT[] := ARRAY['miniblocks_%', 'miniblock_candidates_%', 'minipools_%'];
+    result_tables TEXT[] := ARRAY['tmp_miniblocks', 'tmp_miniblock_candidates', 'tmp_minipools'];
+    size_columns  TEXT[] := ARRAY['blockdata', 'blockdata', 'envelope'];
+    snapshot_columns TEXT[] := ARRAY['snapshot', 'snapshot', NULL];
+
+    i INT;
+    pattern TEXT;
+    result_table TEXT;
+    data_col TEXT;
+    snapshot_col TEXT;
+    dyn_sql TEXT;
+BEGIN
+    -- Create result tables
+    FOR i IN 1..array_length(result_tables, 1) LOOP
+        EXECUTE format('
+            CREATE TEMP TABLE IF NOT EXISTS %I (
+                stream_id TEXT,
+                total_bytes BIGINT,
+                row_count BIGINT,
+                snapshot_bytes BIGINT DEFAULT 0,
+                total_snapshots BIGINT DEFAULT 0
+            ) ON COMMIT DROP',
+            result_tables[i]
+        );
+    END LOOP;
+
+    -- Process each pattern group
+    FOR i IN 1..array_length(result_tables, 1) LOOP
+        pattern      := table_patterns[i];
+        result_table := result_tables[i];
+        data_col     := size_columns[i];
+        snapshot_col := snapshot_columns[i];
+
+        FOR tbl IN
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = schema_name
+              AND table_name LIKE pattern
+        LOOP
+            BEGIN
+                dyn_sql := format(
+                    'INSERT INTO %I
+                     SELECT stream_id,
+					 COALESCE(SUM(octet_length(%I))::BIGINT, 0) as total_bytes,
+					 COUNT(*) as row_count
+                     FROM %I.%I
+                     GROUP BY stream_id',
+                    result_table, data_col, schema_name, tbl.table_name
+                );
+
+                EXECUTE dyn_sql;
+
+				-- Snapshot size aggregation, if applicable
+				IF snapshot_col IS NOT NULL THEN
+					dyn_sql := format(
+						'WITH agg AS (
+							SELECT stream_id,
+								SUM(octet_length(%I))::BIGINT AS snapshot_bytes,
+								COUNT(*) FILTER (WHERE octet_length(%I) > 0) AS snapshot_count
+							FROM %I.%I
+							GROUP BY stream_id
+						)
+						UPDATE %I t
+						SET snapshot_bytes = agg.snapshot_bytes,
+							total_snapshots = agg.snapshot_count
+						FROM agg
+						WHERE t.stream_id = agg.stream_id',
+						snapshot_col, snapshot_col, schema_name, tbl.table_name, result_table
+					);
+					EXECUTE dyn_sql;
+				END IF;
+
+            EXCEPTION
+                WHEN others THEN
+                    RAISE NOTICE 'Skipping table % for pattern % due to error: %',
+                        tbl.table_name, pattern, SQLERRM;
+            END;
+        END LOOP;
+    END LOOP;
+END $$;
+`
+
+const viewReportSql = `
+SELECT
+    COALESCE(tm.stream_id, tmc.stream_id, tmp.stream_id) AS stream_id,
+	(COALESCE(tm.total_bytes, 0) + COALESCE(tmc.total_bytes, 0) + COALESCE(tmp.total_bytes, 0)) as total_bytes,
+	COALESCE(tm.total_bytes, 0) AS miniblock_bytes,
+	COALESCE(tm.row_count, 0)  AS miniblock_count,
+	COALESCE(tm.snapshot_bytes, 0) AS miniblock_snapshot_bytes,
+	COALESCE(tm.total_snapshots, 0)  AS miniblock_total_snapshots,
+	COALESCE(tmc.total_bytes, 0) AS miniblock_candidate_bytes,
+	COALESCE(tmc.row_count, 0)  AS miniblock_candidate_count,
+	COALESCE(tmc.snapshot_bytes, 0) AS candidate_snapshot_bytes,
+	COALESCE(tmc.total_snapshots, 0)  AS candidate_total_snapshots,
+	COALESCE(tmp.total_bytes, 0) AS minipool_bytes,
+	COALESCE(tmp.row_count, 0)  AS minipool_count
+FROM tmp_miniblocks tm
+FULL OUTER JOIN tmp_miniblock_candidates tmc ON tm.stream_id = tmc.stream_id
+FULL OUTER JOIN tmp_minipools tmp ON COALESCE(tm.stream_id, tmc.stream_id) = tmp.stream_id
+ORDER BY total_bytes DESC;
+`
+
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func printUsageReport(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	info *dbInfo,
+) (err error) {
+	escapedSql := strings.ReplaceAll(generateReportSql, "{{schemaName}}", info.schema)
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to create a pgx transaction: %w", err)
+	}
+
+	// Rollback and capture any additional errors on tx failure
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+				err = fmt.Errorf("%w; Failed to roll back (%w)", err, rollbackErr)
+			}
+		}
+	}()
+
+	if _, err = tx.Exec(ctx, escapedSql); err != nil {
+		return fmt.Errorf("error generating stream disk usage report for schema %v: %w", info.schema, err)
+	}
+
+	rows, err := tx.Query(ctx, viewReportSql)
+	if err != nil {
+		return fmt.Errorf("error generating stream disk usage report: %w", err)
+	}
+
+	var (
+		streamIdHex                     string
+		totalBytes                      int64
+		miniblockBytes                  int64
+		miniblockCount                  int64
+		miniblockSnapshotBytes          int64
+		miniblockSnapshotCount          int64
+		miniblockCandidateBytes         int64
+		miniblockCandidateCount         int64
+		miniblockCandidateSnapshotBytes int64
+		miniblockCandidateSnapshotCount int64
+		minipoolBytes                   int64
+		minipoolCount                   int64
+	)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(
+		[]string{
+			"Stream ID",
+			"Total Bytes",
+			"MB bytes",
+			"# MBs",
+			"MB snap bytes",
+			"# MB snaps",
+			"MB Cand Bytes",
+			"# MBCs",
+			"MBC Snap Bytes",
+			"# MBC Snaps",
+			"Minipool Bytes",
+			"# MP Count",
+		},
+	)
+
+	if _, err := pgx.ForEachRow(
+		rows,
+		[]any{
+			&streamIdHex,
+			&totalBytes,
+			&miniblockBytes,
+			&miniblockCount,
+			&miniblockSnapshotBytes,
+			&miniblockSnapshotCount,
+			&miniblockCandidateBytes,
+			&miniblockCandidateCount,
+			&miniblockCandidateSnapshotBytes,
+			&miniblockCandidateSnapshotCount,
+			&minipoolBytes,
+			&minipoolCount,
+		},
+		func() error {
+			table.Append([]string{
+				streamIdHex,
+				formatBytes(totalBytes),
+				formatBytes(miniblockBytes),
+				fmt.Sprintf("%d", miniblockCount),
+				formatBytes(miniblockSnapshotBytes),
+				fmt.Sprintf("%d", miniblockSnapshotCount),
+				formatBytes(miniblockCandidateBytes),
+				fmt.Sprintf("%d", miniblockCandidateCount),
+				formatBytes(miniblockCandidateSnapshotBytes),
+				fmt.Sprintf("%d", miniblockCandidateSnapshotCount),
+				formatBytes(minipoolBytes),
+				fmt.Sprintf("%d", minipoolCount),
+			})
+			return nil
+		},
+	); err != nil {
+		return fmt.Errorf("error scanning usage results: %w", err)
+	}
+
+	table.Render()
+
+	return tx.Commit(ctx)
+}
+
+var usageCmd = &cobra.Command{
+	Use:   "usage",
+	Short: "Generate usage report for schema",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		pool, info, err := getDbPool(ctx, true)
+		if err != nil {
+			return err
+		}
+
+		return printUsageReport(ctx, pool, info)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(usageCmd)
+}


### PR DESCRIPTION
Update the audit tool to print a detailed report of stream contents in the database so we can investigate why disk usage seems to be growing exponentially for some operators.