### PR TITLE
[BUGFIX] - Make TTLs in client cache match the node

### DIFF
--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -203,7 +203,12 @@ export class SpaceDapp {
         const bannedCacheOpts = {
             ttlSeconds: isLocalDev ? 5 : 15 * 60,
         }
-        this.entitlementCache = new EntitlementCache(entitlementCacheOpts)
+
+        // The caching of positive entitlements is shorter on both the node and client.
+        this.entitlementCache = new EntitlementCache({
+            positiveCacheTTLSeconds: isLocalDev ? 5 : 15,
+            negativeCacheTTLSeconds: 2,
+        })
         this.entitledWalletCache = new EntitlementCache(entitlementCacheOpts)
         this.entitlementEvaluationCache = new EntitlementCache(entitlementCacheOpts)
         this.bannedTokenIdsCache = new SimpleCache(bannedCacheOpts)


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->
Upon investigation, I saw that the entitlement cache TTL on the node is actually shorter than other cache ttls, but this is not replicated in the client. This PR updates the client to share the same cache ttls as the node for caches that are common between them.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
