### PR TITLE
fix: _renewSubscription should handle expired memberships

### DIFF
--- a/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
+++ b/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
@@ -19,7 +19,7 @@ abstract contract ERC5643Base is IERC5643Base {
         if (currentExpiration == 0) {
             newExpiration = uint64(block.timestamp) + duration;
         } else if (currentExpiration <= block.timestamp) {
-             if (!_isRenewable(tokenId)) {
+            if (!_isRenewable(tokenId)) {
                 revert ERC5643__SubscriptionNotRenewable(tokenId);
             }
             newExpiration = uint64(block.timestamp) + duration;

--- a/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
+++ b/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
@@ -18,6 +18,11 @@ abstract contract ERC5643Base is IERC5643Base {
 
         if (currentExpiration == 0) {
             newExpiration = uint64(block.timestamp) + duration;
+        } else if (currentExpiration <= block.timestamp) {
+             if (!_isRenewable(tokenId)) {
+                revert ERC5643__SubscriptionNotRenewable(tokenId);
+            }
+            newExpiration = uint64(block.timestamp) + duration;
         } else {
             if (!_isRenewable(tokenId)) {
                 revert ERC5643__SubscriptionNotRenewable(tokenId);

--- a/packages/contracts/test/spaces/membership/unit/MembershipDuration.t.sol
+++ b/packages/contracts/test/spaces/membership/unit/MembershipDuration.t.sol
@@ -221,7 +221,7 @@ contract MembershipDurationTest is MembershipBaseSetup {
         MembershipFacet(userSpace).setMembershipDuration(zeroDuration);
     }
 
-    function test_revertWhen_renewMembershipAfterExpiration() public {
+    function test_renewMembershipAfterExpiration() public {
         // Create a space with custom duration
         address spaceAddress = test_createSpaceWithCustomDuration();
         IMembership space = IMembership(spaceAddress);
@@ -233,8 +233,6 @@ contract MembershipDurationTest is MembershipBaseSetup {
         uint256 tokenId = IERC721AQueryable(spaceAddress).tokensOfOwner(alice)[0];
         uint256 initialExpiry = space.expiresAt(tokenId);
 
-        uint256 expectedNewExpiry = initialExpiry + CUSTOM_DURATION;
-
         // Fast forward past expiration
         vm.warp(initialExpiry + 1);
 
@@ -243,6 +241,9 @@ contract MembershipDurationTest is MembershipBaseSetup {
 
         hoax(alice, renewalPrice);
         space.renewMembership{value: renewalPrice}(tokenId);
+
+        // Expired memberships renew from current time + duration
+        uint256 expectedNewExpiry = block.timestamp + CUSTOM_DURATION;
 
         // Verify the new expiration is based on current time + duration (not extending from the expired time)
         assertEq(space.expiresAt(tokenId), expectedNewExpiry);


### PR DESCRIPTION
### Description

The time between an expiration and now could be greater than the membership duration, so if you renewed you'd still be expired.
This PR checks if the the membership has already expired, and sets the new duration from the current time, instead of the previous expiration time.

### Checklist

- [x] Tests added where required

