### PR TITLE
adding protobuf dependencies to the vscode ~Start Local Dev deps

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,21 @@
   },
   "tasks": [
     {
+      "label": "Dependencies",
+      "dependsOn": [
+        "CheckVersions",
+        "FoundryUp",
+        "YarnInstall",
+        "Install Protobuf Dependencies",
+        "BuildProtobufs",
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "dependsOrder": "sequence"
+    },
+    {
       // start local dev:
       //
       // 1. yarn install
@@ -20,10 +35,7 @@
       // and use the artifacts of the contracts in their builds
       "label": "~Start Local Dev~",
       "dependsOn": [
-        "CheckVersions",
-        "FoundryUp",
-        "YarnInstall",
-        "BuildProtobufs",
+        "Dependencies",
         "Stage 1",
       ],
       // Mark as the default build task so cmd/ctrl+shift+b will create them
@@ -323,6 +335,18 @@
       "label": "BuildContractTypes",
       "type": "shell",
       "command": "./scripts/build-contract-types.sh localhost",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "ephemeral",
+        "focus": true,
+        "panel": "shared",
+      }
+    },
+    {
+      "label": "Install Protobuf Dependencies",
+      "type": "shell",
+      "command": "./scripts/install-protobuf-deps.sh",
       "isBackground": true,
       "problemMatcher": [],
       "presentation": {


### PR DESCRIPTION
### Description

Add "Install Protobuf Dependencies" to the `~ Start Local Dev` task.
Also, pulling other dependency subtasks out of `Stage 1`, into a separate sub-task called "Dependencies" - patten-matching harmony.
