### PR TITLE
chore: update @towns-protocol/diamond dependency to version 0.5.4 in package.json and yarn.lock

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,7 +29,7 @@
     "@openzeppelin/contracts": "^5.3.0",
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@prb/math": "^4.1.0",
-    "@towns-protocol/diamond": "^0.5.1",
+    "@towns-protocol/diamond": "^0.5.4",
     "crypto-lib": "github:towns-protocol/crypto-lib#f40c5f6944a55583a687b672ba680db3bfabb0ef",
     "solady": "^0.1.14"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8133,7 +8133,7 @@ __metadata:
     "@openzeppelin/merkle-tree": ^1.0.8
     "@prb/math": ^4.1.0
     "@prb/test": ^0.6.4
-    "@towns-protocol/diamond": ^0.5.1
+    "@towns-protocol/diamond": ^0.5.4
     "@towns-protocol/prettier-config": "workspace:^"
     "@wagmi/cli": ^2.2.0
     account-abstraction: "github:eth-infinitism/account-abstraction"
@@ -8147,15 +8147,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@towns-protocol/diamond@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "@towns-protocol/diamond@npm:0.5.1"
+"@towns-protocol/diamond@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@towns-protocol/diamond@npm:0.5.4"
   dependencies:
     "@openzeppelin/contracts": ^5.3.0
     "@prb/test": ^0.6.4
     forge-std: "github:foundry-rs/forge-std#v1.9.7"
     solady: ^0.1.14
-  checksum: bf6b42dca77e64b0f35742a59759ff53dafdeb6c2a20a2c9e459e2865ca7a2e3b535c51fb814a9a644d1bd0effe34d07f4df93b63b5334eedaa3affe8702f6b8
+  checksum: d1215edd76d69e80b95d0a987373837fd7d92471e8835f4bc41b742b39a84653bedc3d2f74d8e4a784cd8d18de01596117f46c4c22ce2faf664535ae57f9f8d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Upgrade the `@towns-protocol/diamond` dependency from version 0.5.1 to 0.5.4 to incorporate the latest improvements and bug fixes.

### Changes

- Updated `@towns-protocol/diamond` from version 0.5.1 to 0.5.4 in package.json
- Updated corresponding yarn.lock entries to reflect the new version

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines