### PR TITLE
build(contract): refactor deployment scripts

### DIFF
--- a/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
@@ -27,8 +27,6 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     DeployFacet private facetHelper = new DeployFacet();
 
-    address private multiInit;
-
     string internal constant APP_REGISTRY_SCHEMA =
         "address app, address owner, address[] clients, bytes32[] permissions, ExecutionManifest manifest";
 
@@ -38,7 +36,6 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
@@ -46,8 +43,6 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         facetHelper.add("MetadataFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
@@ -86,6 +81,7 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up feature facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("AppRegistryFacet");
 
         // Deploy all facets in a batch
@@ -98,6 +94,8 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
             facet,
             DeployAppRegistryFacet.makeInitData(APP_REGISTRY_SCHEMA, address(0))
         );
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({

--- a/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
@@ -2,40 +2,34 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
+import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
-
-// helpers
-
-import {FacetHelper} from "@towns-protocol/diamond/scripts/common/helpers/FacetHelper.s.sol";
-import {Diamond} from "@towns-protocol/diamond/src/Diamond.sol";
-import {Deployer} from "scripts/common/Deployer.s.sol";
-
-import {DeployFacet} from "../../common/DeployFacet.s.sol";
 import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.sol";
 import {DeployDiamondLoupe} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondLoupe.sol";
 import {DeployIntrospection} from "@towns-protocol/diamond/scripts/deployments/facets/DeployIntrospection.sol";
 import {DeployOwnable} from "@towns-protocol/diamond/scripts/deployments/facets/DeployOwnable.sol";
-import {DiamondHelper} from "@towns-protocol/diamond/scripts/common/helpers/DiamondHelper.s.sol";
-import {DeployMetadata} from "scripts/deployments/facets/DeployMetadata.s.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {DeployMetadata} from "../facets/DeployMetadata.s.sol";
+import {DeployAppRegistryFacet} from "../facets/DeployAppRegistryFacet.s.sol";
 
-// facets
+// contracts
+import {Diamond} from "@towns-protocol/diamond/src/Diamond.sol";
 import {MultiInit} from "@towns-protocol/diamond/src/initializers/MultiInit.sol";
-import {DeployAppRegistryFacet} from "scripts/deployments/facets/DeployAppRegistryFacet.s.sol";
+import {DiamondHelper} from "@towns-protocol/diamond/scripts/common/helpers/DiamondHelper.s.sol";
 
-contract DeployAppRegistry is DiamondHelper, Deployer {
+// deployers
+import {DeployFacet} from "../../common/DeployFacet.s.sol";
+import {Deployer} from "../../common/Deployer.s.sol";
+
+contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
+    using LibString for string;
+
     DeployFacet private facetHelper = new DeployFacet();
 
-    address internal metadata;
-    address internal multiInit;
-    address internal diamondCut;
-    address internal diamondLoupe;
-    address internal introspection;
-    address internal ownable;
-    address internal appRegistry;
+    address private multiInit;
 
-    string internal APP_REGISTRY_SCHEMA =
+    string internal constant APP_REGISTRY_SCHEMA =
         "address app, address owner, address[] clients, bytes32[] permissions, ExecutionManifest manifest";
 
     function versionName() public pure override returns (string memory) {
@@ -43,49 +37,65 @@ contract DeployAppRegistry is DiamondHelper, Deployer {
     }
 
     function addImmutableCuts(address deployer) internal {
-        multiInit = facetHelper.deploy("MultiInit", deployer);
+        // Queue up all core facets for batch deployment
+        facetHelper.add("MultiInit");
+        facetHelper.add("DiamondCutFacet");
+        facetHelper.add("DiamondLoupeFacet");
+        facetHelper.add("IntrospectionFacet");
+        facetHelper.add("OwnableFacet");
+        facetHelper.add("MetadataFacet");
 
-        diamondCut = facetHelper.deploy("DiamondCutFacet", deployer);
+        // Get predicted addresses
+        multiInit = facetHelper.predictAddress("MultiInit");
+
+        address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(diamondCut, IDiamond.FacetCutAction.Add),
-            diamondCut,
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
+            facet,
             DeployDiamondCut.makeInitData()
         );
 
-        diamondLoupe = facetHelper.deploy("DiamondLoupeFacet", deployer);
+        facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(diamondLoupe, IDiamond.FacetCutAction.Add),
-            diamondLoupe,
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
+            facet,
             DeployDiamondLoupe.makeInitData()
         );
 
-        introspection = facetHelper.deploy("IntrospectionFacet", deployer);
+        facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(introspection, IDiamond.FacetCutAction.Add),
-            introspection,
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
+            facet,
             DeployIntrospection.makeInitData()
         );
 
-        ownable = facetHelper.deploy("OwnableFacet", deployer);
+        facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(ownable, IDiamond.FacetCutAction.Add),
-            ownable,
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
+            facet,
             DeployOwnable.makeInitData(deployer)
         );
 
-        metadata = facetHelper.deploy("MetadataFacet", deployer);
+        facet = facetHelper.predictAddress("MetadataFacet");
         addFacet(
-            DeployMetadata.makeCut(metadata, IDiamond.FacetCutAction.Add),
-            metadata,
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
+            facet,
             DeployMetadata.makeInitData(bytes32("AppRegistry"), "")
         );
     }
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
-        appRegistry = facetHelper.deploy("AppRegistryFacet", deployer);
+        // Queue up feature facets for batch deployment
+        facetHelper.add("AppRegistryFacet");
+
+        // Deploy all facets in a batch
+        facetHelper.deployBatch(deployer);
+
+        // Add feature facets
+        address facet = facetHelper.getDeployedAddress("AppRegistryFacet");
         addFacet(
-            DeployAppRegistryFacet.makeCut(appRegistry, IDiamond.FacetCutAction.Add),
-            appRegistry,
+            makeCut(facet, FacetCutAction.Add, DeployAppRegistryFacet.selectors()),
+            facet,
             DeployAppRegistryFacet.makeInitData(APP_REGISTRY_SCHEMA, address(0))
         );
 
