### PR TITLE
fix(contract): emit missing ERC20 events in `TownsPoints`

### DIFF
--- a/packages/contracts/src/airdrop/points/TownsPoints.sol
+++ b/packages/contracts/src/airdrop/points/TownsPoints.sol
@@ -69,6 +69,7 @@ contract TownsPoints is IERC20Metadata, ITownsPoints, OwnableBase, Facet {
         TownsPointsStorage.Layout storage self = TownsPointsStorage.layout();
         for (uint256 i; i < accounts.length; ++i) {
             self.inner.mint(accounts[i], values[i]);
+            emit Transfer(address(0), accounts[i], values[i]);
         }
     }
 
@@ -114,6 +115,7 @@ contract TownsPoints is IERC20Metadata, ITownsPoints, OwnableBase, Facet {
 
         (userCheckIn.streak, userCheckIn.lastCheckIn) = (newStreak, block.timestamp);
         TownsPointsStorage.layout().inner.mint(msg.sender, pointsToAward);
+        emit Transfer(address(0), msg.sender, pointsToAward);
         emit CheckedIn(msg.sender, pointsToAward, newStreak, block.timestamp);
     }
 
@@ -134,23 +136,27 @@ contract TownsPoints is IERC20Metadata, ITownsPoints, OwnableBase, Facet {
     /// @inheritdoc IERC20
     function approve(address spender, uint256 value) external returns (bool) {
         TownsPointsStorage.layout().inner.approve(spender, value);
+        emit Approval(msg.sender, spender, value);
         return true;
     }
 
     /// @inheritdoc ITownsPoints
     function mint(address to, uint256 value) external onlySpace {
         TownsPointsStorage.layout().inner.mint(to, value);
+        emit Transfer(address(0), to, value);
     }
 
     /// @inheritdoc IERC20
     function transfer(address to, uint256 value) external returns (bool) {
         TownsPointsStorage.layout().inner.transfer(to, value);
+        emit Transfer(msg.sender, to, value);
         return true;
     }
 
     /// @inheritdoc IERC20
     function transferFrom(address from, address to, uint256 value) external returns (bool) {
         TownsPointsStorage.layout().inner.transferFrom(from, to, value);
+        emit Transfer(from, to, value);
         return true;
     }
 

--- a/packages/contracts/test/spaces/swap/SwapFacet.t.sol
+++ b/packages/contracts/test/spaces/swap/SwapFacet.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {ITownsPoints, ITownsPointsBase} from "../../../src/airdrop/points/ITownsPoints.sol";
 import {IPlatformRequirements} from "../../../src/factory/facets/platform/requirements/IPlatformRequirements.sol";
@@ -258,6 +259,9 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
         );
         params.amountIn = amountIn;
 
+        vm.expectEmit(address(riverAirdrop));
+        emit IERC20.Transfer(address(0), caller, expectedPoints);
+
         vm.expectEmit(everyoneSpace);
         emit SwapExecuted(
             recipient,
@@ -329,6 +333,9 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
         // calculate protocol fee and expected points
         uint256 protocolFee = BasisPoints.calculate(amountOut, PROTOCOL_BPS);
         uint256 expectedPoints = _getPoints(protocolFee);
+
+        vm.expectEmit(address(riverAirdrop));
+        emit IERC20.Transfer(address(0), caller, expectedPoints);
 
         vm.expectEmit(everyoneSpace);
         emit SwapExecuted(


### PR DESCRIPTION
### Description

Fixes missing event emissions that are required by ERC20 standard for proper token tracking and integration with external tools.

### Changes

- Add `Transfer` event emissions to `mint`, `transfer`, `transferFrom`, `batchMintPoints`, and `checkIn` functions
- Add `Approval` event emission to `approve` function
- Update existing tests with `vm.expectEmit` to verify proper event emissions
- Ensure ERC20 standard compliance for points token contract

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
