### PR TITLE
Add instanceof check to prevent s.test is not a function issue

### DIFF
--- a/packages/dlog/src/dlog.ts
+++ b/packages/dlog/src/dlog.ts
@@ -10,14 +10,20 @@ debug.enabled = (ns: string): boolean => {
     }
 
     for (const s of debug.skips) {
-        if (s.test(ns)) {
-            return false
+        if (s instanceof RegExp) {
+            // users are complining that s.test is not a function in some cases
+            if (s.test(ns)) {
+                return false
+            }
         }
     }
 
     for (const s of debug.names) {
-        if (s.test(ns)) {
-            return true
+        if (s instanceof RegExp) {
+            if (s.test(ns)) {
+                // users are complining that s.test is not a function in some cases
+                return true
+            }
         }
     }
 


### PR DESCRIPTION
User report:
Hope you’re all doing great! I’m hitting a snag with the @towns-protocol/dlog package in a fresh Vite + React setup (both the official SDK boilerplate and a manual install). As soon as I import and call the hooks, I get this error in the console:

Uncaught (in promise) TypeError: s.test is not a function
This also breaks features like creating a new space—NFTs mint fine on-chain, but the space itself never loads.
 
Digging into dlog.js, I see:

for (const s of debug.names) {
  if (s.test(ns)) {    // ← s.test is not a function
    return true;
  }
}
It looks like debug.skips or debug.names contains non-RegExp entries, so s.test doesn’t exist. Since the package only ships its dist folder, I can’t patch it locally.