@@ -93,19 +103,38 @@ contract DeployAppRegistry is DiamondHelper, Deployer {
             Diamond.InitParams({
                 baseFacets: baseFacets(),
                 init: multiInit,
-                initData: abi.encodeWithSelector(
-                    MultiInit.multiInit.selector,
-                    _initAddresses,
-                    _initDatas
-                )
+                initData: abi.encodeCall(MultiInit.multiInit, (_initAddresses, _initDatas))
             });
+    }
+
+    function diamondInitHelper(
+        address deployer,
+        string[] memory facetNames
+    ) external override returns (FacetCut[] memory) {
+        // Queue up all requested facets for batch deployment
+        for (uint256 i; i < facetNames.length; ++i) {
+            facetHelper.add(facetNames[i]);
+        }
+
+        // Deploy all requested facets in a single batch transaction
+        facetHelper.deployBatch(deployer);
+
+        for (uint256 i; i < facetNames.length; ++i) {
+            string memory facetName = facetNames[i];
+            address facet = facetHelper.getDeployedAddress(facetName);
+
+            if (facetName.eq("AppRegistryFacet")) {
+                addCut(makeCut(facet, FacetCutAction.Add, DeployAppRegistryFacet.selectors()));
+            }
+        }
+
+        return baseFacets();
     }
 
     function __deploy(address deployer) internal override returns (address) {
         addImmutableCuts(deployer);
 
         Diamond.InitParams memory initDiamondCut = diamondInitParams(deployer);
-
         vm.broadcast(deployer);
         Diamond diamond = new Diamond(initDiamondCut);
 

--- a/packages/contracts/scripts/deployments/diamonds/DeployBaseRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployBaseRegistry.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -62,28 +61,28 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
         );
@@ -107,42 +106,42 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         // Add facets using the deployed addresses
         address facet = facetHelper.getDeployedAddress("ERC721ANonTransferable");
         addFacet(
-            DeployERC721ANonTransferable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployERC721ANonTransferable.selectors()),
             facet,
             DeployERC721ANonTransferable.makeInitData("Operator", "OPR")
         );
 
         facet = facetHelper.getDeployedAddress("NodeOperatorFacet");
         addFacet(
-            DeployNodeOperator.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployNodeOperator.selectors()),
             facet,
             DeployNodeOperator.makeInitData()
         );
 
         facet = facetHelper.getDeployedAddress("MetadataFacet");
         addFacet(
-            DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
             facet,
             DeployMetadata.makeInitData(bytes32("SpaceOperator"), "")
         );
 
         facet = facetHelper.getDeployedAddress("EntitlementChecker");
         addFacet(
-            DeployEntitlementChecker.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployEntitlementChecker.selectors()),
             facet,
             DeployEntitlementChecker.makeInitData()
         );
 
         facet = facetHelper.getDeployedAddress("RewardsDistributionV2");
         addFacet(
-            DeployRewardsDistributionV2.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployRewardsDistributionV2.selectors()),
             facet,
             DeployRewardsDistributionV2.makeInitData(riverToken, riverToken, 14 days)
         );
 
         facet = facetHelper.getDeployedAddress("SpaceDelegationFacet");
         addFacet(
-            DeploySpaceDelegation.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeploySpaceDelegation.selectors()),
             facet,
             DeploySpaceDelegation.makeInitData(riverToken)
         );
