### PR TITLE
feat: add InteractRegisterApp script and move SimpleApp to helpers

### DIFF
--- a/packages/contracts/scripts/interactions/InteractRegisterApp.s.sol
+++ b/packages/contracts/scripts/interactions/InteractRegisterApp.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+//interfaces
+import {IAppRegistry} from "src/apps/facets/registry/IAppRegistry.sol";
+
+//contracts
+import {Interaction} from "../common/Interaction.s.sol";
+import {SimpleApp} from "./helpers/SimpleApp.sol";
+
+contract InteractRegisterApp is Interaction {
+    function __interact(address deployer) internal override {
+        address appRegistry = getDeployment("appRegistry");
+
+        // update with the bot public keys you want to register
+        address[] memory bots = new address[](1);
+        bots[0] = deployer; // update this with you public key bot address
+
+        // update with the permissions you want to set for the app
+        bytes32[] memory permissions = new bytes32[](1);
+        permissions[0] = bytes32("Read");
+
+        vm.broadcast(deployer);
+        SimpleApp app = new SimpleApp({
+            owner: deployer, // update with the owner of the app
+            appId: "simple.app",
+            permissions: permissions
+        });
+
+        vm.broadcast(deployer);
+        bytes32 appId = IAppRegistry(appRegistry).registerApp(address(app), bots);
+
+        saveApp("SimpleApp", appId, address(app));
+    }
+
+    function saveApp(string memory versionName, bytes32 appId, address contractAddr) internal {
+        if (!shouldSaveDeployments()) {
+            debug("(set SAVE_DEPLOYMENTS=1 to save deployments to file)");
+            return;
+        }
+
+        string memory networkDir = networkDirPath();
+
+        // create addresses directory
+        createDir(string.concat(networkDir, "/apps"));
+
+        // get deployment path
+        string memory path = string.concat(networkDir, "/apps/", versionName, ".json");
+
+        // save deployment
+        debug("saving deployment to: ", path);
+        string memory contractJson = vm.serializeAddress("apps", "address", contractAddr);
+        string memory appJson = vm.serializeBytes32("apps", "appId", appId);
+        vm.writeJson(contractJson, path);
+        vm.writeJson(appJson, path);
+    }
+}

--- a/packages/contracts/scripts/interactions/helpers/SimpleApp.sol
+++ b/packages/contracts/scripts/interactions/helpers/SimpleApp.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.23;
 // libraries
 
 // contracts
-import {BaseApp} from "../BaseApp.sol";
+import {BaseApp} from "src/apps/BaseApp.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
 

--- a/scripts/deploy-base-contracts.sh
+++ b/scripts/deploy-base-contracts.sh
@@ -37,6 +37,7 @@ make deploy-any-local context=$RIVER_ENV rpc=base_anvil type=diamonds contract=D
 make deploy-any-local context=$RIVER_ENV rpc=base_anvil type=diamonds contract=DeployAppRegistry
 make deploy-any-local context=$RIVER_ENV rpc=base_anvil type=diamonds contract=DeploySwapRouter
 make interact-any-local context=$RIVER_ENV rpc=base_anvil contract=InteractPostDeploy
+make interact-any-local context=$RIVER_ENV rpc=base_anvil contract=InteractRegisterApp
 make interact-any-local context=$RIVER_ENV rpc=base_anvil contract=InteractSetDefaultUriLocalhost
 make interact-any-local context=$RIVER_ENV rpc=base_anvil contract=InteractClaimCondition
 


### PR DESCRIPTION
### Description

Added a new interaction script for registering apps with the AppRegistry, and moved the SimpleApp contract to a more appropriate location in the project structure.

### Changes

- Created a new interaction script `InteractRegisterApp.s.sol` that allows registering apps with the AppRegistry
- Moved `SimpleApp.sol` from `src/apps/examples/` to `scripts/interactions/helpers/` to better reflect its usage
- Updated import paths in SimpleApp to maintain functionality
- Added the app registration step to the base contracts deployment script

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines