### PR TITLE
Fix "Failed to parse stream event" "(13:INTERNAL) Stream event isn't update" error in logs

### DIFF
--- a/core/contracts/river/stream_registry_v1_ex.go
+++ b/core/contracts/river/stream_registry_v1_ex.go
@@ -74,7 +74,8 @@ func (s *StreamWithId) Nodes() []common.Address {
 type (
 	// StreamUpdated is the unified event emitted by the stream registry when a stream mutation occurs.
 	// Either when its created or modified.
-	StreamUpdated = StreamRegistryV1StreamUpdated
+	StreamUpdated                   = StreamRegistryV1StreamUpdated
+	StreamLastMiniblockUpdateFailed = StreamRegistryV1StreamLastMiniblockUpdateFailed
 
 	// StreamUpdatedEventType defines Solidity IStreamRegistryBase.StreamEventType enum type.
 	StreamUpdatedEventType uint8
@@ -101,6 +102,20 @@ type (
 		Reason() StreamUpdatedEventType
 	}
 )
+
+func (t StreamUpdatedEventType) String() string {
+	switch t {
+	case StreamUpdatedEventTypeAllocate:
+		return "Allocate"
+	case StreamUpdatedEventTypeCreate:
+		return "Create"
+	case StreamUpdatedEventTypePlacementUpdated:
+		return "PlacementUpdated"
+	case StreamUpdatedEventTypeLastMiniblockBatchUpdated:
+		return "LastMiniblockBatchUpdated"
+	}
+	return "Unknown"
+}
 
 const (
 	// Event_StreamUpdated is emitted by the streams registry when a stream is added or modified

--- a/core/node/crypto/block_number.go
+++ b/core/node/crypto/block_number.go
@@ -12,6 +12,10 @@ func (bn BlockNumber) AsUint64() uint64 {
 	return uint64(bn)
 }
 
+func (bn BlockNumber) Add(n int64) BlockNumber {
+	return BlockNumber(int64(bn) + n)
+}
+
 func BlockNumberFromBigInt(v *big.Int) BlockNumber {
 	if !v.IsUint64() {
 		panic("block number is too large")

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -197,7 +197,7 @@ func (s *StreamCache) Start(ctx context.Context, opts *MiniblockProducerOpts) er
 }
 
 func (s *StreamCache) onBlockWithLogs(ctx context.Context, blockNum crypto.BlockNumber, logs []*types.Log) {
-	streamEvents, errs := s.params.Registry.FilterStreamEvents(ctx, logs)
+	streamEvents, errs := s.params.Registry.FilterStreamUpdatedEvents(ctx, logs)
 	// Process parsed stream events even if some failed to parse
 	for _, err := range errs {
 		logging.FromCtx(ctx).Errorw("Failed to parse stream event", "err", err)

--- a/core/node/registries/river_registry_contract.go
+++ b/core/node/registries/river_registry_contract.go
@@ -3,7 +3,6 @@ package registries
 import (
 	"context"
 	"math/big"
-	"slices"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -45,11 +44,15 @@ type RiverRegistryContract struct {
 	Settings *config.RiverRegistryConfig
 
 	errDecoder *crypto.EvmErrorDecoder
+
+	StreamUpdatedEventInfo                   *EventInfo
+	StreamLastMiniblockUpdateFailedEventInfo *EventInfo
 }
 
 type EventInfo struct {
 	Name  string
 	Maker func(*types.Log) any
+	Topic common.Hash
 }
 
 func initContract[T any](
@@ -103,6 +106,7 @@ func initContract[T any](
 				LogError(log)
 		}
 		eventSigs = append(eventSigs, ev.ID)
+		e.Topic = ev.ID
 		eventInfo[ev.ID] = e
 	}
 	return contract, abi, [][]common.Hash{eventSigs}, eventInfo, nil
@@ -141,35 +145,34 @@ func NewRiverRegistryContract(
 		blockchain.Client,
 		river.NodeRegistryV1MetaData,
 		[]*EventInfo{
-			{"NodeAdded", func(log *types.Log) any { return &river.NodeRegistryV1NodeAdded{Raw: *log} }},
-			{"NodeRemoved", func(log *types.Log) any { return &river.NodeRegistryV1NodeRemoved{Raw: *log} }},
+			{Name: "NodeAdded", Maker: func(log *types.Log) any { return &river.NodeRegistryV1NodeAdded{Raw: *log} }},
+			{Name: "NodeRemoved", Maker: func(log *types.Log) any { return &river.NodeRegistryV1NodeRemoved{Raw: *log} }},
 			{
-				"NodeStatusUpdated",
-				func(log *types.Log) any { return &river.NodeRegistryV1NodeStatusUpdated{Raw: *log} },
+				Name:  "NodeStatusUpdated",
+				Maker: func(log *types.Log) any { return &river.NodeRegistryV1NodeStatusUpdated{Raw: *log} },
 			},
-			{"NodeUrlUpdated", func(log *types.Log) any { return &river.NodeRegistryV1NodeUrlUpdated{Raw: *log} }},
+			{Name: "NodeUrlUpdated", Maker: func(log *types.Log) any { return &river.NodeRegistryV1NodeUrlUpdated{Raw: *log} }},
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
+	c.StreamUpdatedEventInfo = &EventInfo{
+		Name:  river.Event_StreamUpdated,
+		Maker: func(log *types.Log) any { return &river.StreamRegistryV1StreamUpdated{Raw: *log} },
+	}
+	c.StreamLastMiniblockUpdateFailedEventInfo = &EventInfo{
+		Name:  river.Event_StreamLastMiniblockUpdateFailed,
+		Maker: func(log *types.Log) any { return &river.StreamRegistryV1StreamLastMiniblockUpdateFailed{Raw: *log} },
+	}
 	c.StreamRegistry, c.StreamRegistryAbi, c.StreamEventTopics, c.StreamEventInfo, err = initContract(
 		ctx,
 		river.NewStreamRegistryV1,
 		cfg.Address,
 		blockchain.Client,
 		river.StreamRegistryV1MetaData,
-		[]*EventInfo{
-			{
-				river.Event_StreamUpdated,
-				func(log *types.Log) any { return &river.StreamRegistryV1StreamUpdated{Raw: *log} },
-			},
-			{
-				river.Event_StreamLastMiniblockUpdateFailed,
-				func(log *types.Log) any { return &river.StreamRegistryV1StreamLastMiniblockUpdateFailed{Raw: *log} },
-			},
-		},
+		[]*EventInfo{c.StreamUpdatedEventInfo, c.StreamLastMiniblockUpdateFailedEventInfo},
 	)
 	if err != nil {
 		return nil, err
@@ -764,12 +767,8 @@ func (c *RiverRegistryContract) SetStreamLastMiniblockBatch(
 		// only parse the new events (StreamUpdated + StreamLastMiniblockUpdateFailed) and ignore the old events.
 		// this allows the contract to be upgraded without breaking event parsing.
 		// TODO: remove wanted1/wanted2 check after smart contract has been upgraded and won't emit old event types.
-		wanted1 := common.HexToHash(
-			"0x378ece20ebca29c2f887798617154658265a73d80c84fad8c9c49639ffdb29bb",
-		) // StreamUpdated
-		wanted2 := common.HexToHash(
-			"0x75460fe319331413a18a82d99b07735cec53fa0c4061ada38c2141e331082afa",
-		) // StreamLastMiniblockUpdateFailed
+		wanted1 := c.StreamUpdatedEventInfo.Topic
+		wanted2 := c.StreamLastMiniblockUpdateFailedEventInfo.Topic
 
 		for _, l := range receipt.Logs {
 			if l.Topics[0] != wanted1 && l.Topics[0] != wanted2 {
@@ -973,14 +972,14 @@ func (c *RiverRegistryContract) OnStreamEvent(
 	return nil
 }
 
-func (c *RiverRegistryContract) FilterStreamEvents(
+func (c *RiverRegistryContract) FilterStreamUpdatedEvents(
 	ctx context.Context,
 	logs []*types.Log,
 ) (map[StreamId][]river.StreamUpdatedEvent, []error) {
 	ret := map[StreamId][]river.StreamUpdatedEvent{}
 	var finalErrs []error
 	for _, log := range logs {
-		if log.Address != c.Address || len(log.Topics) == 0 || !slices.Contains(c.StreamEventTopics[0], log.Topics[0]) {
+		if log.Address != c.Address || len(log.Topics) == 0 || log.Topics[0] != c.StreamUpdatedEventInfo.Topic {
 			continue
 		}
 


### PR DESCRIPTION
`FilterStreamEvents` used to pick up `StreamLastMiniblockUpdateFailed` as well, which lead to parsing failure on a call site.

This PR limits `FilterStreamEvents` only to `StreamUpdated`

Also included: `registry events` command to dump stream events from txs.