### PR TITLE
Fix bug in processing of snapshotted key solicitations

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -339,7 +339,7 @@ export abstract class BaseDecryptionExtensions {
                 if (keySolicitation.deviceKey === this.userDevice.deviceKey) {
                     continue
                 }
-                if (!keySolicitation.isNewDevice || keySolicitation.sessionIds.length === 0) {
+                if (keySolicitation.sessionIds.length === 0 && !keySolicitation.isNewDevice) {
                     continue
                 }
                 const selectedQueue =


### PR DESCRIPTION
Seems like we were just skipping them? Probably why snapshots got so huge.