### PR TITLE
Server rules for handling of isNewDevice

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -1998,8 +1998,8 @@ func (ru *aeKeySolicitationRules) validKeySolicitation() (bool, error) {
 		return false, RiverError(Err_INVALID_ARGUMENT, "event is not a key solicitation event")
 	}
 
-	if !ru.solicitation.IsNewDevice && len(ru.solicitation.SessionIds) == 0 {
-		return false, RiverError(Err_INVALID_ARGUMENT, "session ids are required for existing devices")
+	if len(ru.solicitation.SessionIds) == 0 {
+		return false, RiverError(Err_INVALID_ARGUMENT, "session ids are required for all solicitations")
 	}
 
 	if !slices.IsSorted(ru.solicitation.SessionIds) {
@@ -2035,6 +2035,10 @@ func (ru *aeKeyFulfillmentRules) validKeyFulfillment() (bool, error) {
 	for _, solicitation := range solicitations {
 		if solicitation.DeviceKey == ru.fulfillment.DeviceKey {
 			if solicitation.IsNewDevice {
+				// if the user has indicated that this is a new device, it's possible that a client
+				// will fulfill with all known sessionids, but not have an overlapping sessionId
+				// this will clear the IsNewDevice flag, but the solicitation will still be valid, and
+				// a different client could complete the fulfillment
 				return true, nil
 			}
 			if hasCommon(solicitation.SessionIds, ru.fulfillment.SessionIds) {

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -371,7 +371,7 @@ describe('clientTest', () => {
         // solicitation for isNewDevice should resolve
         payload = make_MemberPayload_KeySolicitation({
             deviceKey: 'foo',
-            sessionIds: [],
+            sessionIds: ['bar'],
             fallbackKey: 'baz',
             isNewDevice: true,
         })
@@ -393,7 +393,7 @@ describe('clientTest', () => {
         payload = make_MemberPayload_KeyFulfillment({
             deviceKey: 'foo',
             userAddress: addressFromUserId(bobsClient.userId),
-            sessionIds: [],
+            sessionIds: ['bar'],
         })
         await expect(
             bobsClient.makeEventAndAddToStream(bobsClient.userSettingsStreamId!, payload),


### PR DESCRIPTION
This needs to wait for iOS updates

I think it was a mistake to not pass session ids in the initial key solicitations, we end up in a situation where we can ping pong solicitations without actually satisfying the request. The contents of this change

- isNewDevice becomes a suggestion instead of a state
- all key requests now require session ids
- if isNewDevice is true, clients will still send all known sessions, but explicitly state in the fulfillment if they fulfilled any of the requested ids.

this should tighten the reqest loop and prevent at least one back and forth between clients in some cases.