### PR TITLE
node: fix improper error handling in stream reconciliation

### DIFF
--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -449,7 +449,6 @@ func (s *Stream) schedulePromotionLocked(mb *MiniblockRef) error {
 	} else {
 		lastPending := s.local.pendingCandidates[len(s.local.pendingCandidates)-1]
 		if mb.Num != lastPending.Num+1 {
-			return RiverError(Err_STREAM_RECONCILIATION_REQUIRED, "schedulePromotionNoLock: pending candidates are not consecutive")
 			return RiverError(Err_STREAM_RECONCILIATION_REQUIRED, "schedulePromotionNoLock: pending candidates are not consecutive").
 				Tag("stream", s.streamId)
 		}

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -389,7 +389,7 @@ func (s *Stream) promoteCandidate(ctx context.Context, mb *MiniblockRef) error {
 	return s.promoteCandidateLocked(ctx, mb)
 }
 
-// promoteCandidateLocked shouldbe called with a lock held.
+// promoteCandidateLocked should be called with a lock held.
 func (s *Stream) promoteCandidateLocked(ctx context.Context, mb *MiniblockRef) error {
 	if s.local == nil {
 		return RiverError(Err_FAILED_PRECONDITION, "can't promote candidate for non-local stream").
@@ -441,7 +441,7 @@ func (s *Stream) schedulePromotionLocked(mb *MiniblockRef) error {
 			return RiverError(
 				Err_STREAM_RECONCILIATION_REQUIRED,
 				"schedulePromotionNoLock: next promotion is not for the next block",
-			)
+			).Tags("stream", s.streamId)
 		}
 		s.local.pendingCandidates = append(s.local.pendingCandidates, mb)
 	} else if len(s.local.pendingCandidates) > 3 {
@@ -450,6 +450,8 @@ func (s *Stream) schedulePromotionLocked(mb *MiniblockRef) error {
 		lastPending := s.local.pendingCandidates[len(s.local.pendingCandidates)-1]
 		if mb.Num != lastPending.Num+1 {
 			return RiverError(Err_STREAM_RECONCILIATION_REQUIRED, "schedulePromotionNoLock: pending candidates are not consecutive")
+			return RiverError(Err_STREAM_RECONCILIATION_REQUIRED, "schedulePromotionNoLock: pending candidates are not consecutive").
+				Tag("stream", s.streamId)
 		}
 		s.local.pendingCandidates = append(s.local.pendingCandidates, mb)
 	}
@@ -710,7 +712,11 @@ func (s *Stream) addEvent(ctx context.Context, event *ParsedEvent, relaxDuplicat
 // old to be in the cache and thus can't complete the duplicate check.
 // addEventLocked is not thread-safe.
 // Callers must have a lock held.
-func (s *Stream) addEventLocked(ctx context.Context, event *ParsedEvent, relaxDuplicateCheck bool) (*StreamView, error) {
+func (s *Stream) addEventLocked(
+	ctx context.Context,
+	event *ParsedEvent,
+	relaxDuplicateCheck bool,
+) (*StreamView, error) {
 	envelopeBytes, err := event.GetEnvelopeBytes()
 	if err != nil {
 		return nil, err

--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -93,7 +93,8 @@ func (s *StreamCache) onStreamPlacementUpdated(
 	}
 
 	// Check if this is the start of replication process for previously unreplicated stream.
-	if event.Stream.Stream.ReplicationFactor() == 1 && len(event.Stream.Stream.Nodes) > 1 && event.Stream.Stream.Nodes[0] == s.params.Wallet.Address {
+	if event.Stream.Stream.ReplicationFactor() == 1 && len(event.Stream.Stream.Nodes) > 1 &&
+		event.Stream.Stream.Nodes[0] == s.params.Wallet.Address {
 		go s.writeLatestMbToBlockchain(ctx, stream)
 	} else {
 		// Always submit a sync task, since this only happens on stream placement updates it happens


### PR DESCRIPTION
If stream conciliation fails because non of the remotes could provide all requested miniblocks `err` is `nil` because remotes might be able to return a valid response, just not with all miniblocks.

This error was wrapped in a RiverError but being `nil` resulted in a river error with code unknown. The reconciliation task is rescheduled on particular error codes in which this unknown code is not one of. As a result the stream reconciliation task isn't rescheduled.