### PR TITLE
Proposal for modified handling of isNewDevice

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -1984,8 +1984,8 @@ func (ru *aeKeySolicitationRules) validKeySolicitation() (bool, error) {
 		return false, RiverError(Err_INVALID_ARGUMENT, "event is not a key solicitation event")
 	}
 
-	if !ru.solicitation.IsNewDevice && len(ru.solicitation.SessionIds) == 0 {
-		return false, RiverError(Err_INVALID_ARGUMENT, "session ids are required for existing devices")
+	if len(ru.solicitation.SessionIds) == 0 {
+		return false, RiverError(Err_INVALID_ARGUMENT, "session ids are required for all solicitations")
 	}
 
 	if !slices.IsSorted(ru.solicitation.SessionIds) {
@@ -2021,6 +2021,10 @@ func (ru *aeKeyFulfillmentRules) validKeyFulfillment() (bool, error) {
 	for _, solicitation := range solicitations {
 		if solicitation.DeviceKey == ru.fulfillment.DeviceKey {
 			if solicitation.IsNewDevice {
+				// if the user has indicated that this is a new device, it's possible that a client
+				// will fulfill with all known sessionids, but not have an overlapping sessionId
+				// this will clear the IsNewDevice flag, but the solicitation will still be valid, and
+				// a different client could complete the fulfillment
 				return true, nil
 			}
 			if hasCommon(solicitation.SessionIds, ru.fulfillment.SessionIds) {

--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -339,7 +339,7 @@ export abstract class BaseDecryptionExtensions {
                 if (keySolicitation.deviceKey === this.userDevice.deviceKey) {
                     continue
                 }
-                if (keySolicitation.sessionIds.length === 0 && !keySolicitation.isNewDevice) {
+                if (keySolicitation.sessionIds.length === 0) {
                     continue
                 }
                 const selectedQueue =
@@ -879,9 +879,10 @@ export abstract class BaseDecryptionExtensions {
             streamId,
             userAddress: item.fromUserAddress,
             deviceKey: item.solicitation.deviceKey,
-            sessionIds: item.solicitation.isNewDevice
-                ? []
-                : allSessions.map((x) => x.sessionId).sort(),
+            sessionIds: allSessions
+                .map((x) => x.sessionId)
+                .filter((x) => requestedSessionIds.has(x))
+                .sort(),
         })
 
         // if the key fulfillment failed, someone else already sent a key fulfillment

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -304,7 +304,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             deviceKey: this.userDevice.deviceKey,
             fallbackKey: this.userDevice.fallbackKey,
             isNewDevice,
-            sessionIds: isNewDevice ? [] : missingSessionIds,
+            sessionIds: missingSessionIds,
         })
         await this.client.makeEventAndAddToStream(streamId, keySolicitation)
     }

--- a/packages/sdk/src/sync-agent/timeline/models/timelineEvent.ts
+++ b/packages/sdk/src/sync-agent/timeline/models/timelineEvent.ts
@@ -996,14 +996,11 @@ export function getFallbackContent(
         case RiverTimelineEvent.SpaceImage:
             return `SpaceImage`
         case RiverTimelineEvent.Fulfillment:
-            return `Fulfillment sessionIds: ${
+            return `Fulfillment from: ${content.from} to: ${content.deviceKey} count: ${content.sessionIds.length} sessionIds: ${
                 content.sessionIds.length ? content.sessionIds.join(',') : 'forNewDevice: true'
-            }, from: ${content.from} to: ${content.deviceKey}`
+            }`
         case RiverTimelineEvent.KeySolicitation:
-            if (content.isNewDevice) {
-                return `KeySolicitation deviceKey: ${content.deviceKey}, newDevice: true`
-            }
-            return `KeySolicitation deviceKey: ${content.deviceKey} sessionIds: ${content.sessionIds.length}`
+            return `KeySolicitation deviceKey: ${content.deviceKey} sessionIds: ${content.sessionIds.length} isNewDevice: ${content.isNewDevice}`
         case RiverTimelineEvent.ChannelMessageMissing:
             return `eventId: ${content.eventId}`
         case RiverTimelineEvent.ChannelMessageEncryptedWithRef:

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -371,7 +371,7 @@ describe('clientTest', () => {
         // solicitation for isNewDevice should resolve
         payload = make_MemberPayload_KeySolicitation({
             deviceKey: 'foo',
-            sessionIds: [],
+            sessionIds: ['bar'],
             fallbackKey: 'baz',
             isNewDevice: true,
         })
@@ -393,7 +393,7 @@ describe('clientTest', () => {
         payload = make_MemberPayload_KeyFulfillment({
             deviceKey: 'foo',
             userAddress: addressFromUserId(bobsClient.userId),
-            sessionIds: [],
+            sessionIds: ['bar'],
         })
         await expect(
             bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),


### PR DESCRIPTION
I think it was a mistake to not pass session ids in the initial key solicitations, we end up in a situation where we can ping pong solicitations without actually satisfying the request. The contents of this change

- isNewDevice becomes a suggestion instead of a state
- all key requests now require session ids
- if isNewDevice is true, clients will still send all known sessions, but explicitly state in the fulfillment if they fulfilled any of the requested ids.

this should tighten the reqest loop and prevent at least one back and forth between clients in some cases.



Inspiration for this change, I saw a series of events in this space: 1014336be9f4f7bfa62bdb1f19c73a45c55b2c7ed00000000000000000000000
```
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T19:16:26.212Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T19:16:27.931Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T19:23:42.681Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T19:24:36.369Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T21:26:32.499Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T21:27:58.852Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T23:36:25.205Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-06T23:39:59.266Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-07T05:13:15.580Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-07T05:13:15.992Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-07T12:18:29.725Z memberPayload keySolicitation KeySolicitation deviceKey: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA, newDevice: true
event 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 2025-05-07T12:19:16.206Z memberPayload keyFulfillment Fulfillment sessionIds: forNewDevice: true, from: 0x9fa80D7bD324D87BA83fE2C10F33757dC2ffe588 to: rN/uGOnP49/fAKqfwH3q7HkKzcFh3jBPCsGhB/1noVA
```


Where Ben was continually clearing his own key solicitations and re-submitting. I believe this would have been sent from two devices (I hope), but I don't understand why the device requesting keys never flipped to isNewDevice: false unless his user inbox stream stopped syncing, and perhaps he was continually refreshing his browser? Worth keeping in mind as we revisit the swift logic.