### PR TITLE
fix: update import paths for diamond scripts and LibDeploy

### DIFF
--- a/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
@@ -13,10 +13,10 @@ import {Diamond} from "@towns-protocol/diamond/src/Diamond.sol";
 import {Deployer} from "scripts/common/Deployer.s.sol";
 
 import {DeployFacet} from "../../common/DeployFacet.s.sol";
-import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.s.sol";
-import {DeployDiamondLoupe} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondLoupe.s.sol";
-import {DeployIntrospection} from "@towns-protocol/diamond/scripts/deployments/facets/DeployIntrospection.s.sol";
-import {DeployOwnable} from "@towns-protocol/diamond/scripts/deployments/facets/DeployOwnable.s.sol";
+import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.sol";
+import {DeployDiamondLoupe} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondLoupe.sol";
+import {DeployIntrospection} from "@towns-protocol/diamond/scripts/deployments/facets/DeployIntrospection.sol";
+import {DeployOwnable} from "@towns-protocol/diamond/scripts/deployments/facets/DeployOwnable.sol";
 import {DiamondHelper} from "@towns-protocol/diamond/scripts/common/helpers/DiamondHelper.s.sol";
 import {DeployMetadata} from "scripts/deployments/facets/DeployMetadata.s.sol";
 

--- a/packages/contracts/scripts/deployments/facets/DeployAttestationRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployAttestationRegistry.s.sol
@@ -7,7 +7,7 @@ import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 //libraries
 
 //contracts
-import {DeployLib} from "@towns-protocol/diamond/scripts/common/DeployLib.sol";
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 import {AttestationRegistry} from "src/modules/reference/AttestationRegistry.sol";
 
 library DeployAttestationRegistry {
@@ -35,6 +35,6 @@ library DeployAttestationRegistry {
     }
 
     function deploy() internal returns (address) {
-        return DeployLib.deployCode("AttestationRegistry.sol", "");
+        return LibDeploy.deployCode("AttestationRegistry.sol", "");
     }
 }

--- a/packages/contracts/scripts/deployments/facets/DeployModularAccount.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployModularAccount.s.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.23;
 import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 
 // libraries
-import {DeployLib} from "@towns-protocol/diamond/scripts/common/DeployLib.sol";
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 
 // contracts
 import {ModularAccount} from "src/spaces/facets/account/ModularAccount.sol";
@@ -34,6 +34,6 @@ library DeployModularAccount {
     }
 
     function deploy() internal returns (address) {
-        return DeployLib.deployCode("ModularAccount.sol", "");
+        return LibDeploy.deployCode("ModularAccount.sol", "");
     }
 }

--- a/packages/contracts/scripts/deployments/facets/DeployModuleRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployModuleRegistry.s.sol
@@ -8,7 +8,7 @@ import {ISchemaResolver} from "@ethereum-attestation-service/eas-contracts/resol
 //libraries
 
 //contracts
-import {DeployLib} from "@towns-protocol/diamond/scripts/common/DeployLib.sol";
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 import {ModuleRegistry} from "src/modules/ModuleRegistry.sol";
 import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
 
@@ -56,6 +56,6 @@ library DeployModuleRegistry {
     }
 
     function deploy() internal returns (address) {
-        return DeployLib.deployCode("ModuleRegistry.sol", "");
+        return LibDeploy.deployCode("ModuleRegistry.sol", "");
     }
 }

--- a/packages/contracts/scripts/deployments/facets/DeploySchemaRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeploySchemaRegistry.s.sol
@@ -7,7 +7,7 @@ import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 //libraries
 
 //contracts
-import {DeployLib} from "@towns-protocol/diamond/scripts/common/DeployLib.sol";
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 import {SchemaRegistry} from "src/modules/reference/SchemaRegistry.sol";
 
 library DeploySchemaRegistry {
@@ -34,6 +34,6 @@ library DeploySchemaRegistry {
     }
 
     function deploy() internal returns (address) {
-        return DeployLib.deployCode("SchemaRegistry.sol", "");
+        return LibDeploy.deployCode("SchemaRegistry.sol", "");
     }
 }

--- a/packages/contracts/scripts/deployments/utils/DeployMockDiamond.s.sol
+++ b/packages/contracts/scripts/deployments/utils/DeployMockDiamond.s.sol
@@ -12,10 +12,10 @@ import {SimpleDeployer} from "@towns-protocol/diamond/scripts/common/deployers/S
 
 // deployments
 import {DeployFacet} from "@towns-protocol/diamond/scripts/common/DeployFacet.s.sol";
-import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.s.sol";
-import {DeployDiamondLoupe} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondLoupe.s.sol";
-import {DeployIntrospection} from "@towns-protocol/diamond/scripts/deployments/facets/DeployIntrospection.s.sol";
-import {DeployOwnablePending} from "@towns-protocol/diamond/scripts/deployments/facets/DeployOwnablePending.s.sol";
+import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.sol";
+import {DeployDiamondLoupe} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondLoupe.sol";
+import {DeployIntrospection} from "@towns-protocol/diamond/scripts/deployments/facets/DeployIntrospection.sol";
+import {DeployOwnablePending} from "@towns-protocol/diamond/scripts/deployments/facets/DeployOwnablePending.sol";
 
 // utils
 import {MultiInit} from "@towns-protocol/diamond/src/initializers/MultiInit.sol";


### PR DESCRIPTION
### TL;DR

Updated import paths for diamond-related dependencies to match the new structure in the towns-protocol package.

### What changed?

- Updated import paths for diamond facet deployments by removing the `.s` extension from several files:
  - `DeployDiamondCut.s.sol` → `DeployDiamondCut.sol`
  - `DeployDiamondLoupe.s.sol` → `DeployDiamondLoupe.sol`
  - `DeployIntrospection.s.sol` → `DeployIntrospection.sol`
  - `DeployOwnable.s.sol` → `DeployOwnable.sol`
  - `DeployOwnablePending.s.sol` → `DeployOwnablePending.sol`

- Changed the import for `DeployLib` to `LibDeploy` with an updated path:
  - `@towns-protocol/diamond/scripts/common/DeployLib.sol` → `@towns-protocol/diamond/src/utils/LibDeploy.sol`

- Updated all references from `DeployLib.deployCode()` to `LibDeploy.deployCode()`

### How to test?

1. Ensure all imports resolve correctly by running a build
2. Verify that deployment scripts execute successfully
3. Run any existing tests that use these deployment scripts to confirm functionality is maintained

### Why make this change?

This change aligns with a restructuring of the towns-protocol diamond package, ensuring our contracts use the correct import paths and naming conventions. The refactoring improves code organization by moving deployment utilities from scripts to the main source directory and standardizing file extensions.