### PR TITLE
Fix river registry error tags to contain defined objects for better debugging on stream event parsing failures

### DIFF
--- a/core/node/registries/river_registry_contract.go
+++ b/core/node/registries/river_registry_contract.go
@@ -353,7 +353,11 @@ func (c *RiverRegistryContract) GetStreamCount(ctx context.Context, blockNum cry
 	return num.Int64(), nil
 }
 
-func (c *RiverRegistryContract) GetStreamCountOnNode(ctx context.Context, blockNum crypto.BlockNumber, node common.Address) (int64, error) {
+func (c *RiverRegistryContract) GetStreamCountOnNode(
+	ctx context.Context,
+	blockNum crypto.BlockNumber,
+	node common.Address,
+) (int64, error) {
 	num, err := c.StreamRegistry.GetStreamCountOnNode(c.callOptsWithBlockNum(ctx, blockNum), node)
 	if err != nil {
 		return 0, WrapRiverError(Err_CANNOT_CALL_CONTRACT, err).Func("GetStreamCountOnNode").Message("Call failed")
@@ -507,7 +511,10 @@ func (c *RiverRegistryContract) forAllStreamsSingle(
 	)
 
 	if node != nil {
-		nodeStreamsCountInRegistry, err = c.StreamRegistry.GetStreamCountOnNode(c.callOptsWithBlockNum(ctx, blockNum), *node)
+		nodeStreamsCountInRegistry, err = c.StreamRegistry.GetStreamCountOnNode(
+			c.callOptsWithBlockNum(ctx, blockNum),
+			*node,
+		)
 	} else {
 		nodeStreamsCountInRegistry, err = c.StreamRegistry.GetStreamCount(c.callOptsWithBlockNum(ctx, blockNum))
 	}
@@ -755,8 +762,12 @@ func (c *RiverRegistryContract) SetStreamLastMiniblockBatch(
 		// only parse the new events (StreamUpdated + StreamLastMiniblockUpdateFailed) and ignore the old events.
 		// this allows the contract to be upgraded without breaking event parsing.
 		// TODO: remove wanted1/wanted2 check after smart contract has been upgraded and won't emit old event types.
-		wanted1 := common.HexToHash("0x378ece20ebca29c2f887798617154658265a73d80c84fad8c9c49639ffdb29bb") // StreamUpdated
-		wanted2 := common.HexToHash("0x75460fe319331413a18a82d99b07735cec53fa0c4061ada38c2141e331082afa") // StreamLastMiniblockUpdateFailed
+		wanted1 := common.HexToHash(
+			"0x378ece20ebca29c2f887798617154658265a73d80c84fad8c9c49639ffdb29bb",
+		) // StreamUpdated
+		wanted2 := common.HexToHash(
+			"0x75460fe319331413a18a82d99b07735cec53fa0c4061ada38c2141e331082afa",
+		) // StreamLastMiniblockUpdateFailed
 
 		for _, l := range receipt.Logs {
 			if l.Topics[0] != wanted1 && l.Topics[0] != wanted2 {
@@ -933,7 +944,7 @@ func (c *RiverRegistryContract) OnStreamEvent(
 			if event, ok := parsed.(*river.StreamRegistryV1StreamUpdated); ok {
 				events, err := river.ParseStreamUpdatedEvent(event)
 				if err != nil {
-					logging.FromCtx(ctx).Errorw("Failed to parse stream update event", "event", events)
+					logging.FromCtx(ctx).Errorw("Failed to parse stream update event", "event", event)
 					return
 				}
 
@@ -952,7 +963,7 @@ func (c *RiverRegistryContract) OnStreamEvent(
 					}
 				}
 			} else {
-				logging.FromCtx(ctx).Errorw("Unknown event type", "event", event)
+				logging.FromCtx(ctx).Errorw("Unknown event type", "event", parsed)
 			}
 		})
 	return nil
@@ -979,7 +990,7 @@ func (c *RiverRegistryContract) FilterStreamEvents(
 		if !ok {
 			finalErrs = append(
 				finalErrs,
-				RiverError(Err_INTERNAL, "Stream event isn't update", "event", streamUpdate),
+				RiverError(Err_INTERNAL, "Stream event isn't update", "event", parsed),
 			)
 			continue
 		}


### PR DESCRIPTION
Some of these parsing errors accidentally included objects that are unset. This PR trades the undefined object for the most specific object that was successfully parsed.