### PR TITLE
feat: add SpaceProxyInitializer deployment script and update makefile options

### DIFF
--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -11,3 +11,5 @@ scripts/accumulator-cli
 tsconfig.tsbuildinfo
 deployments/*/*/addresses/facets/
 out/
+.env.gamma
+.env.omega

--- a/packages/contracts/makefile
+++ b/packages/contracts/makefile
@@ -82,6 +82,8 @@ deploy-any :;
 	forge script scripts/deployments/${type}/${contract}.s.sol:${contract} \
 	--ffi --rpc-url ${rpc} --broadcast --verify \
 	$(if $(private_key),--private-key ${private_key},$(if $(account),--account ${account})) \
+	$(if $(password),--password ${password},) \
+	$(if $(sender),--sender ${sender},) \
 	$(if $(verifier),--verifier $(verifier),) \
 	$(if $(verifier-url),--verifier-url $(verifier-url),) \
 	$(if $(etherscan),--etherscan-api-key $(etherscan),)

--- a/packages/contracts/scripts/deployments/utils/DeploySpaceProxyInitializer.s.sol
+++ b/packages/contracts/scripts/deployments/utils/DeploySpaceProxyInitializer.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+//interfaces
+
+//libraries
+
+//contracts
+import {SpaceProxyInitializer} from "src/spaces/facets/proxy/SpaceProxyInitializer.sol";
+import {Deployer} from "scripts/common/Deployer.s.sol";
+
+contract DeploySpaceProxyInitializer is Deployer {
+    function versionName() public pure override returns (string memory) {
+        return "utils/spaceProxyInitializer";
+    }
+
+    function __deploy(address deployer) internal override returns (address) {
+        bytes32 salt = bytes32(uint256(1));
+        bytes32 initCodeHash = hashInitCode(type(SpaceProxyInitializer).creationCode);
+        address soonToBe = vm.computeCreate2Address(salt, initCodeHash);
+
+        vm.broadcast(deployer);
+        SpaceProxyInitializer initializer = new SpaceProxyInitializer{salt: salt}();
+
+        require(address(initializer) == soonToBe, "address mismatch");
+        return address(initializer);
+    }
+}


### PR DESCRIPTION
### Description

Added support for additional environment files and enhanced deployment script capabilities with new parameters and a space proxy initializer.

### Changes

- Added `.env.gamma` and `.env.omega` to `.gitignore`
- Enhanced the `deploy-any` make target with support for `password` and `sender` parameters
- Created a new deployment script `DeploySpaceProxyInitializer.s.sol` for initializing space proxies

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines