### PR TITLE
node: add registry update-stream command line command

### DIFF
--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -881,6 +881,7 @@ max-block-range is optional and limits the number of blocks to consider (default
 		Args:  cobra.ExactArgs(1),
 		RunE:  runStreamValidateCmd,
 	}
+
 	cmdStreamValidate.Flags().String("node", "", "Optional node address to fetch stream from")
 	cmdStreamValidate.Flags().Duration("timeout", 30*time.Second, "Timeout for running the command")
 	cmdStreamValidate.Flags().Int("page-size", 1000, "Number of miniblocks to fetch per page")


### PR DESCRIPTION
Add a command line cmd to update stream registry records. The wallet needs to be given the configuration manager permissions.

Example:

```
./env/omega/run.sh registry update-stream <wallet-file> <stream-id> <replication-factor> \
   <node-addr1> <node-addr2> <node-addr3>
```