### PR TITLE
Save snapshots that come in via push subscription in new format

### DIFF
--- a/packages/sdk/src/stream.ts
+++ b/packages/sdk/src/stream.ts
@@ -3,7 +3,13 @@ import { DLogger } from '@towns-protocol/dlog'
 import EventEmitter from 'events'
 import TypedEmitter from 'typed-emitter'
 import { IStreamStateView, StreamStateView } from './streamStateView'
-import { LocalEventStatus, ParsedEvent, ParsedMiniblock, isLocalEvent } from './types'
+import {
+    LocalEventStatus,
+    ParsedEvent,
+    ParsedMiniblock,
+    ParsedSnapshot,
+    isLocalEvent,
+} from './types'
 import { StreamEvents } from './streamEvents'
 import { DecryptedContent } from './encryptedContentTypes'
 import { DecryptionSessionError } from '@towns-protocol/encryption'
@@ -78,6 +84,7 @@ export class Stream extends (EventEmitter as new () => TypedEmitter<StreamEvents
     async appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
+        snapshot: ParsedSnapshot | undefined,
         cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void> {
         this._view.appendEvents(events, nextSyncCookie, cleartexts, this)

--- a/packages/sdk/src/streamUtils.ts
+++ b/packages/sdk/src/streamUtils.ts
@@ -104,12 +104,12 @@ export function parsedMiniblockToPersistedMiniblock(
     miniblock: ParsedMiniblock,
     direction: 'forward' | 'backward',
 ) {
-    if (direction === 'backward') {
-        miniblock.header.snapshot = undefined
-    }
+    // always zero out the snapshot since we save it separately
+    const header = { ...miniblock.header, snapshot: undefined }
+
     return create(PersistedMiniblockSchema, {
         hash: miniblock.hash,
-        header: miniblock.header,
+        header: header,
         events: miniblock.events
             .filter((event) => isPersistedEvent(event, direction))
             .map(parsedEventToPersistedEvent),

--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -6,7 +6,7 @@ import {
     PersistedSyncedStreamSchema,
 } from '@towns-protocol/proto'
 import { Stream } from './stream'
-import { ParsedMiniblock, ParsedEvent, ParsedStreamResponse } from './types'
+import { ParsedMiniblock, ParsedEvent, ParsedStreamResponse, ParsedSnapshot } from './types'
 import { DLogger, bin_toHexString, dlog } from '@towns-protocol/dlog'
 import { isDefined } from './check'
 import { IPersistenceStore, LoadedStream } from './persistenceStore'
@@ -109,14 +109,15 @@ export class SyncedStream extends Stream implements ISyncedStream {
     async appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
+        snapshot: ParsedSnapshot | undefined,
         cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void> {
-        await super.appendEvents(events, nextSyncCookie, cleartexts)
+        await super.appendEvents(events, nextSyncCookie, snapshot, cleartexts)
         for (const event of events) {
             const payload = event.event.payload
             switch (payload.case) {
                 case 'miniblockHeader': {
-                    await this.onMiniblockHeader(payload.value, event, event.hash)
+                    await this.onMiniblockHeader(payload.value, event, event.hash, snapshot)
                     break
                 }
                 default:
@@ -130,6 +131,7 @@ export class SyncedStream extends Stream implements ISyncedStream {
         miniblockHeader: MiniblockHeader,
         miniblockEvent: ParsedEvent,
         hash: Uint8Array,
+        snapshot: ParsedSnapshot | undefined,
     ) {
         this.log(
             'Received miniblock header',
@@ -150,6 +152,19 @@ export class SyncedStream extends Stream implements ISyncedStream {
             hash: hash,
             header: miniblockHeader,
             events: [...events, miniblockEvent],
+        }
+        if (snapshot && snapshot.hash === miniblockHeader.snapshotHash) {
+            await this.persistenceStore.saveSnapshot(
+                this.streamId,
+                miniblock.header.miniblockNum,
+                snapshot.snapshot,
+            )
+        } else if (miniblockHeader.snapshot !== undefined) {
+            await this.persistenceStore.saveSnapshot(
+                this.streamId,
+                miniblockHeader.miniblockNum,
+                miniblockHeader.snapshot,
+            )
         }
         await this.persistenceStore.saveMiniblock(this.streamId, miniblock)
 

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -19,7 +19,7 @@ import {
     streamIdAsString,
     isChannelStreamId,
 } from './id'
-import { ParsedEvent, ParsedStreamResponse } from './types'
+import { ParsedEvent, ParsedSnapshot, ParsedStreamResponse } from './types'
 import { isDefined, logNever } from './check'
 
 export enum SyncState {
@@ -66,6 +66,7 @@ export interface ISyncedStream {
     appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
+        snapshot: ParsedSnapshot | undefined,
         cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void>
     resetUpToDate(): void
@@ -830,6 +831,7 @@ export class SyncedStreamsLoop {
                         await streamRecord.stream.appendEvents(
                             streamAndCookie.events,
                             streamAndCookie.nextSyncCookie,
+                            streamAndCookie.snapshot,
                             undefined,
                         )
                     }


### PR DESCRIPTION
Also doing this noticed that we're saving the miniblock header twice, once in the struct, once in the events list
Will try to fix that as well.