### PR TITLE
feat(contract): add pausable functionality to `SwapRouter`

### DIFF
--- a/packages/contracts/src/router/SwapRouter.sol
+++ b/packages/contracts/src/router/SwapRouter.sol
@@ -18,11 +18,12 @@ import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
 // contracts
 import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
+import {PausableBase} from "@towns-protocol/diamond/src/facets/pausable/PausableBase.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 
 /// @title SwapRouter
 /// @notice Handles swaps through whitelisted routers with fee collection
-contract SwapRouter is ReentrancyGuardTransient, ISwapRouter, Facet {
+contract SwapRouter is PausableBase, ReentrancyGuardTransient, ISwapRouter, Facet {
     using CustomRevert for bytes4;
     using SafeTransferLib for address;
 
@@ -46,7 +47,7 @@ contract SwapRouter is ReentrancyGuardTransient, ISwapRouter, Facet {
         ExactInputParams calldata params,
         RouterParams calldata routerParams,
         address poster
-    ) external payable nonReentrant returns (uint256 amountOut) {
+    ) external payable nonReentrant whenNotPaused returns (uint256 amountOut) {
         // for standard swaps, the msg.sender provides the tokens
         return _executeSwap(params, routerParams, msg.sender, poster);
     }
@@ -57,7 +58,7 @@ contract SwapRouter is ReentrancyGuardTransient, ISwapRouter, Facet {
     //        RouterParams calldata routerParams,
     //        PermitParams calldata permit,
     //        address poster
-    //    ) external payable nonReentrant returns (uint256 amountOut) {
+    //    ) external payable nonReentrant whenNotPaused returns (uint256 amountOut) {
     //        // sanity check
     //        if (permit.value < params.amountIn) SwapRouter__InvalidAmount.selector.revertWith();
     //

--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -26,8 +26,8 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, Membership
     using CustomRevert for bytes4;
     using SafeTransferLib for address;
 
-    /// @notice Maximum fee in basis points (1%)
-    uint16 internal constant MAX_FEE_BPS = 100;
+    /// @notice Maximum fee in basis points (2%)
+    uint16 internal constant MAX_FEE_BPS = 200;
 
     /// @dev The implementation ID for the SwapRouter
     bytes32 internal constant SWAP_ROUTER_DIAMOND = bytes32("SwapRouter");

--- a/packages/contracts/test/router/SwapRouter.t.sol
+++ b/packages/contracts/test/router/SwapRouter.t.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
+import {IPausableBase, IPausable} from "@towns-protocol/diamond/src/facets/pausable/IPausable.sol";
 import {IPlatformRequirements} from "../../src/factory/facets/platform/requirements/IPlatformRequirements.sol";
 import {ISwapRouter} from "../../src/router/ISwapRouter.sol";
 
@@ -19,9 +21,10 @@ import {DeploySpaceFactory} from "../../scripts/deployments/diamonds/DeploySpace
 import {DeploySwapRouter} from "../../scripts/deployments/diamonds/DeploySwapRouter.s.sol";
 import {SwapTestBase} from "./SwapTestBase.sol";
 
-contract SwapRouterTest is SwapTestBase {
+contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
     address internal spaceFactory;
     ISwapRouter internal swapRouter;
+    IPausable internal pausableFacet;
     address internal mockRouter;
     MockERC20 internal token0;
     MockERC20 internal token1;
@@ -56,12 +59,94 @@ contract SwapRouterTest is SwapTestBase {
         DeploySwapRouter deploySwapRouter = new DeploySwapRouter();
         deploySwapRouter.setDependencies(spaceFactory);
         swapRouter = ISwapRouter(deploySwapRouter.deploy(deployer));
+        pausableFacet = IPausable(address(swapRouter));
     }
 
     function test_storageSlot() external pure {
         bytes32 slot = keccak256(abi.encode(uint256(keccak256("router.swap.storage")) - 1)) &
             ~bytes32(uint256(0xff));
         assertEq(slot, SwapRouterStorage.STORAGE_SLOT, "slot");
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     PAUSABLE FUNCTIONS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function test_pause_revertWhen_notOwner(address notOwner) external {
+        vm.assume(notOwner != address(0) && notOwner != deployer);
+        vm.prank(notOwner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable__NotOwner.selector, notOwner));
+        pausableFacet.pause();
+    }
+
+    function test_pause_success() external {
+        vm.prank(deployer);
+        pausableFacet.pause();
+
+        assertTrue(pausableFacet.paused(), "Router should be paused");
+    }
+
+    function test_unpause_revertWhen_notOwner(address notOwner) external {
+        vm.assume(notOwner != address(0) && notOwner != deployer);
+        // pause the router
+        vm.prank(deployer);
+        pausableFacet.pause();
+
+        // try to unpause with non-owner
+        vm.prank(notOwner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable__NotOwner.selector, notOwner));
+        pausableFacet.unpause();
+    }
+
+    function test_unpause_success() external {
+        // pause the router
+        vm.prank(deployer);
+        pausableFacet.pause();
+        assertTrue(pausableFacet.paused(), "Router should be paused");
+
+        // unpause it
+        vm.prank(deployer);
+        pausableFacet.unpause();
+        assertFalse(pausableFacet.paused(), "Router should be unpaused");
+    }
+
+    function test_executeSwap_revertWhen_paused() external {
+        address caller = address(this);
+        uint256 amountIn = 100 ether;
+        uint256 amountOut = 95 ether;
+
+        // pause the router
+        vm.prank(deployer);
+        pausableFacet.pause();
+
+        // get swap parameters
+        (ExactInputParams memory inputParams, RouterParams memory routerParams) = _createSwapParams(
+            address(swapRouter),
+            mockRouter,
+            address(token0),
+            address(token1),
+            amountIn,
+            amountOut,
+            caller
+        );
+
+        // expect revert when paused
+        vm.expectRevert(Pausable__Paused.selector);
+        swapRouter.executeSwap(inputParams, routerParams, poster);
+    }
+
+    function test_isPaused() external {
+        assertFalse(pausableFacet.paused(), "Should not be paused initially");
+
+        vm.prank(deployer);
+        pausableFacet.pause();
+
+        assertTrue(pausableFacet.paused(), "Should be paused after pause()");
+
+        vm.prank(deployer);
+        pausableFacet.unpause();
+
+        assertFalse(pausableFacet.paused(), "Should not be paused after unpause()");
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
Introduce `Pausable` capabilities to `SwapRouter`, enabling pause/unpause mechanisms. Updated tests to cover pausable behavior. Increased max fee to 2%.