### PR TITLE
Add membership renewal functionality and expiration checks

### DIFF
--- a/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
@@ -16,14 +16,14 @@ import { MembershipOp } from '@towns-protocol/proto'
 import { ethers } from 'ethers'
 
 const SHORT_MEMBERSHIP_DURATION = 20 // seconds
-const WAIT_TIME = SHORT_MEMBERSHIP_DURATION * 1_000 + 1_000
+const WAIT_TIME = SHORT_MEMBERSHIP_DURATION * 1_000 + 500
 
 // this test is long because it has to wait for the membership to expire in real time
 // but the membership duration has to be long enough such that other actions/assertions can be made
 // it tests both node entitlement checks for expired memberships, as well as client entitlement checks via space dapp
 
 describe('membershipRenewals', () => {
-    test('expired membership is not allowed to join', async () => {
+    test.concurrent('expired membership is not allowed to join', async () => {
         const { spaceId, channelId, alice, bob, aliceSpaceDapp, aliceProvider, alicesWallet } =
             await createTownWithRequirements({
                 everyone: true,
@@ -63,120 +63,170 @@ describe('membershipRenewals', () => {
         await bob.stopSync()
     })
 
-    test('user with expired membership is bounced from a channel after scrub is triggered', async () => {
-        const {
-            spaceId,
-            channelId,
-            alice,
-            carol,
-            aliceSpaceDapp,
-            aliceProvider,
-            alicesWallet,
-            carolSpaceDapp,
-            carolProvider,
-            carolsWallet,
-        } = await createTownWithRequirements({
-            everyone: true,
-            users: [],
-            ruleData: NoopRuleData,
-            duration: SHORT_MEMBERSHIP_DURATION,
-        })
+    test.concurrent(
+        'user with expired membership is bounced from a channel after scrub is triggered',
+        async () => {
+            const {
+                spaceId,
+                channelId,
+                alice,
+                carol,
+                aliceSpaceDapp,
+                aliceProvider,
+                alicesWallet,
+                carolSpaceDapp,
+                carolProvider,
+                carolsWallet,
+            } = await createTownWithRequirements({
+                everyone: true,
+                users: [],
+                ruleData: NoopRuleData,
+                duration: SHORT_MEMBERSHIP_DURATION,
+            })
 
-        await expectUserCanJoin(
-            spaceId,
-            channelId,
-            'alice',
-            alice,
-            aliceSpaceDapp,
-            alicesWallet.address,
-            aliceProvider.wallet,
-        )
+            await expectUserCanJoin(
+                spaceId,
+                channelId,
+                'alice',
+                alice,
+                aliceSpaceDapp,
+                alicesWallet.address,
+                aliceProvider.wallet,
+            )
 
-        await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId)
-        // Wait for membership to expire (and for channel to be eligible for scrubbing)
-        await new Promise((f) => setTimeout(f, WAIT_TIME))
+            await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId)
+            // Wait for membership to expire (and for channel to be eligible for scrubbing)
+            await new Promise((f) => setTimeout(f, WAIT_TIME))
 
-        await expectUserCanJoin(
-            spaceId,
-            channelId,
-            'carol',
-            carol,
-            carolSpaceDapp,
-            carolsWallet.address,
-            carolProvider.wallet,
-        )
-        // When carol's join event is added to the stream, it should trigger a scrub, and Alice
-        // should be booted from the stream since her membership has expired
-        await expect(carol.joinStream(channelId)).resolves.not.toThrow()
-        const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
+            await expectUserCanJoin(
+                spaceId,
+                channelId,
+                'carol',
+                carol,
+                carolSpaceDapp,
+                carolsWallet.address,
+                carolProvider.wallet,
+            )
+            // When carol's join event is added to the stream, it should trigger a scrub, and Alice
+            // should be booted from the stream since her membership has expired
+            await expect(carol.joinStream(channelId)).resolves.not.toThrow()
+            const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
 
-        // Wait for alice's user stream to have the leave event
-        await waitFor(async () => {
-            return expect(
-                userStreamView.userContent.isMember(channelId, MembershipOp.SO_LEAVE),
-            ).toBe(true)
-        })
+            // Wait for alice's user stream to have the leave event
+            await waitFor(async () => {
+                return expect(
+                    userStreamView.userContent.isMember(channelId, MembershipOp.SO_LEAVE),
+                ).toBe(true)
+            })
 
-        // Clean up
-        await alice.stopSync()
-        await carol.stopSync()
-    })
+            // Clean up
+            await alice.stopSync()
+            await carol.stopSync()
+        },
+    )
 
-    test('user with unexpired membership is not bounced from a channel after scrub is triggered', async () => {
-        const {
-            spaceId,
-            channelId,
-            alice,
-            carol,
-            aliceSpaceDapp,
-            aliceProvider,
-            alicesWallet,
-            carolSpaceDapp,
-            carolProvider,
-            carolsWallet,
-        } = await createTownWithRequirements({
-            everyone: true,
-            users: [],
-            ruleData: NoopRuleData,
-            duration: SHORT_MEMBERSHIP_DURATION,
-        })
+    test.concurrent(
+        'user with unexpired membership is not bounced from a channel after scrub is triggered',
+        async () => {
+            const {
+                spaceId,
+                channelId,
+                alice,
+                carol,
+                aliceSpaceDapp,
+                aliceProvider,
+                alicesWallet,
+                carolSpaceDapp,
+                carolProvider,
+                carolsWallet,
+            } = await createTownWithRequirements({
+                everyone: true,
+                users: [],
+                ruleData: NoopRuleData,
+                duration: SHORT_MEMBERSHIP_DURATION,
+            })
 
-        await expectUserCanJoin(
-            spaceId,
-            channelId,
-            'alice',
-            alice,
-            aliceSpaceDapp,
-            alicesWallet.address,
-            aliceProvider.wallet,
-        )
+            await expectUserCanJoin(
+                spaceId,
+                channelId,
+                'alice',
+                alice,
+                aliceSpaceDapp,
+                alicesWallet.address,
+                aliceProvider.wallet,
+            )
 
-        // link a wallet to alice
-        const eoaWallet = ethers.Wallet.createRandom()
-        await linkWallets(aliceSpaceDapp, aliceProvider.wallet, eoaWallet)
+            // link a wallet to alice
+            const eoaWallet = ethers.Wallet.createRandom()
+            await linkWallets(aliceSpaceDapp, aliceProvider.wallet, eoaWallet)
 
-        // have alice join the channel
-        await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId)
+            // have alice join the channel
+            await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId)
 
-        // Wait for membership to expire (and for channel to be eligible for scrubbing)
-        await new Promise((f) => setTimeout(f, WAIT_TIME))
+            // Wait for membership to expire (and for channel to be eligible for scrubbing)
+            await new Promise((f) => setTimeout(f, WAIT_TIME))
 
-        // make sure this membership has expired
-        const space = aliceSpaceDapp.getSpace(spaceId)
-        const tokenId = await aliceSpaceDapp.getTokenIdOfOwner(spaceId, alicesWallet.address)
-        const expiresAt = await space?.Membership.read.expiresAt(tokenId!)
-        const expiresAtTimestamp = expiresAt?.toNumber() || 0
-        const now = new Date()
-        const timeUntilExpiration = (expiresAtTimestamp * 1000 - now.getTime()) / 1000
-        expect(timeUntilExpiration).toBeLessThan(0)
+            // make sure this membership has expired
+            const space = aliceSpaceDapp.getSpace(spaceId)
+            const tokenId = await aliceSpaceDapp.getTokenIdOfOwner(spaceId, alicesWallet.address)
+            const expiresAt = await space?.Membership.read.expiresAt(tokenId!)
+            const expiresAtTimestamp = expiresAt?.toNumber() || 0
+            const now = new Date()
+            const timeUntilExpiration = (expiresAtTimestamp * 1000 - now.getTime()) / 1000
+            expect(timeUntilExpiration).toBeLessThan(0)
 
-        // now mint a membership for the eoa wallet, which is linked to alice - mint only, not joining stream
-        await aliceSpaceDapp.joinSpace(spaceId, eoaWallet.address, aliceProvider.wallet)
+            // now mint a membership for the eoa wallet, which is linked to alice - mint only, not joining stream
+            await aliceSpaceDapp.joinSpace(spaceId, eoaWallet.address, aliceProvider.wallet)
 
-        const aliceWallets = await aliceSpaceDapp.getLinkedWallets(alicesWallet.address)
-        const membershipStatus = await aliceSpaceDapp.getMembershipStatus(spaceId, aliceWallets)
-        expect(membershipStatus.isMember).toBe(true)
-        expect(membershipStatus.isExpired).toBe(false)
+            const aliceWallets = await aliceSpaceDapp.getLinkedWallets(alicesWallet.address)
+            const membershipStatus = await aliceSpaceDapp.getMembershipStatus(spaceId, aliceWallets)
+            expect(membershipStatus.isMember).toBe(true)
+            expect(membershipStatus.isExpired).toBe(false)
+            const entitledWallet = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
+                spaceId,
+                alicesWallet.address,
+                getXchainConfigForTesting(),
+            )
+            expect(entitledWallet).toBeDefined()
+
+            await expectUserCanJoin(
+                spaceId,
+                channelId,
+                'carol',
+                carol,
+                carolSpaceDapp,
+                carolsWallet.address,
+                carolProvider.wallet,
+            )
+            // When carol's join event is added to the stream, it should trigger a scrub, and Alice
+            // should not be booted from the stream since her she has an additional token that is not expired
+            await expect(carol.joinStream(channelId)).resolves.not.toThrow()
+            const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
+
+            // wait for any caches to be invalidated
+            await new Promise((f) => setTimeout(f, 5_000))
+
+            // Wait for alice's user stream to have the leave event
+            expect(userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true)
+
+            // Clean up
+            await alice.stopSync()
+            await carol.stopSync()
+        },
+    )
+
+    test.concurrent('(BASE only) user can renew membership', async () => {
+        const _MEMBERSHIP_DURATION = 10
+        const { spaceId, aliceSpaceDapp, aliceProvider, alicesWallet } =
+            await createTownWithRequirements({
+                everyone: true,
+                users: [],
+                ruleData: NoopRuleData,
+                duration: _MEMBERSHIP_DURATION,
+            })
+
+        // Check that the local evaluation of the user's entitlements for joining the space
+        // passes.
         const entitledWallet = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
             spaceId,
             alicesWallet.address,
@@ -184,53 +234,55 @@ describe('membershipRenewals', () => {
         )
         expect(entitledWallet).toBeDefined()
 
-        await expectUserCanJoin(
+        const { issued } = await aliceSpaceDapp.joinSpace(
             spaceId,
-            channelId,
-            'carol',
-            carol,
-            carolSpaceDapp,
-            carolsWallet.address,
-            carolProvider.wallet,
+            alicesWallet.address,
+            aliceProvider.wallet,
         )
-        // When carol's join event is added to the stream, it should trigger a scrub, and Alice
-        // should not be booted from the stream since her she has an additional token that is not expired
-        await expect(carol.joinStream(channelId)).resolves.not.toThrow()
-        const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
+        expect(issued).toBe(true)
 
-        // wait for any caches to be invalidated
-        await new Promise((f) => setTimeout(f, 5_000))
+        // wait for membership to expire
+        await new Promise((resolve) => setTimeout(resolve, _MEMBERSHIP_DURATION * 1_000 + 500))
 
-        // Wait for alice's user stream to have the leave event
-        expect(userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true)
+        const aliceWallets = await aliceSpaceDapp.getLinkedWallets(alicesWallet.address)
+        const membershipStatus = await aliceSpaceDapp.getMembershipStatus(spaceId, aliceWallets)
+        expect(membershipStatus.isMember).toBe(true)
+        expect(membershipStatus.isExpired).toBe(true)
+        const entitledWalletAfterExpiry = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
+            spaceId,
+            alicesWallet.address,
+            getXchainConfigForTesting(),
+        )
+        expect(entitledWalletAfterExpiry).toBeUndefined()
 
-        // Clean up
-        await alice.stopSync()
-        await carol.stopSync()
+        const space = aliceSpaceDapp.getSpace(spaceId)
+
+        const tokenId = membershipStatus.tokenId
+        expect(tokenId).toBeDefined()
+
+        if (!tokenId || !space) {
+            throw new Error('TokenId or space not found')
+        }
+
+        const tx = await space.renewMembership({
+            tokenId,
+            signer: aliceProvider.wallet,
+        })
+        const receipt = await tx.wait()
+        expect(receipt.status).toBe(1)
+
+        const membershipStatusAfterRenewal = await space.getMembershipStatus(aliceWallets)
+        expect(membershipStatusAfterRenewal.isMember).toBe(true)
+        expect(membershipStatusAfterRenewal.isExpired).toBe(false)
+
+        // wait for caches to be invalidated
+        await new Promise((resolve) => setTimeout(resolve, 5_000))
+
+        const entitledWalletAfterRenewal = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
+            spaceId,
+            alicesWallet.address,
+            getXchainConfigForTesting(),
+        )
+        expect(entitledWalletAfterRenewal).toBeDefined()
     })
-
-    // test('user can renew membership', async () => {
-    //     const { spaceId, channelId, alice, aliceSpaceDapp, aliceProvider, alicesWallet } =
-    //         await createTownWithRequirements({
-    //             everyone: true,
-    //             users: [],
-    //             ruleData: NoopRuleData,
-    //             duration: 5,
-    //         })
-
-    //     await expectUserCanJoin(
-    //         spaceId,
-    //         channelId,
-    //         'alice',
-    //         alice,
-    //         aliceSpaceDapp,
-    //         alicesWallet.address,
-    //         aliceProvider.wallet,
-    //     )
-
-    //     await new Promise((resolve) => setTimeout(resolve, 5_000))
-
-    //     // wait for membership to expire
-    //     await new Promise((resolve) => setTimeout(resolve, WAIT_TIME))
-    // })
 })

--- a/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
@@ -15,8 +15,12 @@ import { makeUserStreamId } from '../../../id'
 import { MembershipOp } from '@towns-protocol/proto'
 import { ethers } from 'ethers'
 
-const SHORT_MEMBERSHIP_DURATION = 10 // seconds
+const SHORT_MEMBERSHIP_DURATION = 20 // seconds
 const WAIT_TIME = SHORT_MEMBERSHIP_DURATION * 1_000 + 1_000
+
+// this test is long because it has to wait for the membership to expire in real time
+// but the membership duration has to be long enough such that other actions/assertions can be made
+// it tests both node entitlement checks for expired memberships, as well as client entitlement checks via space dapp
 
 describe('membershipRenewals', () => {
     test('expired membership is not allowed to join', async () => {
@@ -204,4 +208,29 @@ describe('membershipRenewals', () => {
         await alice.stopSync()
         await carol.stopSync()
     })
+
+    // test('user can renew membership', async () => {
+    //     const { spaceId, channelId, alice, aliceSpaceDapp, aliceProvider, alicesWallet } =
+    //         await createTownWithRequirements({
+    //             everyone: true,
+    //             users: [],
+    //             ruleData: NoopRuleData,
+    //             duration: 5,
+    //         })
+
+    //     await expectUserCanJoin(
+    //         spaceId,
+    //         channelId,
+    //         'alice',
+    //         alice,
+    //         aliceSpaceDapp,
+    //         alicesWallet.address,
+    //         aliceProvider.wallet,
+    //     )
+
+    //     await new Promise((resolve) => setTimeout(resolve, 5_000))
+
+    //     // wait for membership to expire
+    //     await new Promise((resolve) => setTimeout(resolve, WAIT_TIME))
+    // })
 })

--- a/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
@@ -42,16 +42,16 @@ describe('membershipRenewals', () => {
         await new Promise((resolve) => setTimeout(resolve, WAIT_TIME))
         await alice.leaveStream(spaceId)
 
-        // space dapp does not check expiration, so we'll still get an entitled wallet
+        const aliceWallets = await aliceSpaceDapp.getLinkedWallets(alicesWallet.address)
+        const membershipStatus = await aliceSpaceDapp.getMembershipStatus(spaceId, aliceWallets)
+        expect(membershipStatus.isMember).toBe(true)
+        expect(membershipStatus.isExpired).toBe(true)
         const entitledWallet = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
             spaceId,
             alicesWallet.address,
             getXchainConfigForTesting(),
         )
-        expect(entitledWallet).toBeDefined()
-        // same here
-        const hasMembership = await aliceSpaceDapp.hasSpaceMembership(spaceId, entitledWallet!)
-        expect(hasMembership).toBe(true)
+        expect(entitledWallet).toBeUndefined()
 
         await expect(alice.joinStream(spaceId)).rejects.toThrow(/7:PERMISSION_DENIED/)
         // Clean up
@@ -168,6 +168,17 @@ describe('membershipRenewals', () => {
 
         // now mint a membership for the eoa wallet, which is linked to alice - mint only, not joining stream
         await aliceSpaceDapp.joinSpace(spaceId, eoaWallet.address, aliceProvider.wallet)
+
+        const aliceWallets = await aliceSpaceDapp.getLinkedWallets(alicesWallet.address)
+        const membershipStatus = await aliceSpaceDapp.getMembershipStatus(spaceId, aliceWallets)
+        expect(membershipStatus.isMember).toBe(true)
+        expect(membershipStatus.isExpired).toBe(false)
+        const entitledWallet = await aliceSpaceDapp.getEntitledWalletForJoiningSpace(
+            spaceId,
+            alicesWallet.address,
+            getXchainConfigForTesting(),
+        )
+        expect(entitledWallet).toBeDefined()
 
         await expectUserCanJoin(
             spaceId,

--- a/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
+++ b/packages/sdk/src/tests/multi/entitlements/membershipRenewals.test.ts
@@ -203,11 +203,12 @@ describe('membershipRenewals', () => {
             await expect(carol.joinStream(channelId)).resolves.not.toThrow()
             const userStreamView = (await alice.waitForStream(makeUserStreamId(alice.userId))).view
 
-            // wait for any caches to be invalidated
-            await new Promise((f) => setTimeout(f, 5_000))
-
             // Wait for alice's user stream to have the leave event
-            expect(userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true)
+            await waitFor(async () => {
+                return expect(
+                    userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN),
+                ).toBe(true)
+            })
 
             // Clean up
             await alice.stopSync()

--- a/packages/stress/src/mode/chat/joinChat.ts
+++ b/packages/stress/src/mode/chat/joinChat.ts
@@ -16,7 +16,8 @@ export async function joinChat(client: StressClient, cfg: ChatConfig) {
 
     // wait for the user to have a membership nft
     await client.waitFor(
-        () => client.spaceDapp.hasSpaceMembership(cfg.spaceId, client.baseProvider.wallet.address),
+        () =>
+            client.spaceDapp.getMembershipStatus(cfg.spaceId, [client.baseProvider.wallet.address]),
         {
             interval: 1000 + Math.random() * 1000,
             timeoutMs: cfg.waitForSpaceMembershipTimeoutMs,

--- a/packages/stress/src/mode/chat/kickoffChat.ts
+++ b/packages/stress/src/mode/chat/kickoffChat.ts
@@ -61,10 +61,9 @@ export async function kickoffChat(rootClient: StressClient, cfg: ChatConfig) {
     )
 
     const mintMembershipForWallet = async (wallet: Wallet, i: number) => {
-        const hasSpaceMembership = await rootClient.spaceDapp.hasSpaceMembership(
-            spaceId,
-            wallet.address,
-        )
+        const hasSpaceMembership = (
+            await rootClient.spaceDapp.getMembershipStatus(spaceId, [wallet.address])
+        ).isMember
         logger.debug({ i, address: wallet.address, hasSpaceMembership }, 'minting membership')
         if (!hasSpaceMembership) {
             const result = await rootClient.spaceDapp.joinSpace(

--- a/packages/stress/src/mode/slowchat/joinSlowChat.ts
+++ b/packages/stress/src/mode/slowchat/joinSlowChat.ts
@@ -13,7 +13,12 @@ export async function joinSlowChat(client: StressClient, cfg: ChatConfig) {
 
     // wait for the user to have a membership nft
     await client.waitFor(
-        () => client.spaceDapp.hasSpaceMembership(cfg.spaceId, client.baseProvider.wallet.address),
+        async () =>
+            (
+                await client.spaceDapp.getMembershipStatus(cfg.spaceId, [
+                    client.baseProvider.wallet.address,
+                ])
+            ).isMember,
         {
             interval: 1000 + Math.random() * 1000,
             timeoutMs: cfg.waitForSpaceMembershipTimeoutMs,

--- a/packages/web3/src/BaseContractShim.ts
+++ b/packages/web3/src/BaseContractShim.ts
@@ -109,14 +109,16 @@ export class BaseContractShim<
     public decodeFunctionResult<FnName extends keyof T_CONTRACT['functions']>(
         functionName: FnName,
         data: BytesLike,
-    ) {
+    ): Awaited<ReturnType<T_CONTRACT['functions'][FnName]>> {
         if (typeof functionName !== 'string') {
             throw new Error('functionName must be a string')
         }
         if (!this.interface.getFunction(functionName)) {
             throw new Error(`Function ${functionName} not found in contract interface`)
         }
-        return this.interface.decodeFunctionResult(functionName, data)
+        const decoded = this.interface.decodeFunctionResult(functionName, data)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return decoded as Awaited<ReturnType<T_CONTRACT['functions'][FnName]>>
     }
 
     public decodeFunctionData<FnName extends keyof T_CONTRACT['functions']>(

--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -855,6 +855,7 @@ export class SpaceDapp {
         permission: Permission,
     ): Promise<EntitledWallet> {
         const { isMember, isExpired } = await space.getMembershipStatus(allWallets)
+
         if (permission === Permission.JoinSpace) {
             // if you're joining a space with an expired membership, you're not entitled to join
             if (isMember && isExpired) {

--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -852,18 +852,11 @@ export class SpaceDapp {
         allWallets: string[],
         entitlements: EntitlementData[],
         xchainConfig: XchainConfig,
-        permission: Permission,
     ): Promise<EntitledWallet> {
-        const { isMember, isExpired } = await space.getMembershipStatus(allWallets)
+        const { isExpired } = await space.getMembershipStatus(allWallets)
 
-        if (permission === Permission.JoinSpace) {
-            // if you're joining a space with an expired membership, you're not entitled to join
-            if (isMember && isExpired) {
-                return
-            }
-        }
         // otherwise you're trying to do something with an expired membership
-        else if (isExpired) {
+        if (isExpired) {
             return
         }
 
@@ -992,7 +985,6 @@ export class SpaceDapp {
             allWallets,
             entitlements,
             xchainConfig,
-            Permission.JoinSpace,
         )
     }
 
@@ -1102,7 +1094,6 @@ export class SpaceDapp {
             linkedWallets,
             entitlements,
             xchainConfig,
-            permission,
         )
         return entitledWallet !== undefined
     }

--- a/packages/web3/src/space-owner/SpaceOwner.ts
+++ b/packages/web3/src/space-owner/SpaceOwner.ts
@@ -1,6 +1,6 @@
 import { ContractTransaction, ethers } from 'ethers'
 import { ISpaceOwnerBase } from '@towns-protocol/generated/dev/typings/SpaceOwner'
-import { BaseContractShim } from '../BaseContractShim'
+import { BaseContractShim, OverrideExecution } from '../BaseContractShim'
 import { SpaceOwner__factory } from '@towns-protocol/generated/dev/typings/factories/SpaceOwner__factory'
 import { Keyable } from '../cache/Keyable'
 import { SimpleCache } from '../cache/SimpleCache'
@@ -53,7 +53,7 @@ export class SpaceOwner extends BaseContractShim<typeof connect> {
         shortDescription: string
         longDescription: string
         signer: ethers.Signer
-        overrideExecution?: (calldata: string) => Promise<T>
+        overrideExecution?: OverrideExecution<T>
         transactionOpts?: TransactionOpts
     }) {
         const {

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -4,7 +4,7 @@ import { dlogger } from '@towns-protocol/dlog'
 import { IMembershipMetadataShim } from './IMembershipMetadataShim'
 import { MembershipFacet__factory } from '@towns-protocol/generated/dev/typings/factories/MembershipFacet__factory'
 import { IERC721AShim } from '../erc-721/IERC721AShim'
-
+import { IMulticallShim } from './IMulticallShim'
 const log = dlogger('csb:IMembershipShim')
 
 const { abi, connect } = MembershipFacet__factory
@@ -12,16 +12,13 @@ const { abi, connect } = MembershipFacet__factory
 export class IMembershipShim extends BaseContractShim<typeof connect> {
     private erc721Shim: IERC721AShim
     metadata: IMembershipMetadataShim
+    multicall: IMulticallShim
 
     constructor(address: string, provider: ethers.providers.Provider) {
         super(address, provider, connect, abi)
         this.erc721Shim = new IERC721AShim(address, provider)
         this.metadata = new IMembershipMetadataShim(address, provider)
-    }
-
-    async hasMembership(wallet: string) {
-        const balance = (await this.erc721Shim.read.balanceOf(wallet)).toNumber()
-        return balance > 0
+        this.multicall = new IMulticallShim(address, provider)
     }
 
     // If the caller doesn't provide an abort controller, create one and set a timeout

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -1,10 +1,11 @@
-import { BigNumber, BigNumberish, ethers } from 'ethers'
-import { BaseContractShim } from '../BaseContractShim'
+import { BigNumber, BigNumberish, ContractTransaction, ethers, Signer } from 'ethers'
+import { BaseContractShim, OverrideExecution } from '../BaseContractShim'
 import { dlogger } from '@towns-protocol/dlog'
 import { IMembershipMetadataShim } from './IMembershipMetadataShim'
 import { MembershipFacet__factory } from '@towns-protocol/generated/dev/typings/factories/MembershipFacet__factory'
 import { IERC721AShim } from '../erc-721/IERC721AShim'
 import { IMulticallShim } from './IMulticallShim'
+import { TransactionOpts } from 'types/ContractTypes'
 const log = dlogger('csb:IMembershipShim')
 
 const { abi, connect } = MembershipFacet__factory
@@ -19,6 +20,28 @@ export class IMembershipShim extends BaseContractShim<typeof connect> {
         this.erc721Shim = new IERC721AShim(address, provider)
         this.metadata = new IMembershipMetadataShim(address, provider)
         this.multicall = new IMulticallShim(address, provider)
+    }
+
+    public async getMembershipRenewalPrice(tokenId: string) {
+        return (await this.read.getMembershipRenewalPrice(tokenId)).toBigInt()
+    }
+
+    public async renewMembership<T = ContractTransaction>(args: {
+        tokenId: string
+        signer: Signer
+        overrideExecution?: OverrideExecution<T>
+        transactionOpts?: TransactionOpts
+    }) {
+        const { tokenId, signer, overrideExecution, transactionOpts } = args
+        const renewalPrice = await this.getMembershipRenewalPrice(tokenId)
+
+        return this.executeCall({
+            signer,
+            functionName: 'renewMembership',
+            args: [tokenId, { value: renewalPrice }],
+            overrideExecution,
+            transactionOpts,
+        })
     }
 
     // If the caller doesn't provide an abort controller, create one and set a timeout

--- a/packages/web3/src/space/IMulticallShim.ts
+++ b/packages/web3/src/space/IMulticallShim.ts
@@ -8,4 +8,11 @@ export class IMulticallShim extends BaseContractShim<typeof connect> {
     constructor(address: string, provider: ethers.providers.Provider) {
         super(address, provider, connect, abi)
     }
+
+    public async makeCalls<T>(args: { encoder: () => string[]; decoder: (result: string) => T }) {
+        const { encoder, decoder } = args
+        const calldata = encoder()
+        const results = await this.read.callStatic.multicall(calldata)
+        return results.map((result) => decoder(result))
+    }
 }

--- a/packages/web3/src/space/Space.ts
+++ b/packages/web3/src/space/Space.ts
@@ -525,12 +525,10 @@ export class Space {
                 },
             })
         } catch (error) {
-            log.error('getMembershipStatus::error', { error })
+            log.error('getMembershipStatus expirations::error', { error })
             // Error evaluating expirations, assume not expired
             return {
-                isMember: true,
-                isExpired: false,
-                expiryTime: 0n,
+                isMember: false,
             }
         }
 

--- a/packages/web3/src/space/Space.ts
+++ b/packages/web3/src/space/Space.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, ethers } from 'ethers'
+import { BigNumber, BigNumberish, ContractTransaction, ethers, Signer } from 'ethers'
 import {
     ChannelDetails,
     ChannelMetadata,
@@ -575,6 +575,10 @@ export class Space {
             expiryTime,
             expiredAt,
         }
+    }
+
+    public async renewMembership(tokenId: string, signer: Signer) {
+        return await this.membership.write(signer).renewMembership(tokenId)
     }
 
     public async getProtocolFee(): Promise<bigint> {


### PR DESCRIPTION
### Description

This PR introduces handling expired memberships in SpaceDapp.

### Changes

- Added membership renewal functionality via `renewMembership` method
- Replaced `hasSpaceMembership` with more detailed `getMembershipStatus` that includes expiration information
- Enhanced entitlement checks to properly handle expired memberships
- Optimized token ownership queries using multicall for better performance
- Fixed stress test code to use the new membership status API
- Added tests for membership renewal and expiration scenarios

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines