### PR TITLE
fix(contract): add `SwapRouter__UnexpectedETH` error handling

### DIFF
--- a/packages/contracts/src/router/ISwapRouter.sol
+++ b/packages/contracts/src/router/ISwapRouter.sol
@@ -61,6 +61,9 @@ interface ISwapRouterBase {
     /// @notice Error thrown when the output amount is less than the minimum expected
     error SwapRouter__InsufficientOutput();
 
+    /// @notice Error thrown when ETH is sent but not expected (tokenIn is not the native token)
+    error SwapRouter__UnexpectedETH();
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           EVENTS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/packages/contracts/src/router/SwapRouter.sol
+++ b/packages/contracts/src/router/SwapRouter.sol
@@ -103,6 +103,9 @@ contract SwapRouter is PausableBase, ReentrancyGuardTransient, ISwapRouter, Face
             uint256 amountIn = params.amountIn;
             bool isNativeToken = params.tokenIn == CurrencyTransfer.NATIVE_TOKEN;
             if (!isNativeToken) {
+                // ensure no ETH is sent when tokenIn is not native
+                if (msg.value != 0) SwapRouter__UnexpectedETH.selector.revertWith();
+
                 // use the actual received amount to handle fee-on-transfer tokens
                 uint256 tokenInBalanceBefore = params.tokenIn.balanceOf(address(this));
                 params.tokenIn.safeTransferFrom(payer, address(this), amountIn);

--- a/packages/contracts/test/router/SwapRouter.t.sol
+++ b/packages/contracts/test/router/SwapRouter.t.sol
@@ -228,6 +228,22 @@ contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
         swapRouter.executeSwap(inputParams, routerParams, poster);
     }
 
+    function test_executeSwap_revertWhen_unexpectedETH() external {
+        (ExactInputParams memory inputParams, RouterParams memory routerParams) = _createSwapParams(
+            address(swapRouter),
+            mockRouter,
+            address(token0), // ERC20 token (not native)
+            address(token1),
+            100 ether,
+            95 ether,
+            address(this)
+        );
+
+        // send ETH with the transaction even though tokenIn is not native token
+        vm.expectRevert(SwapRouter__UnexpectedETH.selector);
+        swapRouter.executeSwap{value: 0.1 ether}(inputParams, routerParams, poster);
+    }
+
     function test_executeSwap_gas() public {
         test_executeSwap(
             address(this),

--- a/packages/generated/dev/abis/ISwapFacet.abi.json
+++ b/packages/generated/dev/abis/ISwapFacet.abi.json
@@ -316,5 +316,10 @@
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ]

--- a/packages/generated/dev/abis/ISwapFacet.abi.ts
+++ b/packages/generated/dev/abis/ISwapFacet.abi.ts
@@ -316,5 +316,10 @@ export default [
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ] as const

--- a/packages/generated/dev/abis/ISwapRouter.abi.json
+++ b/packages/generated/dev/abis/ISwapRouter.abi.json
@@ -185,5 +185,10 @@
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ]

--- a/packages/generated/dev/abis/ISwapRouter.abi.ts
+++ b/packages/generated/dev/abis/ISwapRouter.abi.ts
@@ -185,5 +185,10 @@ export default [
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ] as const

--- a/packages/generated/dev/abis/ISwapRouterBase.abi.json
+++ b/packages/generated/dev/abis/ISwapRouterBase.abi.json
@@ -112,5 +112,10 @@
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ]

--- a/packages/generated/dev/abis/ISwapRouterBase.abi.ts
+++ b/packages/generated/dev/abis/ISwapRouterBase.abi.ts
@@ -112,5 +112,10 @@ export default [
     "type": "error",
     "name": "SwapRouter__InvalidRouter",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SwapRouter__UnexpectedETH",
+    "inputs": []
   }
 ] as const

--- a/packages/generated/dev/typings/factories/ISwapFacet__factory.ts
+++ b/packages/generated/dev/typings/factories/ISwapFacet__factory.ts
@@ -325,6 +325,11 @@ const _abi = [
     name: "SwapRouter__InvalidRouter",
     inputs: [],
   },
+  {
+    type: "error",
+    name: "SwapRouter__UnexpectedETH",
+    inputs: [],
+  },
 ] as const;
 
 export class ISwapFacet__factory {

--- a/packages/generated/dev/typings/factories/ISwapRouter__factory.ts
+++ b/packages/generated/dev/typings/factories/ISwapRouter__factory.ts
@@ -194,6 +194,11 @@ const _abi = [
     name: "SwapRouter__InvalidRouter",
     inputs: [],
   },
+  {
+    type: "error",
+    name: "SwapRouter__UnexpectedETH",
+    inputs: [],
+  },
 ] as const;
 
 export class ISwapRouter__factory {


### PR DESCRIPTION
Introduce `SwapRouter__UnexpectedETH` error to enforce validation where unexpected ETH is sent with non-native token swaps. Includes updated typings, ABIs, and tests.