### PR TITLE
Remove CI protoc dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,6 @@ jobs:
               with:
                   version: ${{ env.FOUNDRY_VERSION }}
 
-            - name: Install Protoc
-              uses: arduino/setup-protoc@v3
-
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'
@@ -407,9 +404,6 @@ jobs:
               with:
                   version: ${{ env.FOUNDRY_VERSION }}
 
-            - name: Install Protoc
-              uses: arduino/setup-protoc@v3
-
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'
@@ -559,9 +553,6 @@ jobs:
               with:
                   version: ${{ env.FOUNDRY_VERSION }}
 
-            - name: Install Protoc
-              uses: arduino/setup-protoc@v3
-
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'
@@ -699,9 +690,6 @@ jobs:
               with:
                   go-version-file: 'go.work'
                   cache-dependency-path: '**/*.sum'
-
-            - name: Install Protoc
-              uses: arduino/setup-protoc@v3
 
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

We are getting download failures for protoc due to github rate limits, but it may actually no longer be a build dependency for us. If CI passes, it's definitely not a dependency and we can go ahead and merge this removal.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
