### PR TITLE
fix: channelScrubbing.test.ts

### DIFF
--- a/packages/sdk/src/tests/multi/channelScrubbing.test.ts
+++ b/packages/sdk/src/tests/multi/channelScrubbing.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../testUtils'
 import { dlog } from '@towns-protocol/dlog'
 import { Address, TestERC721 } from '@towns-protocol/web3'
-
+import { ethers } from 'ethers'
 const log = dlog('csb:test:channelsWithEntitlements')
 
 describe('channelScrubbing', () => {
@@ -23,36 +23,48 @@ describe('channelScrubbing', () => {
         const TestNftAddress = await TestERC721.getContractAddress(TestNftName)
         const {
             alice,
-            bob,
             aliceSpaceDapp,
             aliceProvider,
-            carolsWallet: alicesLinkedWallet,
-            carolProvider: alicesLinkedProvider,
+            carol,
+            carolSpaceDapp,
+            carolProvider,
             spaceId,
             channelId,
         } = await setupChannelWithCustomRole([], getNftRuleData(TestNftAddress))
 
-        // Link carol's wallet to alice's as root
-        await linkWallets(aliceSpaceDapp, aliceProvider.wallet, alicesLinkedProvider.wallet)
+        const aliceLinkedWallet = ethers.Wallet.createRandom()
+        const carolLinkedWallet = ethers.Wallet.createRandom()
 
-        // Mint the needed asset to Alice's linked wallet
+        // link wallets
+        await Promise.all([
+            linkWallets(aliceSpaceDapp, aliceProvider.wallet, aliceLinkedWallet),
+            linkWallets(carolSpaceDapp, carolProvider.wallet, carolLinkedWallet),
+        ])
+        // Mint the needed asset to Alice and Carol's linked wallets
         log('Minting an NFT to alices linked wallet')
-        await TestERC721.publicMint(TestNftName, alicesLinkedWallet.address as Address)
+        await Promise.all([
+            TestERC721.publicMint(TestNftName, aliceLinkedWallet.address as Address),
+            TestERC721.publicMint(TestNftName, carolLinkedWallet.address as Address),
+        ])
 
         // Join alice to the channel based on her linked wallet credentials
         await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)
 
-        await unlinkWallet(aliceSpaceDapp, aliceProvider.wallet, alicesLinkedProvider.wallet)
+        await unlinkWallet(aliceSpaceDapp, aliceProvider.wallet, aliceLinkedWallet)
 
         // Wait 5 seconds so the channel stream will become eligible for scrubbing
         await new Promise((f) => setTimeout(f, 5000))
 
-        // When bob's join event is added to the stream, it should trigger a scrub, and Alice
+        // When carol's join event is added to the stream, it should trigger a scrub, and Alice
         // should be booted from the stream since she unlinked her entitled wallet.
-        await expect(bob.joinStream(channelId!)).resolves.not.toThrow()
+        await expectUserCanJoinChannel(carol, carolSpaceDapp, spaceId, channelId!)
 
         const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
         // Wait for alice's user stream to have the leave event
-        await waitFor(() => userStreamView.userContent.isMember(channelId!, MembershipOp.SO_LEAVE))
+        await waitFor(() =>
+            expect(userStreamView.userContent.isMember(channelId!, MembershipOp.SO_LEAVE)).toBe(
+                true,
+            ),
+        )
     })
 })


### PR DESCRIPTION
### Description

channelScrubbing.test wasn't testing loss entitlement anything because the final waitFor had no assertion

### Changes


- added assertion
- changed the joiner to be a member that was not already joined to the space, which kicked off the scrubber


### Checklist

- [x] Tests added where required