### PR TITLE
Make sure we don’t save duplicate snapshots to the persistence store

### DIFF
--- a/packages/sdk/src/streamUtils.ts
+++ b/packages/sdk/src/streamUtils.ts
@@ -117,6 +117,14 @@ export function parsedMiniblockToPersistedMiniblock(
 }
 
 function parsedEventToPersistedEvent(event: ParsedEvent) {
+    // always zero out the snapshot since we save it separately
+    if (event.event?.payload.case === 'miniblockHeader') {
+        event.event.payload.value = {
+            ...event.event.payload.value,
+            snapshot: undefined,
+        }
+    }
+
     return create(PersistedEventSchema, {
         event: event.event,
         hash: event.hash,


### PR DESCRIPTION
now that we have snapshots saved separately in the db, don't save these to disc

this includes a db wipe, and starts using the snapshot table in the persistence store.