### PR TITLE
refactor(contract): enhance organization of `MainnetDelegation` functions

### DIFF
--- a/packages/contracts/src/base/registry/facets/mainnet/IMainnetDelegation.sol
+++ b/packages/contracts/src/base/registry/facets/mainnet/IMainnetDelegation.sol
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
 interface IMainnetDelegationBase {
-    // =============================================================
-    //                           Structs
-    // =============================================================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @notice Delegation struct
     /// @param operator The operator address
@@ -35,9 +30,9 @@ interface IMainnetDelegationBase {
         address claimer;
     }
 
-    // =============================================================
-    //                           Events
-    // =============================================================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           EVENTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     event DelegationSet(address indexed delegator, address indexed operator, uint256 quantity);
 
@@ -47,9 +42,13 @@ interface IMainnetDelegationBase {
 
     event DelegationDigestSet(bytes32 digest);
 
-    // =============================================================
-    //                           Errors
-    // =============================================================
+    event CrossDomainMessengerSet(address messenger);
+
+    event ProxyDelegationSet(address proxyDelegation);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           ERRORS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     error InvalidDelegator(address delegator);
     error InvalidOperator(address operator);
@@ -61,15 +60,31 @@ interface IMainnetDelegationBase {
 }
 
 interface IMainnetDelegation is IMainnetDelegationBase {
-    /// @notice Set delegation digest from L1
-    /// @dev Only the L2 messenger can call this function
-    /// @param digest The delegation digest
-    function setDelegationDigest(bytes32 digest) external;
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       ADMIN FUNCTIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Set proxy delegation
+    /// @param proxyDelegation The proxy delegation address
+    function setProxyDelegation(address proxyDelegation) external;
 
     /// @notice Relay cross-chain delegations
     /// @dev Only the owner can call this function
     /// @param encodedMsgs The encoded delegation messages
     function relayDelegations(bytes calldata encodedMsgs) external;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         DELEGATION                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Set delegation digest from L1
+    /// @dev Only the L2 messenger can call this function
+    /// @param digest The delegation digest
+    function setDelegationDigest(bytes32 digest) external;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          GETTERS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @notice Get delegation of a delegator
     /// @param delegator The delegator address
@@ -92,10 +107,6 @@ interface IMainnetDelegation is IMainnetDelegationBase {
     /// @param owner The owner address
     /// @return address The claimer address
     function getAuthorizedClaimer(address owner) external view returns (address);
-
-    /// @notice Set proxy delegation
-    /// @param proxyDelegation The proxy delegation address
-    function setProxyDelegation(address proxyDelegation) external;
 
     /// @notice Get proxy delegation
     /// @return address The proxy delegation address

--- a/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegation.sol
+++ b/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegation.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-
 import {ICrossDomainMessenger} from "src/base/registry/facets/mainnet/ICrossDomainMessenger.sol";
 import {IMainnetDelegation} from "src/base/registry/facets/mainnet/IMainnetDelegation.sol";
 
 // libraries
+import {MainnetDelegationStorage} from "./MainnetDelegationStorage.sol";
 
 // contracts
-
 import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
 import {OwnableBase} from "@towns-protocol/diamond/src/facets/ownable/OwnableBase.sol";
 import {MainnetDelegationBase} from "src/base/registry/facets/mainnet/MainnetDelegationBase.sol";
@@ -25,7 +24,9 @@ contract MainnetDelegation is IMainnetDelegation, MainnetDelegationBase, Ownable
 
     function __MainnetDelegation_init_unchained(address messenger) internal {
         _addInterface(type(IMainnetDelegation).interfaceId);
-        _setMessenger(ICrossDomainMessenger(messenger));
+        MainnetDelegationStorage.layout().messenger = messenger;
+
+        emit CrossDomainMessengerSet(messenger);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -33,11 +34,11 @@ contract MainnetDelegation is IMainnetDelegation, MainnetDelegationBase, Ownable
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     modifier onlyCrossDomainMessenger() {
-        ICrossDomainMessenger messenger = _getMessenger();
+        address messenger = _getMessenger();
 
         require(
-            msg.sender == address(messenger) &&
-                messenger.xDomainMessageSender() == address(_getProxyDelegation()),
+            msg.sender == messenger &&
+                ICrossDomainMessenger(messenger).xDomainMessageSender() == _getProxyDelegation(),
             "MainnetDelegation: sender is not the cross-domain messenger"
         );
         _;
@@ -48,7 +49,9 @@ contract MainnetDelegation is IMainnetDelegation, MainnetDelegationBase, Ownable
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function setProxyDelegation(address proxyDelegation) external onlyOwner {
-        _setProxyDelegation(proxyDelegation);
+        MainnetDelegationStorage.layout().proxyDelegation = proxyDelegation;
+
+        emit ProxyDelegationSet(proxyDelegation);
     }
 
     /// @inheritdoc IMainnetDelegation
@@ -62,7 +65,9 @@ contract MainnetDelegation is IMainnetDelegation, MainnetDelegationBase, Ownable
 
     /// @inheritdoc IMainnetDelegation
     function setDelegationDigest(bytes32 digest) external onlyCrossDomainMessenger {
-        _setDelegationDigest(digest);
+        MainnetDelegationStorage.layout().delegationDigest = digest;
+
+        emit DelegationDigestSet(digest);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -71,7 +76,7 @@ contract MainnetDelegation is IMainnetDelegation, MainnetDelegationBase, Ownable
 
     /// @inheritdoc IMainnetDelegation
     function getMessenger() external view returns (address) {
-        return address(_getMessenger());
+        return _getMessenger();
     }
 
     /// @inheritdoc IMainnetDelegation

--- a/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegationBase.sol
+++ b/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegationBase.sol
@@ -2,47 +2,23 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-
+import {IRewardsDistribution} from "../distribution/v2/IRewardsDistribution.sol";
 import {ICrossDomainMessenger} from "./ICrossDomainMessenger.sol";
 import {IMainnetDelegationBase} from "./IMainnetDelegation.sol";
 
 // libraries
-
 import {MainnetDelegationStorage} from "./MainnetDelegationStorage.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 
 // contracts
-import {IRewardsDistribution} from "src/base/registry/facets/distribution/v2/IRewardsDistribution.sol";
 
 abstract contract MainnetDelegationBase is IMainnetDelegationBase {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    function _setDelegationDigest(bytes32 digest) internal {
-        MainnetDelegationStorage.layout().delegationDigest = digest;
-
-        emit DelegationDigestSet(digest);
-    }
-
-    function _verifyDelegations(bytes calldata encodedMsgs) internal view {
-        MainnetDelegationStorage.Layout storage ds = MainnetDelegationStorage.layout();
-
-        bytes32 digest = keccak256(abi.encode(keccak256(encodedMsgs)));
-        require(digest == ds.delegationDigest);
-    }
-
-    /// @dev equivalent: abi.decode(encodedMsgs, (DelegationMsg[]));
-    function _decodeDelegations(
-        bytes calldata encodedMsgs
-    ) internal pure returns (DelegationMsg[] calldata msgs) {
-        assembly {
-            // this is a dynamic array, so calldataload(encodedMsgs.offset) is the
-            // offset from encodedMsgs.offset at which the array begins
-            let lengthPtr := add(encodedMsgs.offset, calldataload(encodedMsgs.offset))
-            msgs.length := calldataload(lengthPtr)
-            msgs.offset := add(lengthPtr, 0x20)
-        }
-    }
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       STATE MUTATING                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function _relayDelegations(bytes calldata encodedMsgs) internal {
         _verifyDelegations(encodedMsgs);
@@ -192,6 +168,25 @@ abstract contract MainnetDelegationBase is IMainnetDelegationBase {
         }
     }
 
+    function _setAuthorizedClaimer(address delegator, address claimer) internal {
+        MainnetDelegationStorage.Layout storage ds = MainnetDelegationStorage.layout();
+
+        address currentClaimer = ds.claimerByDelegator[delegator];
+        if (currentClaimer != claimer) {
+            ds.delegatorsByAuthorizedClaimer[currentClaimer].remove(delegator);
+            ds.claimerByDelegator[delegator] = claimer;
+            if (claimer != address(0)) {
+                ds.delegatorsByAuthorizedClaimer[claimer].add(delegator);
+            }
+
+            emit ClaimerSet(delegator, claimer);
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          GETTERS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
     function _getDepositIdByDelegator(address delegator) internal view returns (uint256) {
         return MainnetDelegationStorage.layout().depositIdByDelegator[delegator];
     }
@@ -230,21 +225,6 @@ abstract contract MainnetDelegationBase is IMainnetDelegationBase {
         }
     }
 
-    function _setAuthorizedClaimer(address delegator, address claimer) internal {
-        MainnetDelegationStorage.Layout storage ds = MainnetDelegationStorage.layout();
-
-        address currentClaimer = ds.claimerByDelegator[delegator];
-        if (currentClaimer != claimer) {
-            ds.delegatorsByAuthorizedClaimer[currentClaimer].remove(delegator);
-            ds.claimerByDelegator[delegator] = claimer;
-            if (claimer != address(0)) {
-                ds.delegatorsByAuthorizedClaimer[claimer].add(delegator);
-            }
-
-            emit ClaimerSet(delegator, claimer);
-        }
-    }
-
     function _getDelegatorsByAuthorizedClaimer(
         address claimer
     ) internal view returns (address[] memory) {
@@ -256,19 +236,35 @@ abstract contract MainnetDelegationBase is IMainnetDelegationBase {
         return MainnetDelegationStorage.layout().claimerByDelegator[owner];
     }
 
-    function _setProxyDelegation(address proxyDelegation) internal {
-        MainnetDelegationStorage.layout().proxyDelegation = proxyDelegation;
-    }
-
     function _getProxyDelegation() internal view returns (address) {
         return MainnetDelegationStorage.layout().proxyDelegation;
     }
 
-    function _setMessenger(ICrossDomainMessenger messenger) internal {
-        MainnetDelegationStorage.layout().messenger = messenger;
+    function _getMessenger() internal view returns (address) {
+        return MainnetDelegationStorage.layout().messenger;
     }
 
-    function _getMessenger() internal view returns (ICrossDomainMessenger) {
-        return MainnetDelegationStorage.layout().messenger;
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                            UTILS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _verifyDelegations(bytes calldata encodedMsgs) internal view {
+        MainnetDelegationStorage.Layout storage ds = MainnetDelegationStorage.layout();
+
+        bytes32 digest = keccak256(abi.encode(keccak256(encodedMsgs)));
+        require(digest == ds.delegationDigest);
+    }
+
+    /// @dev equivalent: abi.decode(encodedMsgs, (DelegationMsg[]));
+    function _decodeDelegations(
+        bytes calldata encodedMsgs
+    ) internal pure returns (DelegationMsg[] calldata msgs) {
+        assembly {
+            // this is a dynamic array, so calldataload(encodedMsgs.offset) is the
+            // offset from encodedMsgs.offset at which the array begins
+            let lengthPtr := add(encodedMsgs.offset, calldataload(encodedMsgs.offset))
+            msgs.length := calldataload(lengthPtr)
+            msgs.offset := add(lengthPtr, 0x20)
+        }
     }
 }

--- a/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegationStorage.sol
+++ b/packages/contracts/src/base/registry/facets/mainnet/MainnetDelegationStorage.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-
-import {ICrossDomainMessenger} from "./ICrossDomainMessenger.sol";
 import {IMainnetDelegationBase} from "./IMainnetDelegation.sol";
 
 // libraries
@@ -22,7 +20,7 @@ library MainnetDelegationStorage {
         mapping(address delegator => IMainnetDelegationBase.Delegation delegation) delegationByDelegator;
         mapping(address delegator => address claimer) claimerByDelegator;
         address deprecatedProxyDelegation; // Do not use this, use proxyDelegation
-        ICrossDomainMessenger messenger;
+        address messenger;
         mapping(address claimer => EnumerableSet.AddressSet delegators) delegatorsByAuthorizedClaimer;
         address proxyDelegation;
         EnumerableSet.AddressSet delegators;


### PR DESCRIPTION
### Description

Added events for configuration changes in the `MainnetDelegation` contract to improve transparency and enable better monitoring of contract state updates.

### Changes

- Added `CrossDomainMessengerSet` event that emits when the cross-domain messenger is configured during initialization
- Added `ProxyDelegationSet` event that emits when the proxy delegation address is updated
- Updated `__MainnetDelegation_init_unchained` function to emit `CrossDomainMessengerSet` event
- Updated `setProxyDelegation` function to emit `ProxyDelegationSet` event
- Added import for `MainnetDelegationStorage` to support the event emissions
- Simplified messenger storage to store address directly rather than casting to interface

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
