### PR TITLE
feat: add getClients function to AppAccount

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
@@ -12,7 +12,7 @@ import {AppAccount} from "src/spaces/facets/account/AppAccount.sol";
 
 library DeployAppAccount {
     function selectors() internal pure returns (bytes4[] memory _selectors) {
-        _selectors = new bytes4[](7);
+        _selectors = new bytes4[](8);
         _selectors[0] = AppAccount.execute.selector;
         _selectors[1] = AppAccount.installApp.selector;
         _selectors[2] = AppAccount.uninstallApp.selector;
@@ -20,6 +20,7 @@ library DeployAppAccount {
         _selectors[4] = AppAccount.disableApp.selector;
         _selectors[5] = AppAccount.getInstalledApps.selector;
         _selectors[6] = AppAccount.getAppId.selector;
+        _selectors[7] = AppAccount.getClients.selector;
     }
 
     function makeCut(

--- a/packages/contracts/src/spaces/facets/account/AppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccount.sol
@@ -72,6 +72,11 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
     }
 
     /// @inheritdoc IAppAccount
+    function getClients(address app) external view returns (address[] memory) {
+        return _getClients(app);
+    }
+
+    /// @inheritdoc IAppAccount
     function isAppEntitled(
         address app,
         address publicKey,

--- a/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
@@ -149,6 +149,12 @@ abstract contract AppAccountBase is IAppAccountBase, TokenOwnableBase, ExecutorB
         _setGroupStatus(appId, false);
     }
 
+    function _getClients(address app) internal view returns (address[] memory) {
+        bytes32 appId = _getAppId(app);
+        if (appId == EMPTY_UID) InvalidAppId.selector.revertWith();
+        return _getAppFromAttestation(app, _getAttestation(appId)).clients;
+    }
+
     // Getters
     function _isEntitled(
         address module,

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -72,6 +72,11 @@ interface IAppAccount is IAppAccountBase {
     /// @return The apps installed on the account
     function getInstalledApps() external view returns (address[] memory);
 
+    /// @notice Gets the clients of an app
+    /// @param app The address of the app to get the clients of
+    /// @return The clients of the app
+    function getClients(address app) external view returns (address[] memory);
+
     /// @notice Checks if a client is entitled to a permission for an app
     /// @param app The address of the app to check
     /// @param publicKey The public key to check

--- a/packages/contracts/test/spaces/account/AppAccount.t.sol
+++ b/packages/contracts/test/spaces/account/AppAccount.t.sol
@@ -101,6 +101,10 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase {
 
         assertEq(appAccount.isAppEntitled(address(mockModule), client, keccak256("Read")), true);
         assertEq(appAccount.isAppEntitled(address(mockModule), client, keccak256("Create")), false);
+
+        address[] memory clients = appAccount.getClients(address(mockModule));
+        assertEq(clients.length, 1);
+        assertEq(clients[0], client);
     }
 
     function test_revertWhen_execute_bannedApp() external givenAppIsInstalled {


### PR DESCRIPTION
### Description

Added a new `getClients` function to the AppAccount contract to retrieve the list of clients associated with a specific app.

### Changes

- Added `getClients` function to the `AppAccount` contract that returns all clients for a given app
- Implemented the underlying `_getClients` helper function in `AppAccountBase`
- Added the function selector to the deployment script
- Updated the `IAppAccount` interface with the new function definition
- Added test coverage for the new functionality

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines