### PR TITLE
membership renewal cleanup code logic

### DIFF
--- a/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
+++ b/packages/contracts/src/diamond/facets/token/ERC5643/ERC5643Base.sol
@@ -12,26 +12,24 @@ import {ERC5643Storage} from "./ERC5643Storage.sol";
 abstract contract ERC5643Base is IERC5643Base {
     function _renewSubscription(uint256 tokenId, uint64 duration) internal {
         ERC5643Storage.Layout storage ds = ERC5643Storage.layout();
-
         uint64 currentExpiration = ds.expiration[tokenId];
-        uint64 newExpiration;
 
-        if (currentExpiration == 0) {
-            newExpiration = uint64(block.timestamp) + duration;
-        } else if (currentExpiration <= block.timestamp) {
-            if (!_isRenewable(tokenId)) {
-                revert ERC5643__SubscriptionNotRenewable(tokenId);
-            }
-            newExpiration = uint64(block.timestamp) + duration;
-        } else {
-            if (!_isRenewable(tokenId)) {
-                revert ERC5643__SubscriptionNotRenewable(tokenId);
-            }
+        // Check renewability for existing subscriptions
+        if (currentExpiration != 0 && !_isRenewable(tokenId)) {
+            revert ERC5643__SubscriptionNotRenewable(tokenId);
+        }
+
+        // Calculate new expiration
+        uint64 newExpiration;
+        if (currentExpiration > block.timestamp) {
+            // Active subscription: extend from current expiration
             newExpiration = currentExpiration + duration;
+        } else {
+            // New or expired subscription: start from current time
+            newExpiration = uint64(block.timestamp) + duration;
         }
 
         ds.expiration[tokenId] = newExpiration;
-
         emit SubscriptionUpdate(tokenId, newExpiration);
     }
 

--- a/packages/contracts/test/spaces/membership/unit/MembershipDuration.t.sol
+++ b/packages/contracts/test/spaces/membership/unit/MembershipDuration.t.sol
@@ -15,9 +15,6 @@ import {Factory} from "src/utils/libraries/Factory.sol";
 import {CreateSpaceFacet} from "src/factory/facets/create/CreateSpace.sol";
 import {MembershipFacet} from "src/spaces/facets/membership/MembershipFacet.sol";
 
-// debuggging
-import {console} from "forge-std/console.sol";
-
 contract MembershipDurationTest is MembershipBaseSetup {
     uint64 CUSTOM_DURATION = 20 days;
 


### PR DESCRIPTION
### Description

Refactored the ERC5643 subscription renewal logic to improve readability and reduce code duplication. 

The changes simplify the conditional flow while maintaining the same functionality.

### Changes

- Restructured the renewal logic in `_renewSubscription()` to first check renewability for all existing subscriptions
- Simplified the expiration calculation into two clear cases: active subscriptions and new/expired subscriptions
- Removed unnecessary conditional checks and redundant code
- Removed unused console import from the membership duration test file