@@ -150,21 +149,21 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         messenger = messengerHelper.deploy(deployer);
         facet = facetHelper.getDeployedAddress("MainnetDelegation");
         addFacet(
-            DeployMainnetDelegation.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployMainnetDelegation.selectors()),
             facet,
             DeployMainnetDelegation.makeInitData(messenger)
         );
 
         facet = facetHelper.getDeployedAddress("EIP712Facet");
         addFacet(
-            DeployEIP712Facet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployEIP712Facet.selectors()),
             facet,
             DeployEIP712Facet.makeInitData("BaseRegistry", "1")
         );
 
         facet = facetHelper.getDeployedAddress("XChain");
         addFacet(
-            DeployXChain.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployXChain.selectors()),
             facet,
             DeployXChain.makeInitData()
         );
@@ -193,56 +192,56 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
             if (facetName.eq("MetadataFacet")) {
                 addFacet(
-                    DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
                     facet,
                     DeployMetadata.makeInitData(bytes32("SpaceOperator"), "")
                 );
             } else if (facetName.eq("EntitlementChecker")) {
                 addFacet(
-                    DeployEntitlementChecker.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployEntitlementChecker.selectors()),
                     facet,
                     DeployEntitlementChecker.makeInitData()
                 );
             } else if (facetName.eq("NodeOperatorFacet")) {
                 addFacet(
-                    DeployNodeOperator.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployNodeOperator.selectors()),
                     facet,
                     DeployNodeOperator.makeInitData()
                 );
             } else if (facetName.eq("RewardsDistributionV2")) {
                 addFacet(
-                    DeployRewardsDistributionV2.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployRewardsDistributionV2.selectors()),
                     facet,
                     DeployRewardsDistributionV2.makeInitData(riverToken, riverToken, 14 days)
                 );
             } else if (facetName.eq("MainnetDelegation")) {
                 messenger = messengerHelper.deploy(deployer);
                 addFacet(
-                    DeployMainnetDelegation.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployMainnetDelegation.selectors()),
                     facet,
                     DeployMainnetDelegation.makeInitData(messenger)
                 );
             } else if (facetName.eq("SpaceDelegationFacet")) {
                 addFacet(
-                    DeploySpaceDelegation.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeploySpaceDelegation.selectors()),
                     facet,
                     DeploySpaceDelegation.makeInitData(riverToken)
                 );
             } else if (facetName.eq("ERC721ANonTransferable")) {
                 addFacet(
-                    DeployERC721ANonTransferable.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployERC721ANonTransferable.selectors()),
                     facet,
                     DeployERC721ANonTransferable.makeInitData("Operator", "OPR")
                 );
             } else if (facetName.eq("EIP712Facet")) {
                 addFacet(
-                    DeployEIP712Facet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployEIP712Facet.selectors()),
                     facet,
                     DeployEIP712Facet.makeInitData("BaseRegistry", "1")
                 );
             } else if (facetName.eq("XChain")) {
                 addFacet(
-                    DeployXChain.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployXChain.selectors()),
                     facet,
                     DeployXChain.makeInitData()
                 );

--- a/packages/contracts/scripts/deployments/diamonds/DeployBaseRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployBaseRegistry.s.sol
@@ -36,7 +36,6 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
     DeployFacet private facetHelper = new DeployFacet();
     DeployMockMessenger private messengerHelper = new DeployMockMessenger();
 
-    address private multiInit;
     address public messenger;
     address private riverToken = 0x9172852305F32819469bf38A3772f29361d7b768;
 
@@ -50,15 +49,12 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
@@ -90,6 +86,7 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up all feature facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("ERC721ANonTransferable");
         facetHelper.add("NodeOperatorFacet");
         facetHelper.add("MetadataFacet");
