### PR TITLE
feat: add token allowance functionality to AppAccount

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
@@ -12,13 +12,15 @@ import {AppAccount} from "src/spaces/facets/account/AppAccount.sol";
 
 library DeployAppAccount {
     function selectors() internal pure returns (bytes4[] memory _selectors) {
-        _selectors = new bytes4[](6);
+        _selectors = new bytes4[](8);
         _selectors[0] = AppAccount.execute.selector;
         _selectors[1] = AppAccount.installApp.selector;
         _selectors[2] = AppAccount.uninstallApp.selector;
         _selectors[3] = AppAccount.isAppEntitled.selector;
         _selectors[4] = AppAccount.setAppAllowance.selector;
         _selectors[5] = AppAccount.getAppAllowance.selector;
+        _selectors[6] = AppAccount.setTokenAllowance.selector;
+        _selectors[7] = AppAccount.getTokenAllowance.selector;
     }
 
     function makeCut(

--- a/packages/contracts/src/spaces/facets/account/AppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccount.sol
@@ -48,7 +48,7 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
         bytes calldata data,
         AppParams calldata params
     ) external onlyOwner {
-        _installApp(appId, params.grantDelay, params.executionDelay, params.allowance, data);
+        _installApp(appId, params.delays, params.allowances, data);
     }
 
     function uninstallApp(bytes32 appId, bytes calldata data) external onlyOwner {

--- a/packages/contracts/src/spaces/facets/account/AppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccount.sol
@@ -6,9 +6,9 @@ import {IAppAccount} from "./IAppAccount.sol";
 
 // libraries
 import {AppAccountBase} from "./AppAccountBase.sol";
+import {CurrencyTransfer} from "src/utils/libraries/CurrencyTransfer.sol";
 
 // contracts
-
 import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
 import {ReentrancyGuard} from "solady/utils/ReentrancyGuard.sol";
 
@@ -73,10 +73,22 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function setAppAllowance(bytes32 appId, uint256 allowance) external onlyOwner {
-        _setAppAllowance(appId, allowance);
+        _setTokenAllowance(appId, CurrencyTransfer.NATIVE_TOKEN, allowance);
     }
 
     function getAppAllowance(bytes32 appId) external view returns (uint256) {
-        return _getAppAllowance(appId);
+        return _getTokenAllowance(appId, CurrencyTransfer.NATIVE_TOKEN);
+    }
+
+    function setTokenAllowance(
+        bytes32 groupId,
+        address token,
+        uint256 allowance
+    ) external onlyOwner {
+        _setTokenAllowance(groupId, token, allowance);
+    }
+
+    function getTokenAllowance(bytes32 groupId, address token) external view returns (uint256) {
+        return _getTokenAllowance(groupId, token);
     }
 }

--- a/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.29;
 // types
 
 // libraries
+import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 
 // types
 
@@ -22,7 +23,8 @@ library AppAccountStorage {
     }
 
     struct Layout {
-        mapping(bytes32 groupId => mapping(address token => TokenAllowance allowance)) allowances;
+        mapping(bytes32 groupId => EnumerableSetLib.AddressSet) allowedTokens;
+        mapping(bytes32 groupId => mapping(address token => TokenAllowance)) allowances;
     }
 
     function getLayout() internal pure returns (Layout storage l) {

--- a/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+// interfaces
+
+// types
+
+// libraries
+
+// types
+
+// contracts
+
+library AppAccountStorage {
+    // keccak256(abi.encode(uint256(keccak256("spaces.facets.account.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant STORAGE_SLOT =
+        0x5203018779d8301358307033923a3bd0a3a759f1f58591c01f878744c0f8c200;
+
+    struct TokenAllowance {
+        uint256 allowance;
+        uint256 lastUpdated;
+    }
+
+    struct Layout {
+        mapping(bytes32 groupId => mapping(address token => TokenAllowance allowance)) allowances;
+    }
+
+    function getLayout() internal pure returns (Layout storage l) {
+        assembly {
+            l.slot := STORAGE_SLOT
+        }
+    }
+}

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -30,6 +30,19 @@ interface IAppAccountBase {
     error AppNotInstalled();
     error AppNotRegistered();
     error AppRevoked();
+    error InvalidToken();
+    error NotEnoughToken();
+    error LargeAllowanceIncrease();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           EVENTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+    event TokenAllowanceSet(
+        bytes32 indexed groupId,
+        address indexed token,
+        uint256 allowance,
+        uint256 timestamp
+    );
 }
 
 interface IAppAccount is IAppAccountBase {

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -8,13 +8,27 @@ pragma solidity ^0.8.23;
 // contracts
 interface IAppAccountBase {
     /// @notice Params for installing an app
-    /// @param allowance The maximum amount of ETH that can be spent by the app
+    /// @param delays The delays for installing an app
+    /// @param allowances The token allowances for a module
+    struct AppParams {
+        Delays delays;
+        Allowance[] allowances;
+    }
+
+    /// @notice Delays for installing an app
     /// @param grantDelay The delay before the app can be granted access to the group
     /// @param executionDelay The delay before the app can execute a transaction
-    struct AppParams {
-        uint256 allowance;
+    struct Delays {
         uint32 grantDelay;
         uint32 executionDelay;
+    }
+
+    /// @notice Allowance for a token
+    /// @param token The token to set the allowance for
+    /// @param allowance The maximum amount of the token that can be spent by the app
+    struct Allowance {
+        address token;
+        uint256 allowance;
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
@@ -17,6 +17,9 @@ import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 import {LibCall} from "solady/utils/LibCall.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
+// debuggging
+import {console} from "forge-std/console.sol";
+
 abstract contract ExecutorBase is IExecutorBase {
     using CustomRevert for bytes4;
     using EnumerableSetLib for EnumerableSetLib.Uint256Set;
@@ -529,6 +532,10 @@ abstract contract ExecutorBase is IExecutorBase {
         if (data.length < 4) InvalidDataLength.selector.revertWith();
         return bytes4(data[0:4]);
     }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           Hooks                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @dev Internal function to get the owner
     function _getOwner() internal view virtual returns (address);

--- a/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
@@ -4,10 +4,8 @@ pragma solidity ^0.8.23;
 // interfaces
 
 // types
-import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
 
 // libraries
-import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 
 // types
 import {Group, Schedule, Target} from "./IExecutor.sol";


### PR DESCRIPTION
### Description

This PR enhances the AppAccount functionality by adding token allowance management capabilities. Previously, the system only supported native token (ETH) allowances, but now it can handle ERC20 token allowances as well, enabling apps to use both native and ERC20 tokens with proper permission controls.

### Changes

- Added new methods `setTokenAllowance` and `getTokenAllowance` to manage ERC20 token allowances
- Refactored existing app allowance methods to use the new token allowance system under the hood
- Created new storage structure in `AppAccountStorage.sol` to track token allowances with timestamps
- Implemented safety mechanisms to prevent large allowance increases without a time delay
- Added validation checks for token balances and addresses
- Updated the mock module to support testing token-based transactions
- Added new selectors to the deployment script

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines