### PR TITLE
chore: dont clean yarn cache on `yarn clean`

### DIFF
--- a/scripts/yarn-clean.sh
+++ b/scripts/yarn-clean.sh
@@ -22,8 +22,6 @@ fi
 
 echo "cleaning node"
 
-yarn cache clean
-
 # remove large directories that we know we will rebuild. Git clean hangs if we try to remove these in one go
 find . -name "node_modules" -type d -exec rm -r "{}" \;
 find . -name "dist" -type d -exec rm -r "{}" \;


### PR DESCRIPTION
this was completely removing the usefulness of https://github.com/towns-protocol/towns/pull/2972