@@ -167,6 +164,8 @@ contract DeployBaseRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
             facet,
             DeployXChain.makeInitData()
         );
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({

--- a/packages/contracts/scripts/deployments/diamonds/DeployRiverAirdrop.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployRiverAirdrop.s.sol
@@ -31,7 +31,6 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
     address private SPACE_FACTORY;
 
     DeployFacet private facetHelper = new DeployFacet();
-    address private multiInit;
 
     function versionName() public pure override returns (string memory) {
         return "riverAirdrop";
@@ -63,15 +62,12 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
@@ -103,6 +99,7 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up all facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("DropFacet");
         facetHelper.add("TownsPoints");
         facetHelper.add("MetadataFacet");
@@ -131,6 +128,8 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
             facet,
             DeployMetadata.makeInitData(bytes32("RiverAirdrop"), "")
         );
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({

--- a/packages/contracts/scripts/deployments/diamonds/DeployRiverAirdrop.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployRiverAirdrop.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -75,28 +74,28 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
 
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
         );
@@ -114,21 +113,21 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
         // Get deployed addresses and add facets
         address facet = facetHelper.getDeployedAddress("DropFacet");
         addFacet(
-            DeployDropFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDropFacet.selectors()),
             facet,
             DeployDropFacet.makeInitData(getBaseRegistry())
         );
 
         facet = facetHelper.getDeployedAddress("TownsPoints");
         addFacet(
-            DeployTownsPoints.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployTownsPoints.selectors()),
             facet,
             DeployTownsPoints.makeInitData(getSpaceFactory())
         );
 
         facet = facetHelper.getDeployedAddress("MetadataFacet");
         addFacet(
-            DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
             facet,
             DeployMetadata.makeInitData(bytes32("RiverAirdrop"), "")
         );
@@ -156,19 +155,19 @@ contract DeployRiverAirdrop is IDiamondInitHelper, DiamondHelper, Deployer {
 
             if (facetName.eq("DropFacet")) {
                 addFacet(
-                    DeployDropFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployDropFacet.selectors()),
                     facet,
                     DeployDropFacet.makeInitData(getBaseRegistry())
                 );
             } else if (facetName.eq("TownsPoints")) {
                 addFacet(
-                    DeployTownsPoints.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployTownsPoints.selectors()),
                     facet,
                     DeployTownsPoints.makeInitData(getSpaceFactory())
                 );
             } else if (facetName.eq("MetadataFacet")) {
                 addFacet(
-                    DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
                     facet,
                     DeployMetadata.makeInitData(bytes32("RiverAirdrop"), "")
                 );

--- a/packages/contracts/scripts/deployments/diamonds/DeployRiverRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployRiverRegistry.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -29,7 +28,6 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
     using LibString for string;
 
     DeployFacet private facetHelper = new DeployFacet();
-    address private multiInit;
 
     function versionName() public pure override returns (string memory) {
         return "riverRegistry";
@@ -37,39 +35,36 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
         );
@@ -77,6 +72,7 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up all feature facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("OperatorRegistry");
         facetHelper.add("RiverConfig");
         facetHelper.add("NodeRegistry");
@@ -90,7 +86,7 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         operators[0] = deployer;
         address facet = facetHelper.getDeployedAddress("OperatorRegistry");
         addFacet(
-            DeployOperatorRegistry.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOperatorRegistry.selectors()),
             facet,
             DeployOperatorRegistry.makeInitData(operators)
         );
@@ -100,16 +96,18 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         configManagers[0] = deployer;
         facet = facetHelper.getDeployedAddress("RiverConfig");
         addFacet(
-            DeployRiverConfig.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployRiverConfig.selectors()),
             facet,
             DeployRiverConfig.makeInitData(configManagers)
         );
 
         facet = facetHelper.getDeployedAddress("NodeRegistry");
-        addCut(DeployNodeRegistry.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployNodeRegistry.selectors()));
 
         facet = facetHelper.getDeployedAddress("StreamRegistry");
-        addCut(DeployStreamRegistry.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployStreamRegistry.selectors()));
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({
@@ -137,7 +135,7 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
                 address[] memory operators = new address[](1);
                 operators[0] = deployer;
                 addFacet(
-                    DeployOperatorRegistry.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployOperatorRegistry.selectors()),
                     facet,
                     DeployOperatorRegistry.makeInitData(operators)
                 );
@@ -145,14 +143,14 @@ contract DeployRiverRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
                 address[] memory configManagers = new address[](1);
                 configManagers[0] = deployer;
                 addFacet(
-                    DeployRiverConfig.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployRiverConfig.selectors()),
                     facet,
                     DeployRiverConfig.makeInitData(configManagers)
                 );
             } else if (facetName.eq("NodeRegistry")) {
-                addCut(DeployNodeRegistry.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployNodeRegistry.selectors()));
             } else if (facetName.eq("StreamRegistry")) {
-                addCut(DeployStreamRegistry.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployStreamRegistry.selectors()));
             }
         }
     }

