### PR TITLE
[BUGFIX] - Fix mutex copy in multi sync runner.

### DIFF
--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -527,7 +527,7 @@ type MultiSyncRunner struct {
 
 	// workerPool tracks workers that empty the queue of streams to relocate and place them in
 	// new or existing syncs
-	workerPool workerpool.WorkerPool
+	workerPool *workerpool.WorkerPool
 
 	otelTracer trace.Tracer
 
@@ -586,7 +586,7 @@ func NewMultiSyncRunner(
 		trackedViewConstructor: trackedStreamViewConstructor,
 		streamsToSync:          make(chan (*streamSyncInitRecord), 2048),
 		config:                 streamTrackingConfig,
-		workerPool:             *workerpool.New(streamTrackingConfig.NumWorkers),
+		workerPool:             workerpool.New(streamTrackingConfig.NumWorkers),
 		otelTracer:             otelTracer,
 	}
 }


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->
This issue was caught by coderabbit in harmony when I merged upstream. I think it may actually be fine since the copy happens only once when the struct is first created, but at best it's still bad form.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
