### PR TITLE
Snapshot migration to flush lost session ids

### DIFF
--- a/core/node/events/migrations/migrate_snapshot.go
+++ b/core/node/events/migrations/migrate_snapshot.go
@@ -12,6 +12,7 @@ var MIGRATIONS = []migrationFunc{
 	snapshot_migration_0001,
 	snapshot_migration_0002,
 	snapshot_migration_0003,
+	snapshot_migration_0004,
 }
 
 func CurrentSnapshotVersion() int32 {

--- a/core/node/events/migrations/snapshot_migration_0004.go
+++ b/core/node/events/migrations/snapshot_migration_0004.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"encoding/hex"
+	"slices"
+
+	. "github.com/towns-protocol/towns/core/node/protocol"
+)
+
+func snapshot_migration_0004(iSnapshot *Snapshot) *Snapshot {
+	return snapshot_migration_0004_(iSnapshot, false)
+}
+
+func snapshot_migration_0004_(iSnapshot *Snapshot, force bool) *Snapshot {
+	if iSnapshot.Members == nil || (len(iSnapshot.Members.Joined) < 500 && !force) {
+		return iSnapshot
+	}
+
+	members := iSnapshot.Members.Joined
+	sessionIdCounts := make(map[string]int)
+	memberCount := len(members)
+	threshold := max(memberCount/4, 2) // 25% threshold, minimum 2 for testing
+
+	for _, member := range members {
+		processedIds := make(map[string]bool) // Track IDs processed for this member
+
+		if len(member.Solicitations) == 0 {
+			continue
+		}
+
+		for _, solicitation := range member.Solicitations {
+			if len(solicitation.SessionIds) == 0 {
+				continue
+			}
+
+			for _, sessionId := range solicitation.SessionIds {
+				if !processedIds[sessionId] {
+					processedIds[sessionId] = true
+					sessionIdCounts[sessionId]++
+				}
+			}
+		}
+	}
+
+	var lostSessionIds []string
+	for sessionId, count := range sessionIdCounts {
+		if count > threshold {
+			lostSessionIds = append(lostSessionIds, sessionId)
+		}
+	}
+	slices.Sort(lostSessionIds)
+
+	if len(lostSessionIds) > 0 {
+		lostSessionIdsSet := make(map[string]bool)
+		for _, id := range lostSessionIds {
+			lostSessionIdsSet[id] = true
+		}
+
+		numRemove := 0
+		usernamesCleared := 0
+		displayNamesCleared := 0
+
+		for _, member := range members {
+			// Remove common session IDs from solicitations
+			for _, solicitation := range member.Solicitations {
+				before := len(solicitation.SessionIds)
+				var newSessionIds []string
+				for _, sessionId := range solicitation.SessionIds {
+					if !lostSessionIdsSet[sessionId] {
+						newSessionIds = append(newSessionIds, sessionId)
+					}
+				}
+				solicitation.SessionIds = newSessionIds
+				numRemove += before - len(newSessionIds)
+			}
+
+			// Clear lost usernames and display names
+			if member.Username != nil && member.Username.Data != nil {
+				if (member.Username.Data.SessionId != "" && lostSessionIdsSet[member.Username.Data.SessionId]) ||
+					(len(member.Username.Data.SessionIdBytes) > 0 &&
+						lostSessionIdsSet[hex.EncodeToString(member.Username.Data.SessionIdBytes)]) {
+					member.Username = nil
+					usernamesCleared++
+				}
+			}
+
+			if member.DisplayName != nil && member.DisplayName.Data != nil {
+				if (member.DisplayName.Data.SessionId != "" && lostSessionIdsSet[member.DisplayName.Data.SessionId]) ||
+					(len(member.DisplayName.Data.SessionIdBytes) > 0 &&
+						lostSessionIdsSet[hex.EncodeToString(member.DisplayName.Data.SessionIdBytes)]) {
+					member.DisplayName = nil
+					displayNamesCleared++
+				}
+			}
+		}
+	}
+
+	return iSnapshot
+}

