### PR TITLE
fix: add `@connectrpc/connect-web` as dev dependency of sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,7 @@
         "vitest": "3.0.5"
     },
     "devDependencies": {
+        "@connectrpc/connect-web": "^2.0.0",
         "@types/debug": "^4.1.8",
         "@types/lodash": "^4.14.186",
         "@types/node": "^20.14.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7996,6 +7996,7 @@ __metadata:
   dependencies:
     "@bufbuild/protobuf": ^2.2.2
     "@connectrpc/connect": ^2.0.0
+    "@connectrpc/connect-web": ^2.0.0
     "@ethereumjs/util": ^8.0.1
     "@towns-protocol/dlog": "workspace:^"
     "@towns-protocol/encryption": "workspace:^"


### PR DESCRIPTION
SDK only require the types of `@connectrpc/connect-web`.

This should unblock stream-metadata docker image to build