--- a/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
@@ -88,6 +88,9 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
         );
 
         facet = facetHelper.predictAddress("TokenOwnableFacet");
+        // TokenOwnableFacet doesn't require global initialization during deployment.
+        // Unlike other facets with immediate initialization, TokenOwnableFacet is initialized
+        // individually for each Space instance at creation time rather than globally.
         addCut(makeCut(facet, FacetCutAction.Add, DeployTokenOwnable.selectors()));
     }
 

--- a/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
@@ -46,15 +46,12 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
 
     DeployFacet private facetHelper = new DeployFacet();
 
-    address private multiInit;
-
     function versionName() public pure override returns (string memory) {
         return "space";
     }
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
@@ -62,8 +59,6 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
         facetHelper.add("TokenOwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
@@ -98,6 +93,7 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up all feature facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("MembershipToken");
         facetHelper.add("ERC721AQueryable");
         facetHelper.add("Banning");
@@ -187,6 +183,8 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
             facet = facetHelper.getDeployedAddress("MockLegacyMembership");
             addCut(makeCut(facet, FacetCutAction.Add, DeployMockLegacyMembership.selectors()));
         }
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({

--- a/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -67,34 +66,34 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
 
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnablePendingFacet");
         addFacet(
-            DeployOwnablePending.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnablePending.selectors()),
             facet,
             DeployOwnablePending.makeInitData(deployer)
         );
 
         facet = facetHelper.predictAddress("TokenOwnableFacet");
-        addCut(DeployTokenOwnable.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployTokenOwnable.selectors()));
     }
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
@@ -131,62 +130,62 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
 
         // deploy and add facets one by one to avoid stack too deep
         address facet = facetHelper.getDeployedAddress("MembershipToken");
-        addCut(DeployMembershipToken.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployMembershipToken.selectorsExceptTokenURI()));
 
         facet = facetHelper.getDeployedAddress("ERC721AQueryable");
-        addCut(DeployERC721AQueryable.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployERC721AQueryable.selectors()));
 
         facet = facetHelper.getDeployedAddress("Banning");
-        addCut(DeployBanning.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployBanning.selectors()));
 
         facet = facetHelper.getDeployedAddress("MembershipFacet");
-        addCut(DeployMembership.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployMembership.selectors()));
 
         facet = facetHelper.getDeployedAddress("MembershipMetadata");
-        addCut(DeployMembershipMetadata.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployMembershipMetadata.selectors()));
 
         facet = facetHelper.getDeployedAddress("EntitlementDataQueryable");
-        addCut(DeployEntitlementDataQueryable.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployEntitlementDataQueryable.selectors()));
 
         facet = facetHelper.getDeployedAddress("EntitlementsManager");
-        addCut(DeployEntitlementsManager.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployEntitlementsManager.selectors()));
 
         facet = facetHelper.getDeployedAddress("Roles");
-        addCut(DeployRoles.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployRoles.selectors()));
 
         facet = facetHelper.getDeployedAddress("Channels");
-        addCut(DeployChannels.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployChannels.selectors()));
 
         facet = facetHelper.getDeployedAddress("TokenPausableFacet");
-        addCut(DeployTokenPausable.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployTokenPausable.selectors()));
 
         facet = facetHelper.getDeployedAddress("PrepayFacet");
-        addCut(DeployPrepayFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployPrepayFacet.selectors()));
 
         facet = facetHelper.getDeployedAddress("ReferralsFacet");
-        addCut(DeployReferrals.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployReferrals.selectors()));
 
         facet = facetHelper.getDeployedAddress("ReviewFacet");
-        addCut(DeployReviewFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployReviewFacet.selectors()));
 
         facet = facetHelper.getDeployedAddress("SpaceEntitlementGated");
-        addCut(DeploySpaceEntitlementGated.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeploySpaceEntitlementGated.selectors()));
 
         facet = facetHelper.getDeployedAddress("SwapFacet");
-        addCut(DeploySwapFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeploySwapFacet.selectors()));
 
         facet = facetHelper.getDeployedAddress("TippingFacet");
-        addCut(DeployTipping.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployTipping.selectors()));
 
         facet = facetHelper.getDeployedAddress("Treasury");
-        addCut(DeployTreasury.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployTreasury.selectors()));
 
         facet = facetHelper.getDeployedAddress("AppAccount");