--- a/core/node/events/migrations/snapshot_migration_0004.go
+++ b/core/node/events/migrations/snapshot_migration_0004.go
@@ -7,6 +7,12 @@ import (
 	. "github.com/towns-protocol/towns/core/node/protocol"
 )
 
+/**
+ * One time fix migration to remove lost sessionIds from key solicitations
+ * Loop over all Member objects, count sessionIds across solicitations
+ * and log those appearing in get 25% of members, checking if they map to
+ * username or display_name encrypted payloads
+ */
 func snapshot_migration_0004(iSnapshot *Snapshot) *Snapshot {
 	return snapshot_migration_0004_(iSnapshot, false)
 }

--- a/core/node/events/migrations/snapshot_migration_0004_test.go
+++ b/core/node/events/migrations/snapshot_migration_0004_test.go
@@ -1,0 +1,143 @@
+package migrations
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/proto"
+
+	. "github.com/towns-protocol/towns/core/node/protocol"
+	"github.com/towns-protocol/towns/core/node/shared"
+)
+
+func TestSnapshotMigration0004(t *testing.T) {
+	// Test case 1: Run migration with common session IDs
+	t.Run("with common session IDs", func(t *testing.T) {
+		commonSessionIdBytes := []byte("common-session-id")
+		commonSessionId := hex.EncodeToString(commonSessionIdBytes)
+		spaceId, err := shared.MakeSpaceId()
+		require.NoError(t, err)
+
+		snap := &Snapshot{
+			Content: &Snapshot_SpaceContent{
+				SpaceContent: &SpacePayload_Snapshot{
+					Inception: &SpacePayload_Inception{
+						StreamId: spaceId[:],
+					},
+				},
+			},
+			Members: &MemberPayload_Snapshot{
+				Joined: []*MemberPayload_Snapshot_Member{
+					{
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{commonSessionId, "unique1_a"}},
+							{SessionIds: []string{commonSessionId, "unique1_b"}},
+						},
+						Username: &WrappedEncryptedData{
+							Data: &EncryptedData{
+								SessionId: commonSessionId,
+								Algorithm: "test-algo",
+							},
+						},
+						DisplayName: &WrappedEncryptedData{
+							Data: &EncryptedData{
+								SessionIdBytes: commonSessionIdBytes,
+								Algorithm:      "test-algo",
+							},
+						},
+					},
+					{
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{commonSessionId, "unique2"}},
+						},
+						Username: &WrappedEncryptedData{
+							Data: &EncryptedData{
+								SessionIdBytes: commonSessionIdBytes,
+								Algorithm:      "test-algo",
+							},
+						},
+					},
+					{
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{commonSessionId, "unique3"}},
+						},
+					},
+					{
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{"unique4"}},
+						},
+					},
+				},
+			},
+		}
+
+		result := snapshot_migration_0004_(snap, true)
+
+		// Verify that common session IDs are removed
+		for _, member := range result.GetMembers().GetJoined() {
+			for _, solicitation := range member.GetSolicitations() {
+				require.NotContains(t, solicitation.GetSessionIds(), commonSessionId)
+			}
+
+			// Verify that usernames and display names with common session IDs are cleared
+			if member.GetUsername() != nil {
+				require.NotEqual(t, member.GetUsername().GetData().GetSessionId(), commonSessionId)
+				if len(member.GetUsername().GetData().GetSessionIdBytes()) > 0 {
+					require.NotEqual(t, string(member.GetUsername().GetData().GetSessionIdBytes()), commonSessionId)
+				}
+			}
+
+			if member.GetDisplayName() != nil {
+				require.NotEqual(t, member.GetDisplayName().GetData().GetSessionId(), commonSessionId)
+				if len(member.GetDisplayName().GetData().GetSessionIdBytes()) > 0 {
+					require.NotEqual(t, string(member.GetDisplayName().GetData().GetSessionIdBytes()), commonSessionId)
+				}
+			}
+		}
+	})
+
+	// Test case 2: Run migration with empty members
+	t.Run("with empty members", func(t *testing.T) {
+		snap := &Snapshot{}
+		result := snapshot_migration_0004_(snap, true)
+		require.Equal(t, snap, result)
+	})
+
+	// Test case 3: Run migration with no common session IDs
+	t.Run("with no common session IDs", func(t *testing.T) {
+		snap := &Snapshot{
+			Members: &MemberPayload_Snapshot{
+				Joined: []*MemberPayload_Snapshot_Member{
+					{
+						UserAddress: []byte("member1"),
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{"unique1", "unique2"}},
+						},
+						Username: &WrappedEncryptedData{
+							Data: &EncryptedData{
+								SessionId: "unique3",
+								Algorithm: "test-algo",
+							},
+						},
+					},
+					{
+						UserAddress: []byte("member2"),
+						Solicitations: []*MemberPayload_KeySolicitation{
+							{SessionIds: []string{"unique4", "unique5"}},
+						},
+					},
+				},
+			},
+		}
+
+		snapCopy, err := proto.Marshal(snap)
+		require.NoError(t, err)
+		result := snapshot_migration_0004_(snap, true)
+		// Verify the snapshot remains unchanged when no common session IDs are found
+		resultBytes, err := proto.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, snapCopy, resultBytes)
+	})
+}

