### PR TITLE
chore: add 'area/contracts' label to `.coderabbit.yaml`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,5 +19,6 @@ reviews:
             - 'ai'
             - 'rabbit'
             - 'coderabbit'
+            - 'area/contracts'
 chat:
     auto_reply: true


### PR DESCRIPTION
Extend labels list in `.coderabbit.yaml` to include 'area/contracts'.