### PR TITLE
Refactor isEntitled to return result instead of bool

### DIFF
--- a/core/cmd/is_entitled_cmd.go
+++ b/core/cmd/is_entitled_cmd.go
@@ -87,7 +87,7 @@ func isEntitledForSpaceAndChannel(
 		auth.PermissionRead,
 	)
 
-	isEntitled, err := chainAuth.IsEntitled(
+	isEntitledResult, err := chainAuth.IsEntitled(
 		ctx,
 		&cfg,
 		args,
@@ -99,7 +99,7 @@ func isEntitledForSpaceAndChannel(
 	fmt.Printf("User %v entitled to read permission for\n", userId)
 	fmt.Printf(" - space   %v\n", spaceId.String())
 	fmt.Printf(" - channel %v\n", channelId.String())
-	fmt.Printf("%v\n", isEntitled)
+	fmt.Printf("isEntitled: %v, reason: %v\n", isEntitledResult.IsEntitled(), isEntitledResult.Reason())
 	return nil
 }
 

--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -61,10 +61,16 @@ type IsEntitledResult interface {
 }
 
 func (r *isEntitledResult) IsEntitled() bool {
+	if r == nil {
+		return false
+	}
 	return r.isAllowed
 }
 
 func (r *isEntitledResult) Reason() EntitlementResultReason {
+	if r == nil {
+		return EntitlementResultReason_NONE
+	}
 	return r.reason
 }
 

--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -551,11 +551,11 @@ type entitlementCacheResult struct {
 	owner           common.Address
 }
 
-func (scr *entitlementCacheResult) IsAllowed() bool {
-	return scr.allowed
+func (ecr *entitlementCacheResult) IsAllowed() bool {
+	return ecr.allowed
 }
 
-func (scr *entitlementCacheResult) Reason() EntitlementResultReason {
+func (ecr *entitlementCacheResult) Reason() EntitlementResultReason {
 	return EntitlementResultReason_NONE // entitlement cache results are a second layer of caching, so we don't need to return a reason
 }
 

--- a/core/node/auth/auth_impl_cache.go
+++ b/core/node/auth/auth_impl_cache.go
@@ -35,11 +35,22 @@ const (
 	EntitlementResultReason_CHANNEL_DISABLED
 	EntitlementResultReason_WALLET_NOT_LINKED
 
-	EntitlementResultReason_MAX // leave at the end
+	EntitlementResultReason_MAX // MAX - leave at the end
 )
 
+var entitlementResultReasonDescriptions = []string{
+	"NONE",
+	"MEMBERSHIP",
+	"MEMBERSHIP_EXPIRED",
+	"SPACE_ENTITLEMENTS",
+	"CHANNEL_ENTITLEMENTS",
+	"SPACE_DISABLED",
+	"CHANNEL_DISABLED",
+	"WALLET_NOT_LINKED",
+}
+
 func (r EntitlementResultReason) String() string {
-	return []string{"NONE", "MEMBERSHIP", "MEMBERSHIP_EXPIRED", "SPACE_ENTITLEMENTS", "CHANNEL_ENTITLEMENTS", "SPACE_DISABLED", "CHANNEL_DISABLED", "WALLET_NOT_LINKED"}[r]
+	return entitlementResultReasonDescriptions[r]
 }
 
 type CacheResult interface {

--- a/core/node/auth/auth_impl_cache.go
+++ b/core/node/auth/auth_impl_cache.go
@@ -28,16 +28,18 @@ type EntitlementResultReason int
 const (
 	EntitlementResultReason_NONE EntitlementResultReason = iota
 	EntitlementResultReason_MEMBERSHIP
-	EntitlementResultReason_MEMBERSHIP_EXPIRATION
+	EntitlementResultReason_MEMBERSHIP_EXPIRED
 	EntitlementResultReason_SPACE_ENTITLEMENTS
 	EntitlementResultReason_CHANNEL_ENTITLEMENTS
 	EntitlementResultReason_SPACE_DISABLED
 	EntitlementResultReason_CHANNEL_DISABLED
 	EntitlementResultReason_WALLET_NOT_LINKED
+
+	EntitlementResultReason_MAX // leave at the end
 )
 
 func (r EntitlementResultReason) String() string {
-	return []string{"NONE", "MEMBERSHIP", "MEMBERSHIP_EXPIRATION", "SPACE_ENTITLEMENTS", "CHANNEL_ENTITLEMENTS", "SPACE_DISABLED", "CHANNEL_DISABLED"}[r]
+	return []string{"NONE", "MEMBERSHIP", "MEMBERSHIP_EXPIRED", "SPACE_ENTITLEMENTS", "CHANNEL_ENTITLEMENTS", "SPACE_DISABLED", "CHANNEL_DISABLED", "WALLET_NOT_LINKED"}[r]
 }
 
 type CacheResult interface {
@@ -109,10 +111,10 @@ func (ms *membershipStatusCacheResult) Reason() EntitlementResultReason {
 		return EntitlementResultReason_NONE
 	}
 	if !ms.status.IsMember {
-		return EntitlementResultReason_NOT_MEMBER
+		return EntitlementResultReason_MEMBERSHIP
 	}
 	if ms.status.IsExpired {
-		return EntitlementResultReason_EXPIRED
+		return EntitlementResultReason_MEMBERSHIP_EXPIRED
 	}
 	return EntitlementResultReason_NONE
 }
@@ -131,8 +133,12 @@ func (lwcv *linkedWalletCacheValue) IsAllowed() bool {
 	return true
 }
 
-func (lwcv *linkedWalletCacheValue) IsExpired() bool {
-	return false
+func (lwcv *linkedWalletCacheValue) Reason() EntitlementResultReason {
+	return EntitlementResultReason_NONE
+}
+
+func (lwcv *linkedWalletCacheValue) GetTimestamp() time.Time {
+	return time.Now()
 }
 
 func newEntitlementCache(ctx context.Context, cfg *config.ChainConfig) (*entitlementCache, error) {

--- a/core/node/auth/auth_impl_cache.go
+++ b/core/node/auth/auth_impl_cache.go
@@ -25,11 +25,13 @@ type entitlementCache struct {
 
 type CacheResult interface {
 	IsAllowed() bool
+	IsExpired() bool
 }
 
 // Cached results of isEntitlement check with the TTL of the result
 type entitlementCacheValue interface {
 	IsAllowed() bool
+	IsExpired() bool
 	GetTimestamp() time.Time
 }
 
@@ -40,6 +42,10 @@ type timestampedCacheValue struct {
 
 func (ccv *timestampedCacheValue) IsAllowed() bool {
 	return ccv.result.IsAllowed()
+}
+
+func (ccv *timestampedCacheValue) IsExpired() bool {
+	return ccv.result.IsExpired()
 }
 
 func (ccv *timestampedCacheValue) Result() CacheResult {
@@ -54,6 +60,10 @@ type boolCacheResult bool
 
 func (b boolCacheResult) IsAllowed() bool {
 	return bool(b)
+}
+
+func (b boolCacheResult) IsExpired() bool {
+	return false
 }
 
 type membershipStatusCacheResult struct {
@@ -71,6 +81,10 @@ func (ms *membershipStatusCacheResult) GetMembershipStatus() *MembershipStatus {
 	return ms.status
 }
 
+func (ms *membershipStatusCacheResult) IsExpired() bool {
+	return ms.status.IsExpired
+}
+
 type linkedWalletCacheValue struct {
 	wallets []common.Address
 }
@@ -83,6 +97,10 @@ func (lwcv *linkedWalletCacheValue) GetLinkedWallets() []common.Address {
 // the node busts the cache. See the note on newLinkedWalletCache below.
 func (lwcv *linkedWalletCacheValue) IsAllowed() bool {
 	return true
+}
+
+func (lwcv *linkedWalletCacheValue) IsExpired() bool {
+	return false
 }
 
 func newEntitlementCache(ctx context.Context, cfg *config.ChainConfig) (*entitlementCache, error) {

--- a/core/node/auth/auth_impl_cache_test.go
+++ b/core/node/auth/auth_impl_cache_test.go
@@ -24,11 +24,22 @@ func (scr *simpleCacheResult) Reason() EntitlementResultReason {
 	return EntitlementResultReason_NONE
 }
 
-func testEntitlementResultReasons(t *testing.T) {
+func TestEntitlementResultReasons(t *testing.T) {
 	for i := EntitlementResultReason_NONE; i < EntitlementResultReason_MAX; i++ {
 		assert.True(t, i >= EntitlementResultReason_NONE && i < EntitlementResultReason_MAX)
-		assert.NotNil(t, i.String()) // the stringer is an array, please keep it up to date
+		assert.NotNil(
+			t,
+			i.String(),
+			"EntitlementResultReason.String() is an array, please keep it up to date with EntitlementResultReason values",
+		)
 	}
+
+	// test that EntitlementReason_MAX is the last value
+	assert.Equal(
+		t,
+		EntitlementResultReason_MAX,
+		EntitlementResultReason(len(entitlementResultReasonDescriptions)),
+	)
 }
 
 // Test for the newEntitlementCache function

--- a/core/node/auth/auth_impl_cache_test.go
+++ b/core/node/auth/auth_impl_cache_test.go
@@ -20,6 +20,10 @@ func (scr *simpleCacheResult) IsAllowed() bool {
 	return scr.allowed
 }
 
+func (scr *simpleCacheResult) IsExpired() bool {
+	return false
+}
+
 // Test for the newEntitlementCache function
 func TestCache(t *testing.T) {
 	ctx, cancel := test.NewTestContext()

--- a/core/node/auth/auth_impl_cache_test.go
+++ b/core/node/auth/auth_impl_cache_test.go
@@ -20,10 +20,18 @@ func (scr *simpleCacheResult) IsAllowed() bool {
 	return scr.allowed
 }
 
-func (scr *simpleCacheResult) IsExpired() bool {
-	return false
+func (scr *simpleCacheResult) Reason() EntitlementResultReason {
+	return EntitlementResultReason_NONE
 }
 
+func testEntitlementResultReasons(t *testing.T) {
+	for i := EntitlementResultReason_NONE; i < EntitlementResultReason_MAX; i++ {
+		assert.True(t, i >= EntitlementResultReason_NONE && i < EntitlementResultReason_MAX)
+		assert.NotNil(t, i.String()) // the stringer is an array, please keep it up to date
+	}
+}
+
+// Test for the newEntitlementCache function
 // Test for the newEntitlementCache function
 func TestCache(t *testing.T) {
 	ctx, cancel := test.NewTestContext()

--- a/core/node/auth/fake_auth.go
+++ b/core/node/auth/fake_auth.go
@@ -16,8 +16,15 @@ type fakeChainAuth struct{}
 
 var _ ChainAuth = (*fakeChainAuth)(nil)
 
-func (a *fakeChainAuth) IsEntitled(ctx context.Context, cfg *config.Config, args *ChainAuthArgs) (bool, error) {
-	return true, nil
+func (a *fakeChainAuth) IsEntitled(
+	ctx context.Context,
+	cfg *config.Config,
+	args *ChainAuthArgs,
+) (IsEntitledResult, error) {
+	return &isEntitledResult{
+		isAllowed: true,
+		isExpired: false,
+	}, nil
 }
 
 func (a *fakeChainAuth) VerifyReceipt(

--- a/core/node/auth/fake_auth.go
+++ b/core/node/auth/fake_auth.go
@@ -23,7 +23,7 @@ func (a *fakeChainAuth) IsEntitled(
 ) (IsEntitledResult, error) {
 	return &isEntitledResult{
 		isAllowed: true,
-		isExpired: false,
+		reason:    EntitlementResultReason_NONE,
 	}, nil
 }
 

--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -146,11 +146,12 @@ func (s *Service) addParsedEvent(
 		var err error
 		// Determine if any chainAuthArgs grant entitlement
 		for _, chainAuthArgs := range verifications.OneOfChainAuths {
-			isEntitled, err = s.chainAuth.IsEntitled(ctx, s.config, chainAuthArgs)
+			isEntitledResult, err := s.chainAuth.IsEntitled(ctx, s.config, chainAuthArgs)
 			if err != nil {
 				return nil, err
 			}
-			if isEntitled {
+			if isEntitledResult.IsEntitled() {
+				isEntitled = true
 				break
 			}
 		}

--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/towns-protocol/towns/core/node/auth"
 	. "github.com/towns-protocol/towns/core/node/base"
 	. "github.com/towns-protocol/towns/core/node/events"
 	"github.com/towns-protocol/towns/core/node/logging"
@@ -142,21 +143,20 @@ func (s *Service) addParsedEvent(
 	}
 
 	if len(verifications.OneOfChainAuths) > 0 {
-		isEntitled := false
+		var isEntitledResult auth.IsEntitledResult
 		var err error
 		// Determine if any chainAuthArgs grant entitlement
 		for _, chainAuthArgs := range verifications.OneOfChainAuths {
-			isEntitledResult, err := s.chainAuth.IsEntitled(ctx, s.config, chainAuthArgs)
+			isEntitledResult, err = s.chainAuth.IsEntitled(ctx, s.config, chainAuthArgs)
 			if err != nil {
 				return nil, err
 			}
 			if isEntitledResult.IsEntitled() {
-				isEntitled = true
 				break
 			}
 		}
 		// If no chainAuthArgs grant entitlement, execute the OnChainAuthFailure side effect.
-		if !isEntitled {
+		if !isEntitledResult.IsEntitled() {
 			var newEvents []*EventRef = nil
 			if sideEffects.OnChainAuthFailure != nil {
 				newEvents, err = s.AddEventPayload(
@@ -172,6 +172,7 @@ func (s *Service) addParsedEvent(
 			return newEvents, RiverError(
 				Err_PERMISSION_DENIED,
 				"IsEntitled failed",
+				"reason", isEntitledResult.Reason().String(),
 				"chainAuthArgsList",
 				verifications.OneOfChainAuths,
 			).Func("addParsedEvent")

--- a/core/node/rpc/create_media_stream.go
+++ b/core/node/rpc/create_media_stream.go
@@ -118,6 +118,7 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 			return nil, RiverError(
 				Err_PERMISSION_DENIED,
 				"IsEntitled failed",
+				"reason", isEntitledResult.Reason().String(),
 				"chainAuthArgs",
 				csRules.ChainAuth.String(),
 			).Func("createStream")

--- a/core/node/rpc/create_media_stream.go
+++ b/core/node/rpc/create_media_stream.go
@@ -110,11 +110,11 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 
 	// check entitlements
 	if csRules.ChainAuth != nil {
-		isEntitled, err := s.chainAuth.IsEntitled(ctx, s.config, csRules.ChainAuth)
+		isEntitledResult, err := s.chainAuth.IsEntitled(ctx, s.config, csRules.ChainAuth)
 		if err != nil {
 			return nil, err
 		}
-		if !isEntitled {
+		if !isEntitledResult.IsEntitled() {
 			return nil, RiverError(
 				Err_PERMISSION_DENIED,
 				"IsEntitled failed",

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -114,11 +114,11 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 
 	// check entitlements
 	if csRules.ChainAuth != nil {
-		isEntitled, err := s.chainAuth.IsEntitled(ctx, s.config, csRules.ChainAuth)
+		isEntitledResult, err := s.chainAuth.IsEntitled(ctx, s.config, csRules.ChainAuth)
 		if err != nil {
 			return nil, nil, err
 		}
-		if !isEntitled {
+		if !isEntitledResult.IsEntitled() {
 			return nil, nil, RiverError(
 				Err_PERMISSION_DENIED,
 				"IsEntitled failed",

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -122,6 +122,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 			return nil, nil, RiverError(
 				Err_PERMISSION_DENIED,
 				"IsEntitled failed",
+				"reason", isEntitledResult.Reason().String(),
 				"chainAuthArgs",
 				csRules.ChainAuth.String(),
 			).Func("createStream")

--- a/core/node/rpc/membership_scrub_test.go
+++ b/core/node/rpc/membership_scrub_test.go
@@ -85,25 +85,21 @@ func createUserAndAddToChannel(
 
 type MockChainAuth struct {
 	auth.ChainAuth
-	result    bool
-	isExpired bool
-	err       error
+	result bool
+	err    error
 }
 
 type mockChainAuthResult struct {
 	isAllowed bool
-	isExpired bool
+	reason    auth.EntitlementResultReason
 }
 
 func (m *mockChainAuthResult) IsEntitled() bool {
 	return m.isAllowed
 }
 
-func (m *mockChainAuthResult) Reason() string {
-	if m.isExpired {
-		return "entitlement expired"
-	}
-	return "not entitled"
+func (m *mockChainAuthResult) Reason() auth.EntitlementResultReason {
+	return m.reason
 }
 
 func (m *MockChainAuth) IsEntitled(
@@ -113,15 +109,14 @@ func (m *MockChainAuth) IsEntitled(
 ) (auth.IsEntitledResult, error) {
 	return &mockChainAuthResult{
 		isAllowed: m.result,
-		isExpired: m.isExpired,
+		reason:    auth.EntitlementResultReason_NONE,
 	}, m.err
 }
 
 func NewMockChainAuth(expectedResult bool, expectedErr error) auth.ChainAuth {
 	return &MockChainAuth{
-		result:    expectedResult,
-		isExpired: false,
-		err:       expectedErr,
+		result: expectedResult,
+		err:    expectedErr,
 	}
 }
 
@@ -142,13 +137,13 @@ func (m *MockChainAuthForWallets) IsEntitled(
 		if args.Principal() == wallet.Address {
 			return &mockChainAuthResult{
 				isAllowed: result.expectedResult,
-				isExpired: false,
+				reason:    auth.EntitlementResultReason_NONE,
 			}, result.expectedErr
 		}
 	}
 	return &mockChainAuthResult{
 		isAllowed: true,
-		isExpired: false,
+		reason:    auth.EntitlementResultReason_NONE,
 	}, nil
 }
 

--- a/core/node/scrub/stream_membership_scrub_task.go
+++ b/core/node/scrub/stream_membership_scrub_task.go
@@ -115,7 +115,7 @@ func (tp *streamMembershipScrubTaskProcessorImpl) processMemberImpl(
 	tp.membershipChecks.Inc()
 
 	spaceId := channelId.SpaceID()
-	isEntitled, err := tp.chainAuth.IsEntitled(
+	isEntitledResult, err := tp.chainAuth.IsEntitled(
 		ctx,
 		tp.config,
 		auth.NewChainAuthArgsForChannel(
@@ -130,12 +130,12 @@ func (tp *streamMembershipScrubTaskProcessorImpl) processMemberImpl(
 	}
 
 	if span != nil {
-		span.SetAttributes(attribute.Bool("isEntitled", isEntitled))
+		span.SetAttributes(attribute.Bool("isEntitled", isEntitledResult.IsEntitled()))
 	}
 
 	// In the case that the user is not entitled, they must have lost their entitlement
 	// after joining the channel, so let's go ahead and boot them.
-	if !isEntitled {
+	if !isEntitledResult.IsEntitled() {
 		tp.entitlementLosses.Inc()
 
 		userId, err := AddressFromUserId(member)


### PR DESCRIPTION
Add stub for Evan to add reason into the result
Reasoning: We want to differentiate between leave membership events which were initiated by the user, by the scrubber when entitlements were lost, and by the scrubber when membership has expired.