### PR TITLE
App registry changes to support h2c for local testing

### DIFF
--- a/core/node/app_registry/service.go
+++ b/core/node/app_registry/service.go
@@ -63,7 +63,7 @@ func NewService(
 	nodes []nodes.NodeRegistry,
 	metrics infra.MetricsFactory,
 	listener track_streams.StreamEventListener,
-	httpClient *http.Client,
+	webhookHttpClient *http.Client,
 ) (*Service, error) {
 	if len(nodes) < 1 {
 		return nil, base.RiverError(
@@ -88,7 +88,7 @@ func NewService(
 	if len(nodes) > 1 {
 		streamTrackerNodeRegistries = nodes[1:]
 	}
-	appClient := app_client.NewAppClient(httpClient, cfg.AllowInsecureWebhooks)
+	appClient := app_client.NewAppClient(webhookHttpClient, cfg.AllowInsecureWebhooks)
 	cache, err := NewCachedEncryptedMessageQueue(
 		ctx,
 		store,

--- a/core/node/app_registry/testutil.go
+++ b/core/node/app_registry/testutil.go
@@ -15,7 +15,10 @@ import (
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/towns-protocol/towns/core/node/app_registry/app_client"
@@ -25,7 +28,6 @@ import (
 	"github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
 	"github.com/towns-protocol/towns/core/node/shared"
-	"github.com/towns-protocol/towns/core/node/testutils/testcert"
 	"github.com/towns-protocol/towns/core/node/utils"
 )
 
@@ -125,12 +127,13 @@ func NewTestAppServer(
 	client protocolconnect.StreamServiceClient,
 	enableLogging bool,
 ) *TestAppServer {
-	listener, url := testcert.MakeTestListener(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
 
 	b := &TestAppServer{
 		t:             t,
 		listener:      listener,
-		url:           url,
+		url:           "https://" + listener.Addr().String(),
 		appWallet:     appWallet,
 		client:        client,
 		enableLogging: enableLogging,
@@ -616,8 +619,15 @@ func (b *TestAppServer) Serve(ctx context.Context) error {
 	// Register the handler for the root path
 	mux.HandleFunc("/", b.rootHandler)
 
+	// Define the h2c server
+	h2s := &http2.Server{}
+
+	// Wrap the mux in an h2c handler
+	h2cHandler := h2c.NewHandler(mux, h2s)
+
+	// Create and start the server
 	b.httpServer = &http.Server{
-		Handler: mux,
+		Handler: h2cHandler,
 		BaseContext: func(listener net.Listener) context.Context {
 			return ctx
 		},

--- a/core/node/http_client/client.go
+++ b/core/node/http_client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -75,6 +76,19 @@ func GetHttp11Client(ctx context.Context) (*http.Client, error) {
 			TLSClientConfig:   getTLSConfig(ctx),
 			ForceAttemptHTTP2: false,
 			TLSNextProto:      map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+		},
+	}, nil
+}
+
+func GetH2cHttpClient(ctx context.Context, cfg *config.Config) (*http.Client, error) {
+	// Define a custom HTTP/2 transport with h2c support
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				// This bypasses TLS and just dials a plain TCP connection
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			},
 		},
 	}, nil
 }

--- a/core/node/testutils/testcert/testcert.go
+++ b/core/node/testutils/testcert/testcert.go
@@ -122,8 +122,8 @@ func GetHttp2LocalhostTLSClient(ctx context.Context, _ *config.Config) (*http.Cl
 	}, nil
 }
 
-// MakeTestListener creates a localhost listener on a random port and and validates proper
-// listener creation. It does not clean up the listener on test close.
+// MakeTestListener creates a TLS-configured localhost listener on a random port and and
+// validates proper listener creation. It does not clean up the listener on test close.
 func MakeTestListener(t *testing.T) (net.Listener, string) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

Allow unencrypted http2 webhook calls for local testing to enable easier configuration of the bot framework tests.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
