### PR TITLE
Increase rpc timeout to 90 seconds

### DIFF
--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -17,7 +17,7 @@ export const DEFAULT_RETRY_PARAMS: RetryParams = {
     maxAttempts: 3,
     initialRetryDelay: 2000,
     maxRetryDelay: 6000,
-    defaultTimeoutMs: 30000, // 30 seconds for long running requests
+    defaultTimeoutMs: 90000, // 90 seconds for long running requests
 }
 
 export type RetryParams = {


### PR DESCRIPTION
ModifySync was timing out today at 30 seconds