### PR TITLE
docs: fix broken link to config crate

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -51,4 +51,4 @@ quote_style = "double"
 wrap_comments = true
 sort_imports = true
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
### Description

Replaces outdated `/config` link with `/crates/config` after the directory move.  
Docs-only change; no functional impact.

### Checklist

- [ ] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
