### PR TITLE
refactor: replace IERC173 with moduleOwner() in ITownsApp interface

### DIFF
--- a/packages/contracts/src/apps/BaseApp.sol
+++ b/packages/contracts/src/apps/BaseApp.sol
@@ -34,7 +34,13 @@ abstract contract BaseApp is ITownsApp {
         _onUninstall(postUninstallData);
     }
 
+    function moduleOwner() external view returns (address) {
+        return _moduleOwner();
+    }
+
     function _onInstall(bytes calldata postInstallData) internal virtual {}
 
     function _onUninstall(bytes calldata postUninstallData) internal virtual {}
+
+    function _moduleOwner() internal view virtual returns (address) {}
 }

--- a/packages/contracts/src/apps/ITownsApp.sol
+++ b/packages/contracts/src/apps/ITownsApp.sol
@@ -4,14 +4,17 @@ pragma solidity ^0.8.23;
 // interfaces
 import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
 import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
-import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 
 /// @title ITownsApp Interface
 /// @notice Base interface for Towns apps implementing core module functionality
-/// @dev Combines IERC173 (ownership), IERC6900Module (module lifecycle), and IERC6900ExecutionModule (execution)
+/// @dev Combines IERC6900Module (module lifecycle), and IERC6900ExecutionModule (execution)
 /// @dev Apps must implement required permissions and support these interfaces
-interface ITownsApp is IERC173, IERC6900Module, IERC6900ExecutionModule {
+interface ITownsApp is IERC6900Module, IERC6900ExecutionModule {
     /// @notice Returns the required permissions for the module
     /// @return permissions The required permissions for the module
     function requiredPermissions() external view returns (bytes32[] memory);
+
+    /// @notice Returns the owner of the module
+    /// @return owner The owner of the module
+    function moduleOwner() external view returns (address);
 }

--- a/packages/contracts/src/apps/examples/SimpleApp.sol
+++ b/packages/contracts/src/apps/examples/SimpleApp.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+import {BaseApp} from "../BaseApp.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+
+contract SimpleApp is Ownable, BaseApp {
+    string internal _appId;
+    bytes32[] internal _permissions;
+
+    constructor(address owner, string memory appId, bytes32[] memory permissions) {
+        _setOwner(owner);
+        _appId = appId;
+        _permissions = permissions;
+    }
+
+    function moduleId() public view returns (string memory) {
+        return _appId;
+    }
+
+    function executionManifest() external pure returns (ExecutionManifest memory) {}
+
+    function requiredPermissions() external view returns (bytes32[] memory) {
+        return _permissions;
+    }
+
+    function _moduleOwner() internal view override returns (address) {
+        return owner();
+    }
+}

--- a/packages/contracts/src/apps/facets/registry/AppRegistryBase.sol
+++ b/packages/contracts/src/apps/facets/registry/AppRegistryBase.sol
@@ -99,13 +99,12 @@ abstract contract AppRegistryBase is IAppRegistryBase, SchemaBase, AttestationBa
 
         if (appInfo.isBanned) BannedApp.selector.revertWith();
 
-        address owner = ITownsApp(app).owner();
-        if (msg.sender != owner) NotAppOwner.selector.revertWith();
-
         bytes32[] memory permissions = ITownsApp(app).requiredPermissions();
         ExecutionManifest memory manifest = ITownsApp(app).executionManifest();
 
         if (permissions.length == 0) InvalidArrayInput.selector.revertWith();
+
+        address owner = ITownsApp(app).moduleOwner();
 
         AttestationRequest memory request;
         request.schema = _getSchemaId();
@@ -204,8 +203,7 @@ abstract contract AppRegistryBase is IAppRegistryBase, SchemaBase, AttestationBa
         if (
             !IERC165(app).supportsInterface(type(IERC6900Module).interfaceId) ||
             !IERC165(app).supportsInterface(type(IERC6900ExecutionModule).interfaceId) ||
-            !IERC165(app).supportsInterface(type(ITownsApp).interfaceId) ||
-            !IERC165(app).supportsInterface(type(IERC173).interfaceId)
+            !IERC165(app).supportsInterface(type(ITownsApp).interfaceId)
         ) {
             AppDoesNotImplementInterface.selector.revertWith();
         }

--- a/packages/contracts/test/mocks/MockInvalidModule.sol
+++ b/packages/contracts/test/mocks/MockInvalidModule.sol
@@ -25,6 +25,10 @@ contract MockInvalidModule is OwnableFacet, ITownsApp {
         return "invalid-module";
     }
 
+    function moduleOwner() external view returns (address) {
+        return _owner();
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                      PERMISSIONS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/packages/contracts/test/mocks/MockModule.sol
+++ b/packages/contracts/test/mocks/MockModule.sol
@@ -40,6 +40,10 @@ contract MockModule is UUPSUpgradeable, OwnableFacet, ITownsApp {
         return "mock-module";
     }
 
+    function moduleOwner() external view returns (address) {
+        return _owner();
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                      PERMISSIONS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/packages/contracts/test/mocks/MockPlugin.sol
+++ b/packages/contracts/test/mocks/MockPlugin.sol
@@ -39,6 +39,10 @@ contract MockPlugin is OwnableFacet, ITownsApp {
         return permissions;
     }
 
+    function moduleOwner() external view returns (address) {
+        return _owner();
+    }
+
     function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return
             interfaceId == type(IERC6900Module).interfaceId ||

--- a/packages/contracts/test/mocks/MockSavingsModule.sol
+++ b/packages/contracts/test/mocks/MockSavingsModule.sol
@@ -46,6 +46,11 @@ contract MockSavingsModule is OwnableFacet, ITownsApp {
             interfaceId == type(IERC173).interfaceId;
     }
 
+    /// @inheritdoc ITownsApp
+    function moduleOwner() external view returns (address) {
+        return _owner();
+    }
+
     /**
      * @notice Returns the required permissions for the module
      * @return permissions The required permissions for the module


### PR DESCRIPTION
### Description

This PR refactors the Towns app ownership model by replacing the direct IERC173 inheritance with a dedicated `moduleOwner()` function. This approach provides a cleaner separation between module ownership and the Ownable implementation details.

### Changes

- Removed IERC173 inheritance from ITownsApp interface
- Added new `moduleOwner()` function to ITownsApp interface
- Implemented `moduleOwner()` and `_moduleOwner()` functions in BaseApp
- Created a new SimpleApp example that demonstrates the ownership pattern using Solady's Ownable
- Updated all mock implementations to support the new ownership interface
- Modified AppRegistryBase to use the new moduleOwner() function instead of owner()

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines