### PR TITLE
Remove commented-out error handling for missing miniblock candidates …

### DIFF
--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -1387,9 +1387,6 @@ func (s *PostgresStreamStore) getMiniblockCandidateCountTx(
 		streamId,
 		miniblockNumber,
 	).Scan(&count); err != nil {
-		// if errors.Is(err, pgx.ErrNoRows) {
-		// 	return 0, RiverError(Err_NOT_FOUND, "Miniblock candidate not found")
-		// }
 		return 0, err
 	}
 	return count, nil


### PR DESCRIPTION
…in pg_stream_store.go
