### PR TITLE
Rename some sync agent models

### DIFF
--- a/packages/react-sdk/src/useReactions.ts
+++ b/packages/react-sdk/src/useReactions.ts
@@ -1,4 +1,4 @@
-import { type ReactionsMap, Space, assert } from '@towns-protocol/sdk'
+import { type ReactionsMapModel, Space, assert } from '@towns-protocol/sdk'
 import { useSyncAgent } from './useSyncAgent'
 import { type ObservableConfig, useObservable } from './useObservable'
 import { getRoom } from './utils'
@@ -11,7 +11,7 @@ import { getRoom } from './utils'
  */
 export const useReactions = (
     streamId: string,
-    config?: ObservableConfig.FromData<ReactionsMap>,
+    config?: ObservableConfig.FromData<ReactionsMapModel>,
 ) => {
     const sync = useSyncAgent()
     const room = getRoom(sync, streamId)

--- a/packages/sdk/src/sync-agent/timeline/models/reactions.ts
+++ b/packages/sdk/src/sync-agent/timeline/models/reactions.ts
@@ -2,9 +2,9 @@ import { Observable } from '../../../observable/observable'
 import { TimelineEvent, RiverTimelineEvent, type MessageReactions } from './timeline-types'
 
 // { parentEventId -> { reactionName: { userId: { eventId: string } } } }
-export type ReactionsMap = Record<string, MessageReactions>
-export class Reactions extends Observable<ReactionsMap> {
-    constructor(initialValue: ReactionsMap = {}) {
+export type ReactionsMapModel = Record<string, MessageReactions>
+export class Reactions extends Observable<ReactionsMapModel> {
+    constructor(initialValue: ReactionsMapModel = {}) {
         super(initialValue)
     }
 
@@ -14,7 +14,7 @@ export class Reactions extends Observable<ReactionsMap> {
         return reactions && Object.keys(reactions).length > 0 ? reactions : undefined
     }
 
-    update(fn: (current: ReactionsMap) => ReactionsMap): void {
+    update(fn: (current: ReactionsMapModel) => ReactionsMapModel): void {
         this.setValue(fn(this.value))
     }
 

--- a/packages/sdk/src/sync-agent/timeline/models/threadStats.ts
+++ b/packages/sdk/src/sync-agent/timeline/models/threadStats.ts
@@ -3,7 +3,7 @@ import { RiverTimelineEvent, TimelineEvent, ThreadStatsData } from './timeline-t
 import { getMessageSenderId, getChannelMessageContent } from './timelineEvent'
 
 // eventId -> threadStats
-export type ThreadStatsMap = Record<string, ThreadStatsData>
+type ThreadStatsMap = Record<string, ThreadStatsData>
 
 // TODO: better name
 export class ThreadStats extends Observable<ThreadStatsMap> {


### PR DESCRIPTION
to avoid conflicts when moving the timeline into river