### PR TITLE
node: reduce default worker pool online stream reconcile task size

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -41,7 +41,7 @@ func GetDefaultConfig() *Config {
 		// TODO: RegistryContract:  ContractConfig{},
 		StreamReconciliation: StreamReconciliationConfig{
 			InitialWorkerPoolSize: 4,
-			OnlineWorkerPoolSize:  32,
+			OnlineWorkerPoolSize:  16,
 			GetMiniblocksPageSize: 128,
 		},
 		Log: LogConfig{


### PR DESCRIPTION
Currently the worker pool size for stream reconcile tasks is by default 32. With the number of nodes growing this can put a lot of stress on nodes that process these tasks. This change reduces the default count to 16.

Long term solution is to harden the receiving service and return an error that indicates to the caller to retry it later because the service is too busy to accept additional requests from the caller.