-        addCut(DeployAppAccount.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployAppAccount.selectors()));
 
         if (isAnvil()) {
             facet = facetHelper.getDeployedAddress("MockLegacyMembership");
-            addCut(DeployMockLegacyMembership.makeCut(facet, IDiamond.FacetCutAction.Add));
+            addCut(makeCut(facet, FacetCutAction.Add, DeployMockLegacyMembership.selectors()));
         }
 
         return
@@ -211,41 +210,49 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
             address facet = facetHelper.getDeployedAddress(facetName);
 
             if (facetName.eq("MembershipToken")) {
-                addCut(DeployMembershipToken.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(
+                    makeCut(
+                        facet,
+                        FacetCutAction.Add,
+                        DeployMembershipToken.selectorsExceptTokenURI()
+                    )
+                );
             } else if (facetName.eq("ERC721AQueryable")) {
-                addCut(DeployERC721AQueryable.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployERC721AQueryable.selectors()));
             } else if (facetName.eq("Banning")) {
-                addCut(DeployBanning.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployBanning.selectors()));
             } else if (facetName.eq("MembershipFacet")) {
-                addCut(DeployMembership.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployMembership.selectors()));
             } else if (facetName.eq("MembershipMetadata")) {
-                addCut(DeployMembershipMetadata.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployMembershipMetadata.selectors()));
             } else if (facetName.eq("EntitlementDataQueryable")) {
-                addCut(DeployEntitlementDataQueryable.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(
+                    makeCut(facet, FacetCutAction.Add, DeployEntitlementDataQueryable.selectors())
+                );
             } else if (facetName.eq("EntitlementsManager")) {
-                addCut(DeployEntitlementsManager.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployEntitlementsManager.selectors()));
             } else if (facetName.eq("Roles")) {
-                addCut(DeployRoles.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployRoles.selectors()));
             } else if (facetName.eq("Channels")) {
-                addCut(DeployChannels.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployChannels.selectors()));
             } else if (facetName.eq("TokenPausableFacet")) {
-                addCut(DeployTokenPausable.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployTokenPausable.selectors()));
             } else if (facetName.eq("PrepayFacet")) {
-                addCut(DeployPrepayFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployPrepayFacet.selectors()));
             } else if (facetName.eq("ReferralsFacet")) {
-                addCut(DeployReferrals.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployReferrals.selectors()));
             } else if (facetName.eq("ReviewFacet")) {
-                addCut(DeployReviewFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployReviewFacet.selectors()));
             } else if (facetName.eq("SpaceEntitlementGated")) {
-                addCut(DeploySpaceEntitlementGated.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeploySpaceEntitlementGated.selectors()));
             } else if (facetName.eq("SwapFacet")) {
-                addCut(DeploySwapFacet.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeploySwapFacet.selectors()));
             } else if (facetName.eq("TippingFacet")) {
-                addCut(DeployTipping.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployTipping.selectors()));
             } else if (facetName.eq("Treasury")) {
-                addCut(DeployTreasury.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployTreasury.selectors()));
             } else if (facetName.eq("AppAccount")) {
-                addCut(DeployAppAccount.makeCut(facet, IDiamond.FacetCutAction.Add));
+                addCut(makeCut(facet, FacetCutAction.Add, DeployAppAccount.selectors()));
             }
         }
     }