--- a/packages/sdk/src/migrations/migrateSnapshot.ts
+++ b/packages/sdk/src/migrations/migrateSnapshot.ts
@@ -3,12 +3,14 @@ import { snapshotMigration0000 } from './snapshotMigration0000'
 import { snapshotMigration0001 } from './snapshotMigration0001'
 import { snapshotMigration0002 } from './snapshotMigration0002'
 import { snapshotMigration0003 } from './snapshotMigration0003'
+import { snapshotMigration0004 } from './snapshotMigration0004'
 
 const SNAPSHOT_MIGRATIONS = [
     snapshotMigration0000,
     snapshotMigration0001,
     snapshotMigration0002,
     snapshotMigration0003,
+    snapshotMigration0004,
 ]
 
 export function migrateSnapshot(snapshot: Snapshot): Snapshot {

--- a/packages/sdk/src/migrations/snapshotMigration0004.ts
+++ b/packages/sdk/src/migrations/snapshotMigration0004.ts
@@ -1,0 +1,112 @@
+import { bin_toHexString, dlogger } from '@towns-protocol/dlog'
+import { Snapshot, SnapshotSchema } from '@towns-protocol/proto'
+import { SpaceIdFromSpaceAddress } from '@towns-protocol/web3'
+import { removeCommon } from '../utils'
+import { toBinary } from '@bufbuild/protobuf'
+
+const logger = dlogger('csb:snapshotMigration0004')
+const LOG_SIZE_REDUCTION = false
+/**
+ * Loop over all Member objects, count sessionIds across solicitations
+ * and log those appearing in >50% of members, checking if they map to
+ * username or display_name encrypted payloads
+ */
+export function snapshotMigration0004(snapshot: Snapshot, force: boolean = false): Snapshot {
+    if (!snapshot.members?.joined?.length || (snapshot.members.joined.length < 500 && !force)) {
+        return snapshot
+    }
+
+    const members = snapshot.members.joined
+    const sessionIdCounts = new Map<string, number>()
+    const memberCount = members.length
+    const threshold = Math.max(memberCount / 4, 2) // 25% threshold, minimum 2 for testing
+
+    for (const member of members) {
+        const processedIds = new Set<string>() // Track IDs processed for this member
+
+        if (!member.solicitations?.length) {
+            continue
+        }
+
+        for (const solicitation of member.solicitations) {
+            if (!solicitation.sessionIds?.length) {
+                continue
+            }
+
+            for (const sessionId of solicitation.sessionIds) {
+                if (!processedIds.has(sessionId)) {
+                    processedIds.add(sessionId)
+                    sessionIdCounts.set(sessionId, (sessionIdCounts.get(sessionId) || 0) + 1)
+                }
+            }
+        }
+    }
+
+    const lostSessionIds = Array.from(sessionIdCounts.entries())
+        .filter(([_, count]) => count > threshold)
+        .map(([id]) => id)
+        .toSorted()
+
+    if (lostSessionIds.length) {
+        const lostSessionIdsSet = new Set(lostSessionIds)
+        const before = LOG_SIZE_REDUCTION ? toBinary(SnapshotSchema, snapshot).length : undefined
+
+        let numRemove = 0
+        let usernamesCleared = 0
+        let displayNamesCleared = 0
+        for (const member of members) {
+            // remove all lost sessionIds from members
+            for (const solicitation of member.solicitations) {
+                const before = solicitation.sessionIds.length
+                solicitation.sessionIds = removeCommon(solicitation.sessionIds, lostSessionIds)
+                const after = solicitation.sessionIds.length
+                numRemove += before - after
+            }
+            // clear lost user and display names
+            if (
+                member.displayName?.data?.sessionId &&
+                lostSessionIdsSet.has(member.displayName.data.sessionId)
+            ) {
+                member.displayName = undefined
+                displayNamesCleared++
+            }
+            if (
+                member.displayName?.data?.sessionIdBytes &&
+                member.displayName.data.sessionIdBytes.length > 0 &&
+                lostSessionIdsSet.has(bin_toHexString(member.displayName.data.sessionIdBytes))
+            ) {
+                member.displayName = undefined
+                displayNamesCleared++
+            }
+            if (
+                member.username?.data?.sessionId &&
+                lostSessionIdsSet.has(member.username.data.sessionId)
+            ) {
+                member.username = undefined
+                usernamesCleared++
+            }
+            if (
+                member.username?.data?.sessionIdBytes &&
+                member.username.data.sessionIdBytes.length > 0 &&
+                lostSessionIdsSet.has(bin_toHexString(member.username.data.sessionIdBytes))
+            ) {
+                member.username = undefined
+                usernamesCleared++
+            }
+        }
+        const streamIdBytes = snapshot.content.value?.inception?.streamId
+        const streamId = streamIdBytes ? bin_toHexString(streamIdBytes) : ''
+        const spaceAddress = SpaceIdFromSpaceAddress(streamId)
+        const after = LOG_SIZE_REDUCTION ? toBinary(SnapshotSchema, snapshot).length : undefined
+        const mbSaved = before && after ? (before - after) / 1024 / 1024 : undefined
+        const sizeLog =
+            before && after && mbSaved
+                ? `Snapshot size reduced from ${before} to ${after}, ${mbSaved.toFixed(2)} MB saved`
+                : ''
+        logger.info(
+            `${spaceAddress} ${sizeLog} ${numRemove} sessionIds ${usernamesCleared} usernames and ${displayNamesCleared} display names removed`,
+        )
+    }
+
+    return snapshot
+}

--- a/packages/sdk/src/migrations/snapshotMigration0004.ts
+++ b/packages/sdk/src/migrations/snapshotMigration0004.ts
@@ -7,8 +7,9 @@ import { toBinary } from '@bufbuild/protobuf'
 const logger = dlogger('csb:snapshotMigration0004')
 const LOG_SIZE_REDUCTION = false
 /**
+ * One time fix migration to remove lost sessionIds from key solicitations
  * Loop over all Member objects, count sessionIds across solicitations
- * and log those appearing in >50% of members, checking if they map to
+ * and log those appearing in get 25% of members, checking if they map to
  * username or display_name encrypted payloads
  */
 export function snapshotMigration0004(snapshot: Snapshot, force: boolean = false): Snapshot {

--- a/packages/sdk/src/tests/unit/snapshotMigration0004.test.ts
+++ b/packages/sdk/src/tests/unit/snapshotMigration0004.test.ts
@@ -1,0 +1,126 @@
+import { SnapshotSchema } from '@towns-protocol/proto'
+import { bin_toHexString } from '@towns-protocol/dlog'
+import { create } from '@bufbuild/protobuf'
+import { snapshotMigration0004 } from '../../migrations/snapshotMigration0004'
+import { streamIdToBytes } from '../../id'
+import { makeUniqueSpaceStreamId } from '../testUtils'
+
+describe('snapshotMigration0004', () => {
+    test('run migration with common session IDs', () => {
+        // Create a test session ID that will appear frequently
+        const commonSessionIdBytes = new Uint8Array(
+            'common-session-id'.split('').map((c) => c.charCodeAt(0)),
+        )
+        const commonSessionId = bin_toHexString(commonSessionIdBytes)
+        const spaceId = makeUniqueSpaceStreamId()
+        const spaceIdBytes = streamIdToBytes(spaceId)
+
+        // Create a snapshot with multiple members having the same session ID
+        const snap = create(SnapshotSchema, {
+            content: {
+                case: 'spaceContent',
+                value: {
+                    inception: {
+                        streamId: spaceIdBytes,
+                    },
+                },
+            },
+            members: {
+                joined: [
+                    {
+                        solicitations: [
+                            { sessionIds: [commonSessionId, 'unique1_a'] },
+                            { sessionIds: [commonSessionId, 'unique1_b'] },
+                        ],
+                        username: {
+                            data: {
+                                sessionId: commonSessionId,
+                                algorithm: 'test-algo',
+                            },
+                        },
+                        displayName: {
+                            data: {
+                                sessionIdBytes: commonSessionIdBytes,
+                                algorithm: 'test-algo',
+                            },
+                        },
+                    },
+                    {
+                        solicitations: [{ sessionIds: [commonSessionId, 'unique2'] }],
+                        username: {
+                            data: {
+                                sessionIdBytes: commonSessionIdBytes,
+                                algorithm: 'test-algo',
+                            },
+                        },
+                    },
+                    {
+                        solicitations: [{ sessionIds: [commonSessionId, 'unique3'] }],
+                    },
+                    {
+                        solicitations: [{ sessionIds: ['unique4'] }],
+                    },
+                ],
+            },
+        })
+
+        const result = snapshotMigration0004(snap, true)
+
+        // Verify that common session IDs are removed
+        for (const member of result.members!.joined) {
+            for (const solicitation of member.solicitations) {
+                expect(solicitation.sessionIds).not.toContain(commonSessionId)
+            }
+
+            // Verify that usernames and display names with common session IDs are cleared
+            if (member.username?.data) {
+                expect(member.username.data.sessionId).not.toBe(commonSessionId)
+                if (member.username.data.sessionIdBytes?.length) {
+                    expect(bin_toHexString(member.username.data.sessionIdBytes)).not.toBe(
+                        commonSessionId,
+                    )
+                }
+            }
+
+            if (member.displayName?.data) {
+                expect(member.displayName.data.sessionId).not.toBe(commonSessionId)
+                if (member.displayName.data.sessionIdBytes?.length) {
+                    expect(bin_toHexString(member.displayName.data.sessionIdBytes)).not.toBe(
+                        commonSessionId,
+                    )
+                }
+            }
+        }
+    })
+
+    test('run migration with empty members', () => {
+        const snap = create(SnapshotSchema, {})
+        const result = snapshotMigration0004(snap, true)
+        expect(result).toEqual(snap)
+    })
+
+    test('run migration with no common session IDs', () => {
+        const snap = create(SnapshotSchema, {
+            members: {
+                joined: [
+                    {
+                        solicitations: [{ sessionIds: ['unique1', 'unique2'] }],
+                        username: {
+                            data: {
+                                sessionId: 'unique3',
+                                algorithm: 'test-algo',
+                            },
+                        },
+                    },
+                    {
+                        solicitations: [{ sessionIds: ['unique4', 'unique5'] }],
+                    },
+                ],
+            },
+        })
+
+        const result = snapshotMigration0004(snap, true)
+        // Verify the snapshot remains unchanged when no common session IDs are found
+        expect(result).toEqual(snap)
+    })
+})


### PR DESCRIPTION
some usernames are just lost. users uploaded their username to the stream but didn’t share any keys.
then everyone requests the same session id to decrypt, but nobody has it, so we just save those requests forever.

this pr detects and flushes out lost username and displaynames.

We’re working on a real fix for this, but in the meantime this cuts the ax1 snapshot size in half.

Snapshot size reduced from 42133234 to 16167148, 24.76 MB saved 409854 sessionIds 85 usernames and 0 display names removed