### PR TITLE
Harden joining a stream test code

### DIFF
--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -507,7 +507,9 @@ export async function createSpaceAndDefaultChannel(
 
     const returnVal = await client.createSpace(spaceId)
     expect(returnVal.streamId).toEqual(spaceId)
-    expect(userStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true)
+    await waitFor(() =>
+        expect(userStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true),
+    )
 
     const channelReturnVal = await client.createChannel(
         spaceId,


### PR DESCRIPTION
this was asserting that an event ended up in the user stream, but this could be slow now because of replication