### PR TITLE
[BUGFIX] - add handling for channel inception events to the test bot server

### DIFF
--- a/core/node/app_registry/testutil.go
+++ b/core/node/app_registry/testutil.go
@@ -151,6 +151,16 @@ func FormatChannelRedactionReply(redaction *protocol.ChannelPayload_Redaction) s
 	)
 }
 
+func FormatChannelInceptionReply(inception *protocol.ChannelPayload_Inception) string {
+	streamId := shared.StreamId(inception.StreamId)
+	spaceId := shared.StreamId(inception.SpaceId)
+	return fmt.Sprintf(
+		"ChannelInception streamId(%v) spaceId(%v)",
+		streamId,
+		spaceId,
+	)
+}
+
 func FormatMembershipReply(membership *protocol.MemberPayload_Membership) string {
 	userAddress := common.BytesToAddress(membership.UserAddress)
 	initiatorAddress := common.BytesToAddress(membership.InitiatorAddress)
@@ -656,6 +666,14 @@ func (b *TestAppServer) respondToSendMessages(
 					err := b.sendChannelMessage(ctx, botIndex, shared.StreamId(data.StreamId), FormatChannelRedactionReply(content.Redaction), placeHolderSessionBytes)
 					if err != nil {
 						return logAndReturnErr(log, fmt.Errorf("could not respond to channel redaction event: %w", err))
+					}
+					continue
+				}
+			case *protocol.ChannelPayload_Inception_:
+				{
+					err := b.sendChannelMessage(ctx, botIndex, shared.StreamId(data.StreamId), FormatChannelInceptionReply(content.Inception), placeHolderSessionBytes)
+					if err != nil {
+						return logAndReturnErr(log, fmt.Errorf("could not respond to channel inception event: %w", err))
 					}
 					continue
 				}


### PR DESCRIPTION

### Description

This should fix some flaky app registry tests I've been seeing. Here is an example: https://github.com/towns-protocol/towns/actions/runs/15200586362/job/42753869981?pr=3152

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
