### PR TITLE
Allow skipping of duplicate check for addEvent on mb reconciliation

### DIFF
--- a/core/cmd/cmd_context.go
+++ b/core/cmd/cmd_context.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"github.com/towns-protocol/towns/core/config"
+	"github.com/towns-protocol/towns/core/contracts/river"
+	. "github.com/towns-protocol/towns/core/node/base"
+	"github.com/towns-protocol/towns/core/node/crypto"
+	"github.com/towns-protocol/towns/core/node/http_client"
+	"github.com/towns-protocol/towns/core/node/infra"
+	. "github.com/towns-protocol/towns/core/node/protocol"
+	. "github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
+	"github.com/towns-protocol/towns/core/node/registries"
+	"github.com/towns-protocol/towns/core/node/rpc"
+	. "github.com/towns-protocol/towns/core/node/shared"
+)
+
+type cmdContext struct {
+	ctx              context.Context
+	ctxCancel        context.CancelFunc
+	cfg              *config.Config
+	blockchain       *crypto.Blockchain
+	registryContract *registries.RiverRegistryContract
+	httpClient       *http.Client
+
+	// Below are parsed values for optional common flags
+	// Value are parsed only if flag is present in the flagset
+	// If if command does not define a flag, value is not parsed
+	streamID    StreamId       // "stream"
+	nodeAddress common.Address // "node"
+	verbose     bool           // "verbose"
+	csv         bool           // "csv"
+	json        bool           // "json"
+	pageSize    int            // "page-size"
+	timeout     time.Duration  // "timeout" (if not set, default is 30 seconds)
+}
+
+func newCmdContext(cmd *cobra.Command, cfg *config.Config) (*cmdContext, context.CancelFunc, error) {
+	ctx := cmd.Context()
+	cc := &cmdContext{
+		ctx: ctx,
+		cfg: cfg,
+	}
+
+	var err error
+	f := cmd.Flags().Lookup("stream")
+	if f != nil {
+		streamID, err := StreamIdFromString(f.Value.String())
+		if err != nil {
+			return nil, nil, err
+		}
+		cc.streamID = streamID
+	}
+
+	f = cmd.Flags().Lookup("node")
+	if f != nil {
+		val := f.Value.String()
+		if !common.IsHexAddress(val) {
+			return nil, nil, RiverError(Err_INVALID_ARGUMENT, "Invalid node address", "arg", val)
+		}
+		cc.nodeAddress = common.HexToAddress(val)
+	}
+
+	f = cmd.Flags().Lookup("verbose")
+	if f != nil {
+		cc.verbose, err = cmd.Flags().GetBool("verbose")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	f = cmd.Flags().Lookup("csv")
+	if f != nil {
+		cc.csv, err = cmd.Flags().GetBool("csv")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	f = cmd.Flags().Lookup("json")
+	if f != nil {
+		cc.json, err = cmd.Flags().GetBool("json")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	f = cmd.Flags().Lookup("page-size")
+	if f != nil {
+		cc.pageSize, err = cmd.Flags().GetInt("page-size")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	f = cmd.Flags().Lookup("timeout")
+	if f != nil {
+		cc.timeout, err = cmd.Flags().GetDuration("timeout")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if cc.timeout <= 0 {
+		cc.timeout = 30 * time.Second
+	}
+
+	cc.ctx, cc.ctxCancel = context.WithTimeout(cc.ctx, cc.timeout)
+
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cfg.RiverChain,
+		nil,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	cc.blockchain = blockchain
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cfg.RegistryContract,
+		&cfg.RiverRegistry,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	cc.registryContract = registryContract
+
+	return cc, cc.ctxCancel, nil
+}
+
+func (cc *cmdContext) getHttpClient() (*http.Client, error) {
+	if cc.httpClient != nil {
+		return cc.httpClient, nil
+	}
+
+	httpClient, err := http_client.GetHttpClient(cc.ctx, cc.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cc.httpClient = httpClient
+	return httpClient, nil
+}
+
+func (cc *cmdContext) getStubForStream(streamID StreamId, preferredNode common.Address) (StreamServiceClient, *river.StreamWithId, *river.Node, error) {
+	ctx, cancel := context.WithTimeout(cc.ctx, 30*time.Second)
+	defer cancel()
+
+	record, err := cc.registryContract.GetStream(ctx, streamID, cc.blockchain.InitialBlockNum)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var node common.Address
+	if preferredNode != (common.Address{}) {
+		node = preferredNode
+	} else {
+		node = record.Stream.Nodes[0]
+	}
+
+	nodeRecord, err := cc.registryContract.NodeRegistry.GetNode(&bind.CallOpts{
+		Context: ctx,
+	}, node)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	httpClient, err := cc.getHttpClient()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	streamServiceClient := NewStreamServiceClient(httpClient, nodeRecord.Url, connect.WithGRPC())
+	return streamServiceClient, record, &nodeRecord, nil
+}
+
+func (cc *cmdContext) getStream(streamId StreamId, stub StreamServiceClient) (*StreamAndCookie, error) {
+	request := connect.NewRequest(&GetStreamRequest{
+		StreamId: streamId[:],
+	})
+	request.Header().Set(rpc.RiverNoForwardHeader, rpc.RiverHeaderTrueValue)
+	request.Header().Set(rpc.RiverAllowNoQuorumHeader, rpc.RiverHeaderTrueValue)
+	response, err := stub.GetStream(cc.ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return response.Msg.GetStream(), nil
+}

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	"github.com/towns-protocol/towns/core/node/events"
 	"github.com/towns-protocol/towns/core/node/infra"
@@ -23,6 +25,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	"github.com/towns-protocol/towns/core/node/registries"
 	"github.com/towns-protocol/towns/core/node/shared"
+	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/storage"
 )
 
@@ -273,19 +276,26 @@ func runStreamGetMiniblockCmd(cmd *cobra.Command, args []string) error {
 	}
 	from := max(to-blockRange, 0)
 
-	miniblocks, err := remoteClient.GetMiniblocks(ctx, connect.NewRequest(&protocol.GetMiniblocksRequest{
-		StreamId:      streamID[:],
-		FromInclusive: from,
-		ToExclusive:   to,
-	}))
-	if err != nil {
-		return err
+	var miniblocks []*protocol.Miniblock
+	for currentFrom := from; currentFrom < to; currentFrom += 100 {
+		currentTo := min(currentFrom+100, to)
+		resp, err := remoteClient.GetMiniblocks(ctx, connect.NewRequest(&protocol.GetMiniblocksRequest{
+			StreamId:      streamID[:],
+			FromInclusive: currentFrom,
+			ToExclusive:   currentTo,
+			OmitSnapshots: true,
+		}))
+		if err != nil {
+			return err
+		}
+		miniblocks = append(miniblocks, resp.Msg.GetMiniblocks()...)
 	}
 
-	for n, miniblock := range miniblocks.Msg.GetMiniblocks() {
+	for n, miniblock := range miniblocks {
 		// Parse header
 		info, err := events.NewMiniblockInfoFromProto(
-			miniblock, miniblocks.Msg.GetMiniblockSnapshot(from+int64(n)),
+			miniblock,
+			nil,
 			events.NewParsedMiniblockInfoOpts().
 				WithExpectedBlockNumber(from+int64(n)),
 		)
@@ -699,6 +709,91 @@ func runStreamPartitionCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func runStreamUserCmd(cmd *cobra.Command, args []string) error {
+	a := args[0]
+	if !common.IsHexAddress(a) {
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "Not a valid address", "arg", a)
+	}
+	address := common.HexToAddress(a)
+
+	fmt.Printf("%s\n", UserStreamIdFromAddr(address))
+	fmt.Printf("%s\n", UserSettingStreamIdFromAddr(address))
+	fmt.Printf("%s\n", UserMetadataStreamIdFromAddress(address))
+	fmt.Printf("%s\n", UserInboxStreamIdFromAddress(address))
+
+	return nil
+}
+
+func runStreamValidateCmd(cmd *cobra.Command, args []string) error {
+	cc, ctxCancel, err := newCmdContext(cmd, cmdConfig)
+	if err != nil {
+		return err
+	}
+	defer ctxCancel()
+
+	streamId, err := shared.StreamIdFromString(args[0])
+	if err != nil {
+		return err
+	}
+
+	stub, _, _, err := cc.getStubForStream(streamId, cc.nodeAddress)
+	if err != nil {
+		return err
+	}
+
+	stream, err := cc.getStream(streamId, stub)
+	if err != nil {
+		return err
+	}
+
+	si := &streamInfo{}
+	if err := si.init(stream); err != nil {
+		return err
+	}
+
+	if si.minKnownMb != math.MaxInt64 && si.minKnownMb > 0 {
+		for {
+			toExclusive := si.minKnownMb
+			fromInclusive := toExclusive - int64(cc.pageSize)
+			if fromInclusive < 0 {
+				fromInclusive = 0
+			}
+
+			resp, err := stub.GetMiniblocks(cc.ctx, connect.NewRequest(&protocol.GetMiniblocksRequest{
+				StreamId:      streamId[:],
+				FromInclusive: fromInclusive,
+				ToExclusive:   toExclusive,
+			}))
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Msg.Miniblocks) != 0 {
+				if err := si.addMbProtos(resp.Msg.Miniblocks, fromInclusive); err != nil {
+					return err
+				}
+			}
+
+			if fromInclusive == 0 || resp.Msg.Terminus {
+				break
+			}
+
+			if len(resp.Msg.Miniblocks) == 0 {
+				return RiverError(protocol.Err_INTERNAL, "No miniblocks found in range", "stream", streamId, "from", fromInclusive, "to", toExclusive)
+			}
+		}
+	}
+
+	err = si.validateEventMbRefs()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("OK\n")
+
+	return nil
+}
+
 func init() {
 	cmdStream := &cobra.Command{
 		Use:   "stream",
@@ -772,6 +867,25 @@ max-block-range is optional and limits the number of blocks to consider (default
 		RunE:  runStreamPartitionCmd,
 	}
 
+	cmdStreamUser := &cobra.Command{
+		Use:   "user <stream-id>",
+		Short: "Get user stream ids",
+		Long:  `Print 4 stream ids for the given user`,
+		Args:  cobra.RangeArgs(1, 1),
+		RunE:  runStreamUserCmd,
+	}
+
+	cmdStreamValidate := &cobra.Command{
+		Use:   "validate <stream-id>",
+		Short: "Validate stream contents",
+		Long:  `Validate stream content by loading all miniblocks and checking for duplicate events.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runStreamValidateCmd,
+	}
+	cmdStreamValidate.Flags().String("node", "", "Optional node address to fetch stream from")
+	cmdStreamValidate.Flags().Duration("timeout", 30*time.Second, "Timeout for running the command")
+	cmdStreamValidate.Flags().Int("page-size", 1000, "Number of miniblocks to fetch per page")
+
 	cmdStream.AddCommand(cmdStreamGetMiniblock)
 	cmdStream.AddCommand(cmdStreamGetMiniblockNum)
 	cmdStream.AddCommand(cmdStreamGetEvent)
@@ -780,5 +894,7 @@ max-block-range is optional and limits the number of blocks to consider (default
 	cmdStream.AddCommand(cmdStreamGet)
 	cmdStream.AddCommand(cmdStreamNodeGet)
 	cmdStream.AddCommand(cmdStreamGetPartition)
+	cmdStream.AddCommand(cmdStreamUser)
+	cmdStream.AddCommand(cmdStreamValidate)
 	rootCmd.AddCommand(cmdStream)
 }

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	"github.com/towns-protocol/towns/core/node/registries"
-	"github.com/towns-protocol/towns/core/node/shared"
 	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/storage"
 )
@@ -33,7 +32,7 @@ func getStreamFromNode(
 	ctx context.Context,
 	registryContract registries.RiverRegistryContract,
 	remoteNodeAddress common.Address,
-	streamID shared.StreamId,
+	streamID StreamId,
 ) error {
 	remote, err := registryContract.NodeRegistry.GetNode(nil, remoteNodeAddress)
 	if err != nil {
@@ -75,7 +74,7 @@ func getStreamFromNode(
 
 func runStreamGetEventCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -184,7 +183,7 @@ func runStreamNodeGetCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid argument 0: node-address")
 	}
 
-	streamID, err := shared.StreamIdFromString(args[1])
+	streamID, err := StreamIdFromString(args[1])
 	if err != nil {
 		return fmt.Errorf("invalid argument 1: stream-id; %w", err)
 	}
@@ -215,7 +214,7 @@ func runStreamNodeGetCmd(cmd *cobra.Command, args []string) error {
 
 func runStreamGetMiniblockCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -407,7 +406,7 @@ func printMbSummary(miniblock *protocol.Miniblock, snapshot *protocol.Envelope, 
 
 func runStreamGetMiniblockNumCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -473,7 +472,7 @@ func runStreamGetMiniblockNumCmd(cmd *cobra.Command, args []string) error {
 
 func runStreamDumpCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -573,7 +572,7 @@ func runStreamNodeDumpCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid argument 0: node-address")
 	}
 
-	streamId, err := shared.StreamIdFromString(args[1])
+	streamId, err := StreamIdFromString(args[1])
 	if err != nil {
 		return err
 	}
@@ -660,7 +659,7 @@ func runStreamNodeDumpCmd(cmd *cobra.Command, args []string) error {
 
 func runStreamGetCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -698,7 +697,7 @@ func runStreamGetCmd(cmd *cobra.Command, args []string) error {
 }
 
 func runStreamPartitionCmd(cmd *cobra.Command, args []string) error {
-	streamID, err := shared.StreamIdFromString(args[0])
+	streamID, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}
@@ -731,7 +730,7 @@ func runStreamValidateCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer ctxCancel()
 
-	streamId, err := shared.StreamIdFromString(args[0])
+	streamId, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}

--- a/core/cmd/stream_util.go
+++ b/core/cmd/stream_util.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"math"
+
+	"github.com/ethereum/go-ethereum/common"
+	. "github.com/towns-protocol/towns/core/node/base"
+	. "github.com/towns-protocol/towns/core/node/events"
+	. "github.com/towns-protocol/towns/core/node/protocol"
+)
+
+type streamInfo struct {
+	mbsByNum     map[int64]*MiniblockInfo
+	mbsByHash    map[common.Hash]*MiniblockInfo
+	eventsByHash map[common.Hash]*eventInfo
+	minKnownMb   int64
+}
+
+type eventInfo struct {
+	parsedEvent *ParsedEvent
+	mbNum       int64
+	pos         int
+}
+
+func (si *streamInfo) addMb(mb *MiniblockInfo) error {
+	if _, exists := si.mbsByNum[mb.Ref.Num]; exists {
+		return RiverError(Err_INTERNAL, "Duplicate miniblock number", "mb", mb.Ref)
+	}
+	si.mbsByNum[mb.Ref.Num] = mb
+	if _, exists := si.mbsByHash[mb.Ref.Hash]; exists {
+		return RiverError(Err_INTERNAL, "Duplicate miniblock hash", "mb", mb.Ref)
+	}
+	si.mbsByHash[mb.Ref.Hash] = mb
+
+	for i, event := range mb.Events() {
+		if err := si.addEvent(event, mb.Ref.Num, i); err != nil {
+			return err
+		}
+	}
+	if err := si.addEvent(mb.HeaderEvent(), mb.Ref.Num, -1); err != nil {
+		return err
+	}
+
+	if mb.Ref.Num < si.minKnownMb {
+		si.minKnownMb = mb.Ref.Num
+	}
+
+	return nil
+}
+
+func (si *streamInfo) addMbProtos(mbs []*Miniblock, expectedFirst int64) error {
+	var prev *MiniblockInfo
+	for _, mb := range mbs {
+		opts := NewParsedMiniblockInfoOpts()
+		if prev != nil {
+			opts = opts.WithExpectedBlockNumber(prev.Ref.Num + 1).WithExpectedPrevMiniblockHash(prev.Ref.Hash)
+		} else if expectedFirst > -1 {
+			opts = opts.WithExpectedBlockNumber(expectedFirst)
+		}
+		mbInfo, err := NewMiniblockInfoFromProto(mb, nil, opts)
+		if err != nil {
+			return err
+		}
+		if err := si.addMb(mbInfo); err != nil {
+			return err
+		}
+		prev = mbInfo
+	}
+	if expectedFirst > -1 && prev != nil {
+		nextBlockNum := prev.Ref.Num + 1
+		if nextBlock, exists := si.mbsByNum[nextBlockNum]; exists {
+			if common.Hash(nextBlock.HeaderEvent().Event.PrevMiniblockHash) != prev.Ref.Hash {
+				return RiverError(Err_INTERNAL, "Next block's hash doesn't match current block's hash",
+					"current_block", prev.Ref.Num,
+					"current_hash", prev.Ref.Hash.Hex(),
+					"next_block", nextBlockNum,
+					"next_hash", nextBlock.HeaderEvent().Hash.Hex())
+			}
+		} else {
+			return RiverError(Err_INTERNAL, "Expected next block not found",
+				"current", prev.Ref.Num,
+				"expected_next", nextBlockNum)
+		}
+	}
+	return nil
+}
+
+func (si *streamInfo) addEvent(event *ParsedEvent, mbNum int64, pos int) error {
+	if _, exists := si.eventsByHash[event.Hash]; exists {
+		return RiverError(Err_INTERNAL, "Duplicate event hash", "event", event.Hash.Hex())
+	}
+	si.eventsByHash[event.Hash] = &eventInfo{
+		parsedEvent: event,
+		mbNum:       mbNum,
+		pos:         pos,
+	}
+	return nil
+}
+
+func (si *streamInfo) addEventProto(event *Envelope, mbNum int64, pos int) error {
+	parsedEvent, err := ParseEvent(event)
+	if err != nil {
+		return err
+	}
+	return si.addEvent(parsedEvent, mbNum, pos)
+}
+
+func (si *streamInfo) init(stream *StreamAndCookie) error {
+	si.mbsByNum = make(map[int64]*MiniblockInfo)
+	si.mbsByHash = make(map[common.Hash]*MiniblockInfo)
+	si.eventsByHash = make(map[common.Hash]*eventInfo)
+	si.minKnownMb = math.MaxInt64
+
+	if err := si.addMbProtos(stream.Miniblocks, -1); err != nil {
+		return err
+	}
+	for i, event := range stream.Events {
+		if err := si.addEventProto(event, -1, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (si *streamInfo) validateEventMbRefs() error {
+	for _, e := range si.eventsByHash {
+		event := e.parsedEvent
+		if event.MiniblockRef == nil {
+			return RiverError(Err_INTERNAL, "Event has no miniblock reference", "event", event.Hash.Hex())
+		}
+		mb, exists := si.mbsByHash[event.MiniblockRef.Hash]
+		if !exists && e.mbNum != 0 {
+			return RiverError(Err_INTERNAL, "Event has miniblock reference to non-existent miniblock",
+				"event", event.Hash.Hex(), "miniblock", event.MiniblockRef.Hash.Hex())
+		}
+		if event.MiniblockRef.Num != -1 && mb.Ref.Num != event.MiniblockRef.Num {
+			return RiverError(Err_INTERNAL, "Event has miniblock reference to wrong miniblock",
+				"event", event.Hash.Hex(), "miniblock", event.MiniblockRef.Hash.Hex(), "expected", event.MiniblockRef.Num, "got", mb.Ref.Num)
+		}
+	}
+	return nil
+}

--- a/core/node/events/dumpevents/dump_events.go
+++ b/core/node/events/dumpevents/dump_events.go
@@ -53,9 +53,8 @@ func GetContentName(p IsStreamEvent_Payload) string {
 		return "NIL_CONTENT"
 	}
 	n := fmt.Sprintf("%T", c)
-	if u := strings.Index(n, "_"); u >= 0 {
-		n = n[u+1:]
-	}
+	n = strings.TrimPrefix(n, "*protocol.")
+	n = strings.TrimSuffix(n, "_")
 	return n
 }
 

--- a/core/node/events/miniblock_job.go
+++ b/core/node/events/miniblock_job.go
@@ -199,6 +199,10 @@ func (j *mbJob) processRemoteProposals(ctx context.Context) ([]*mbProposal, *Str
 	for i, p := range proposals {
 		converted[i] = mbProposalFromProto(p.response.Proposal)
 
+		if converted[i].newMiniblockNum != view.minipool.generation {
+			continue
+		}
+
 		for _, e := range p.response.MissingEvents {
 			parsed, err := ParseEvent(e)
 			if err != nil {
@@ -209,7 +213,7 @@ func (j *mbJob) processRemoteProposals(ctx context.Context) ([]*mbProposal, *Str
 				added[parsed.Hash] = true
 
 				if !view.minipool.events.Has(parsed.Hash) {
-					newView, err := j.stream.AddEvent2(ctx, parsed)
+					newView, err := j.stream.addEvent(ctx, parsed, true)
 					if err == nil {
 						view = newView
 					} else {

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -706,7 +706,8 @@ func (s *Stream) addEvent(ctx context.Context, event *ParsedEvent, relaxDuplicat
 // If relaxDuplicateCheck is true, it will not return an error if referenced miniblock can't be found in the cache.
 // In this case duplicate check can't be completed.
 // This options is used to add events that are reported by other nodes.
-// Without this option 
+// Without this option there are rare situations when events stay in minipools forever since they have mbs that too
+// old to be in the cache and thus can't complete the duplicate check.
 // addEventLocked is not thread-safe.
 // Callers must have a lock held.
 func (s *Stream) addEventLocked(ctx context.Context, event *ParsedEvent, relaxDuplicateCheck bool) (*StreamView, error) {

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -670,13 +670,7 @@ func (s *Stream) AddEvent(ctx context.Context, event *ParsedEvent) error {
 // AddEvent2 adds an event to the stream and returns the new stream view.
 // AddEvent2 is thread-safe.
 func (s *Stream) AddEvent2(ctx context.Context, event *ParsedEvent) (*StreamView, error) {
-	_, err := s.lockMuAndLoadView(ctx)
-	defer s.mu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-
-	return s.addEventLocked(ctx, event)
+	return s.addEvent(ctx, event, false)
 }
 
 // notifySubscribersLocked updates all callers with unseen events and the new sync cookie.
@@ -698,9 +692,24 @@ func (s *Stream) notifySubscribersLocked(
 	}
 }
 
+func (s *Stream) addEvent(ctx context.Context, event *ParsedEvent, relaxDuplicateCheck bool) (*StreamView, error) {
+	_, err := s.lockMuAndLoadView(ctx)
+	defer s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.addEventLocked(ctx, event, relaxDuplicateCheck)
+}
+
+// addEventLocked adds an event to the stream.
+// If relaxDuplicateCheck is true, it will not return an error if referenced miniblock can't be found in the cache.
+// In this case duplicate check can't be completed.
+// This options is used to add events that are reported by other nodes.
+// Without this option 
 // addEventLocked is not thread-safe.
 // Callers must have a lock held.
-func (s *Stream) addEventLocked(ctx context.Context, event *ParsedEvent) (*StreamView, error) {
+func (s *Stream) addEventLocked(ctx context.Context, event *ParsedEvent, relaxDuplicateCheck bool) (*StreamView, error) {
 	envelopeBytes, err := event.GetEnvelopeBytes()
 	if err != nil {
 		return nil, err
@@ -712,7 +721,11 @@ func (s *Stream) addEventLocked(ctx context.Context, event *ParsedEvent) (*Strea
 		if IsRiverErrorCode(err, Err_DUPLICATE_EVENT) {
 			return oldSV, nil
 		}
-		return nil, AsRiverError(err).Func("copyAndAddEvent")
+		skipError := relaxDuplicateCheck && IsRiverErrorCode(err, Err_BAD_PREV_MINIBLOCK_HASH)
+		if !skipError {
+			return nil, AsRiverError(err).Func("copyAndAddEvent")
+		}
+		logging.FromCtx(ctx).Warnw("Stream.addEventLocked: adding event with relaxed duplicate check", "error", err)
 	}
 
 	// Check if event can be added before writing to storage.

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -713,6 +713,7 @@ func (r *StreamView) ValidateNextEvent(
 				"expNum", lastBlock.Ref.Num,
 				"requestedBlockNum", parsedEvent.MiniblockRef.Num,
 				"requestedBlock", parsedEvent.MiniblockRef.Hash,
+				"firstLoadedBlockNum", r.blocks[0].Ref.Num,
 				"streamId", r.streamId,
 				"event", parsedEvent.Hash,
 			).Func("ValidateNextEvent")
@@ -750,6 +751,7 @@ func (r *StreamView) ValidateNextEvent(
 				"requestedBlock", parsedEvent.MiniblockRef.Hash,
 				"expected", lastBlock.Ref.Hash,
 				"expNum", lastBlock.Ref.Num,
+				"firstLoadedBlockNum", r.blocks[0].Ref.Num,
 				"streamId", r.streamId,
 				"event", parsedEvent.Hash,
 			).Func("ValidateNextEvent")
@@ -772,6 +774,7 @@ func (r *StreamView) ValidateNextEvent(
 			"requestedBlock", parsedEvent.MiniblockRef.Hash,
 			"expected", lastBlock.Ref.Hash,
 			"expNum", lastBlock.Ref.Num,
+			"firstLoadedBlockNum", r.blocks[0].Ref.Num,
 			"streamId", r.streamId,
 			"event", parsedEvent.Hash,
 		).Func("ValidateNextEvent")


### PR DESCRIPTION
Plus tooling to inspect streams for duplicate events.

Without this options in rare failure scenarios during node unavailability some events stay in minitpools forever since they are rejected by other nodes because they reference mb which is not in cache anymore and thus they can't complete duplicate check.
