### PR TITLE
fix typos and improve code comments

### DIFF
--- a/packages/sdk/src/sync-agent/syncAgent.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.ts
@@ -125,7 +125,7 @@ export class SyncAgent {
         // commit the initialization transaction, which triggers onLoaded on the models
         await this.store.commitTransaction()
         this.log('SyncAgent::start: starting river connection')
-        // start thie river connection, this will log us in if the user is already signed up
+        // start this river connection, this will log us in if the user is already signed up
         // it will leave us in a connected state otherwise, see riverConnection.authStatus
         await this.riverConnection.start()
         this.log('SyncAgent::start: river connection started')

--- a/packages/sdk/src/tests/multi_ne/space.test.ts
+++ b/packages/sdk/src/tests/multi_ne/space.test.ts
@@ -79,7 +79,7 @@ describe('spaceTests', () => {
             bobsClient.createChannel(spaceId, 'name', 'topic', channelId),
         ).resolves.not.toThrow()
 
-        // our space channels metatdata should reflect the new channel
+        // our space channels metadata should reflect the new channel
         await waitFor(() => {
             expect(spaceStream.view.spaceContent.spaceChannelsMetadata.get(channelId)).toBeDefined()
             expect(
@@ -116,7 +116,7 @@ describe('spaceTests', () => {
         // update the channel metadata
         await bobsClient.updateChannel(spaceId, channelId, '', '')
 
-        // see the metadat update
+        // see the metadata update
         await waitFor(() => {
             expect(spaceStream.view.spaceContent.spaceChannelsMetadata.get(channelId)).toBeDefined()
             expect(

--- a/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
+++ b/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
@@ -35,7 +35,7 @@ describe('syncStreams', () => {
         expect(stateConstraints[SyncState.Canceling].has(SyncState.Syncing)).toBe(false)
         expect(stateConstraints[SyncState.NotSyncing].has(SyncState.Syncing)).toBe(false)
 
-        // the starting, and retrying state should both be able to transition to syncing, othwerwise waitForSyncingState will break
+        // the starting, and retrying state should both be able to transition to syncing, otherwise waitForSyncingState will break
         expect(stateConstraints[SyncState.Starting].has(SyncState.Syncing)).toBe(true)
         expect(stateConstraints[SyncState.Retrying].has(SyncState.Syncing)).toBe(true) // if this breaks, we just need to change the two conditions in waitForSyncingState
     })


### PR DESCRIPTION
### Description
Fixed minor typos in comments and logs across multiple files:

- **syncAgent.ts**
  - `thie` → `this`

- **multi_me/space.test.ts**
  - `metatdata` → `metadata`
  - `metadat` → `metadata`

- **multi_me/syncedStreams.test.ts**
  - `othwerwise` → `otherwise`
  - 

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