--- a/packages/contracts/scripts/deployments/diamonds/DeploySpaceOwner.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySpaceOwner.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 // interface
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -29,7 +28,6 @@ contract DeploySpaceOwner is IDiamondInitHelper, DiamondHelper, Deployer {
     using LibString for string;
 
     DeployFacet private facetHelper = new DeployFacet();
-    address private multiInit;
 
     function versionName() public pure override returns (string memory) {
         return "spaceOwner";
@@ -37,39 +35,36 @@ contract DeploySpaceOwner is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
         );
@@ -77,6 +72,7 @@ contract DeploySpaceOwner is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up all feature facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("SpaceOwner");
         facetHelper.add("EIP712Facet");
         facetHelper.add("GuardianFacet");
@@ -88,31 +84,33 @@ contract DeploySpaceOwner is IDiamondInitHelper, DiamondHelper, Deployer {
         // Add feature facets
         address facet = facetHelper.getDeployedAddress("SpaceOwner");
         addFacet(
-            DeploySpaceOwnerFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeploySpaceOwnerFacet.selectors()),
             facet,
             DeploySpaceOwnerFacet.makeInitData("Space Owner", "OWNER")
         );
 
         facet = facetHelper.getDeployedAddress("EIP712Facet");
         addFacet(
-            DeployEIP712Facet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployEIP712Facet.selectors()),
             facet,
             DeployEIP712Facet.makeInitData("Space Owner", "1")
         );
 
         facet = facetHelper.getDeployedAddress("GuardianFacet");
         addFacet(
-            DeployGuardianFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployGuardianFacet.selectors()),
             facet,
             DeployGuardianFacet.makeInitData(7 days)
         );
 
         facet = facetHelper.getDeployedAddress("MetadataFacet");
         addFacet(
-            DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
             facet,
             DeployMetadata.makeInitData(bytes32("Space Owner"), "")
         );
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({
@@ -138,25 +136,25 @@ contract DeploySpaceOwner is IDiamondInitHelper, DiamondHelper, Deployer {
 
             if (facetName.eq("MetadataFacet")) {
                 addFacet(
-                    DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
                     facet,
                     DeployMetadata.makeInitData(bytes32("Space Owner"), "")
                 );
             } else if (facetName.eq("SpaceOwner")) {
                 addFacet(
-                    DeploySpaceOwnerFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeploySpaceOwnerFacet.selectors()),
                     facet,
                     DeploySpaceOwnerFacet.makeInitData("Space Owner", "OWNER")
                 );
             } else if (facetName.eq("EIP712Facet")) {
                 addFacet(
-                    DeployEIP712Facet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployEIP712Facet.selectors()),
                     facet,
                     DeployEIP712Facet.makeInitData("Space Owner", "1")
                 );
             } else if (facetName.eq("GuardianFacet")) {
                 addFacet(
-                    DeployGuardianFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployGuardianFacet.selectors()),
                     facet,
                     DeployGuardianFacet.makeInitData(7 days)
                 );

--- a/packages/contracts/scripts/deployments/diamonds/DeploySwapRouter.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySwapRouter.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {IDiamondInitHelper} from "./IDiamondInitHelper.sol";
 
 // libraries
@@ -28,7 +27,6 @@ contract DeploySwapRouter is IDiamondInitHelper, DiamondHelper, Deployer {
     using LibString for string;
 
     DeployFacet private facetHelper = new DeployFacet();
-    address private multiInit;
     address private spaceFactory;
 
     function versionName() public pure override returns (string memory) {
@@ -46,39 +44,36 @@ contract DeploySwapRouter is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function addImmutableCuts(address deployer) internal {
         // Queue up all core facets for batch deployment
-        facetHelper.add("MultiInit");
         facetHelper.add("DiamondCutFacet");
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
 
         // Get predicted addresses
-        multiInit = facetHelper.predictAddress("MultiInit");
-
         address facet = facetHelper.predictAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.predictAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.predictAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         facet = facetHelper.predictAddress("OwnableFacet");
         addFacet(
-            DeployOwnable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
         );
@@ -86,6 +81,7 @@ contract DeploySwapRouter is IDiamondInitHelper, DiamondHelper, Deployer {
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue additional facets for batch deployment
+        facetHelper.add("MultiInit");
         facetHelper.add("SwapRouter");
         facetHelper.add("MetadataFacet");
         facetHelper.add("PausableFacet");
@@ -96,24 +92,26 @@ contract DeploySwapRouter is IDiamondInitHelper, DiamondHelper, Deployer {
         // Add each facet to the diamond cut using its deployment library
         address facet = facetHelper.getDeployedAddress("SwapRouter");
         addFacet(
-            DeploySwapRouterFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeploySwapRouterFacet.selectors()),
             facet,
             DeploySwapRouterFacet.makeInitData(getSpaceFactory())
         );
 
         facet = facetHelper.getDeployedAddress("MetadataFacet");
         addFacet(
-            DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
             facet,
             DeployMetadata.makeInitData(bytes32("SwapRouter"), "")
         );
 
         facet = facetHelper.getDeployedAddress("PausableFacet");
         addFacet(
-            DeployPausable.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployPausable.selectors()),
             facet,
             DeployPausable.makeInitData()
         );
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({
@@ -138,19 +136,19 @@ contract DeploySwapRouter is IDiamondInitHelper, DiamondHelper, Deployer {
 
             if (facetName.eq("SwapRouter")) {
                 addFacet(
-                    DeploySwapRouterFacet.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeploySwapRouterFacet.selectors()),
                     facet,
                     DeploySwapRouterFacet.makeInitData(getSpaceFactory())
                 );
             } else if (facetName.eq("MetadataFacet")) {
                 addFacet(
-                    DeployMetadata.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
                     facet,
                     DeployMetadata.makeInitData(bytes32("SwapRouter"), "")
                 );
             } else if (facetName.eq("PausableFacet")) {
                 addFacet(
-                    DeployPausable.makeCut(facet, IDiamond.FacetCutAction.Add),
+                    makeCut(facet, FacetCutAction.Add, DeployPausable.selectors()),
                     facet,
                     DeployPausable.makeInitData()
                 );

--- a/packages/contracts/scripts/deployments/utils/DeployMockNFT.s.sol
+++ b/packages/contracts/scripts/deployments/utils/DeployMockNFT.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 
 // libraries
 import {DeployDiamondCut} from "@towns-protocol/diamond/scripts/deployments/facets/DeployDiamondCut.sol";
@@ -24,7 +23,6 @@ contract DeployMockNFT is DiamondHelper, Deployer {
     using LibString for string;
 
     DeployFacet private facetHelper = new DeployFacet();
-    address private multiInit;
 
     function versionName() public pure override returns (string memory) {
         return "utils/mockNFT";
@@ -42,33 +40,32 @@ contract DeployMockNFT is DiamondHelper, Deployer {
         facetHelper.deployBatch(deployer);
 
         // Get deployed addresses
-        multiInit = facetHelper.getDeployedAddress("MultiInit");
-
-        // Add core facets
         address facet = facetHelper.getDeployedAddress("DiamondCutFacet");
         addFacet(
-            DeployDiamondCut.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondCut.selectors()),
             facet,
             DeployDiamondCut.makeInitData()
         );
 
         facet = facetHelper.getDeployedAddress("DiamondLoupeFacet");
         addFacet(
-            DeployDiamondLoupe.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployDiamondLoupe.selectors()),
             facet,
             DeployDiamondLoupe.makeInitData()
         );
 
         facet = facetHelper.getDeployedAddress("IntrospectionFacet");
         addFacet(
-            DeployIntrospection.makeCut(facet, IDiamond.FacetCutAction.Add),
+            makeCut(facet, FacetCutAction.Add, DeployIntrospection.selectors()),
             facet,
             DeployIntrospection.makeInitData()
         );
 
         // Add ERC721A mock
         facet = facetHelper.getDeployedAddress("MockERC721A");
-        addCut(DeployMockERC721A.makeCut(facet, IDiamond.FacetCutAction.Add));
+        addCut(makeCut(facet, FacetCutAction.Add, DeployMockERC721A.selectors()));
+
+        address multiInit = facetHelper.getDeployedAddress("MultiInit");
 
         return
             Diamond.InitParams({

--- a/packages/contracts/test/factory/wallet-link/WalletLink.t.sol
+++ b/packages/contracts/test/factory/wallet-link/WalletLink.t.sol
@@ -13,12 +13,11 @@ import {WalletLib} from "src/factory/facets/wallet-link/libraries/WalletLib.sol"
 import {SolanaUtils} from "src/factory/facets/wallet-link/libraries/SolanaUtils.sol";
 
 // contracts
-import {DeployBase} from "scripts/common/DeployBase.s.sol";
 import {BaseSetup} from "test/spaces/BaseSetup.sol";
 import {Nonces} from "@towns-protocol/diamond/src/utils/Nonces.sol";
 import {SimpleAccount} from "account-abstraction/samples/SimpleAccount.sol";
 
-contract WalletLinkTest is IWalletLinkBase, BaseSetup, DeployBase {
+contract WalletLinkTest is IWalletLinkBase, BaseSetup {
     Vm.Wallet internal rootWallet;
     Vm.Wallet internal wallet;
     Vm.Wallet internal smartAccount;


### PR DESCRIPTION
### Description

This pull request includes a series of refactors aimed at simplifying and improving the maintainability of deployment scripts and tests. Redundant imports, dependencies, and logic have been removed or optimized to enhance clarity and efficiency across the codebase.

### Changes

- Removed unnecessary `DeployBase` import and inheritance in `WalletLink` test suite.
- Simplified facet addition logic in deployment scripts by standardizing on the `makeCut` utility function.
- Refactored handling of `MultiInit` by centralizing its management into `diamondInitParams`.
- Optimized `DeployAppRegistry` contract to batch facet deployment operations and reduce redundancy.
- Eliminated unused `IDiamond` imports and redundant variables to clean up dependencies.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution