### PR TITLE
Make write timeout configurable and remove unused snapshot index logic

### DIFF
--- a/core/node/events/miniblock_job.go
+++ b/core/node/events/miniblock_job.go
@@ -331,7 +331,7 @@ func (j *mbJob) saveCandidate(ctx context.Context) error {
 	qp := NewQuorumPool(
 		ctx,
 		NewQuorumPoolOpts().
-			WriteMode().
+			WriteModeWithTimeout(240*time.Second). // TODO: REPLICATION: FIX: make this timeout configurable
 			WithTags(
 				"method", "mbJob.saveCandidate",
 				"streamId", j.stream.streamId,

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -116,7 +116,6 @@ func MakeRemoteStreamView(stream *StreamAndCookie) (*StreamView, error) {
 
 	miniblocks := make([]*MiniblockInfo, len(stream.Miniblocks))
 	lastMiniblockNumber := int64(-1)
-	snapshotIndex := 0
 	for i, binMiniblock := range stream.Miniblocks {
 		opts := NewParsedMiniblockInfoOpts()
 		// Ignore block number of first block, but enforce afterward
@@ -129,9 +128,6 @@ func MakeRemoteStreamView(stream *StreamAndCookie) (*StreamView, error) {
 		}
 		lastMiniblockNumber = miniblock.Header().MiniblockNum
 		miniblocks[i] = miniblock
-		if miniblock.Header().IsSnapshot() {
-			snapshotIndex = i
-		}
 	}
 
 	snapshot := miniblocks[0].GetSnapshot()
@@ -170,7 +166,7 @@ func MakeRemoteStreamView(stream *StreamAndCookie) (*StreamView, error) {
 		blocks:        miniblocks,
 		minipool:      newMiniPoolInstance(minipoolEvents, generation, eventNumOffset),
 		snapshot:      snapshot,
-		snapshotIndex: snapshotIndex,
+		snapshotIndex: 0,
 	}, nil
 }
 


### PR DESCRIPTION
This temporarily raises timeout on candidate save operation. From logs it can be seen that candidates timeout to apply.