### PR TITLE
tests: remove timeout when debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -36,7 +36,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -49,7 +49,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
      {
@@ -62,7 +62,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.multi_ne.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.multi_ne.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -75,7 +75,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -88,7 +88,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.multi_legacy.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.multi_legacy.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -101,7 +101,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.entitlements.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.entitlements.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -117,7 +117,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     },
     {
@@ -130,7 +130,7 @@
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "smartStep": true,
-      "args": ["run", "${file}", "--config", "vitest.config.unit.ts"],
+      "args": ["run", "${file}", "--config", "vitest.config.unit.ts", "--testTimeout", "0"],
       "console": "integratedTerminal",
     }
   ]


### PR DESCRIPTION
We don't want to resume a debugger and get a timeout error. 

That's why this PR changes the tests timeout when debugging.