### PR TITLE
dont throw on yarn checksumBehavior

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-checksumBehavior: throw
+checksumBehavior: update
 
 compressionLevel: mixed
 


### PR DESCRIPTION
We got a mismatch on `crypto-lib`, previously it wasn't throwing. 
https://github.com/HereNotThere/harmony/pull/9717
This PR reverts the behavior to the old one until we figure out the `crypto-lib` checksum mismatch


edit: actually, it was on harmony. But for the sake of having everything same, lets change here too.