### PR TITLE
Modified handling of isNewDevice

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -339,7 +339,7 @@ export abstract class BaseDecryptionExtensions {
                 if (keySolicitation.deviceKey === this.userDevice.deviceKey) {
                     continue
                 }
-                if (keySolicitation.sessionIds.length === 0 && !keySolicitation.isNewDevice) {
+                if (keySolicitation.sessionIds.length === 0) {
                     continue
                 }
                 const selectedQueue =
@@ -879,9 +879,10 @@ export abstract class BaseDecryptionExtensions {
             streamId,
             userAddress: item.fromUserAddress,
             deviceKey: item.solicitation.deviceKey,
-            sessionIds: item.solicitation.isNewDevice
-                ? []
-                : allSessions.map((x) => x.sessionId).sort(),
+            sessionIds: allSessions
+                .map((x) => x.sessionId)
+                .filter((x) => requestedSessionIds.has(x))
+                .sort(),
         })
 
         // if the key fulfillment failed, someone else already sent a key fulfillment

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -304,7 +304,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             deviceKey: this.userDevice.deviceKey,
             fallbackKey: this.userDevice.fallbackKey,
             isNewDevice,
-            sessionIds: isNewDevice ? [] : missingSessionIds,
+            sessionIds: missingSessionIds,
         })
         await this.client.makeEventAndAddToStream(streamId, keySolicitation)
     }


### PR DESCRIPTION
This should be able to go in without affecting needing iOS updates yet

I think it was a mistake to not pass session ids in the initial key solicitations, we end up in a situation where we can ping pong solicitations without actually satisfying the request. The contents of this change

- isNewDevice becomes a suggestion instead of a state
- all key requests now require session ids
- if isNewDevice is true, clients will still send all known sessions, but explicitly state in the fulfillment if they fulfilled any of the requested ids.

this should tighten the reqest loop and prevent at least one back and forth between clients in some cases.

update test