### PR TITLE
Revert "use olm with correct packaging (#3007)"

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -23,8 +23,8 @@
     "dependencies": {
         "@bufbuild/protobuf": "^2.2.2",
         "@ethereumjs/util": "^8.0.1",
+        "@matrix-org/olm": "^3.2.15",
         "@towns-protocol/dlog": "workspace:^",
-        "@towns-protocol/olm": "3.2.28",
         "@towns-protocol/proto": "workspace:^",
         "@towns-protocol/web3": "workspace:^",
         "debug": "^4.3.4",

--- a/packages/encryption/src/encryptionDelegate.ts
+++ b/packages/encryption/src/encryptionDelegate.ts
@@ -1,4 +1,10 @@
-import Olm, { type OlmImpl } from '@towns-protocol/olm'
+// @ts-ignore
+// need to include the olmWasm file for the app/browser. BUT this is probably not what we want to do in the long run
+// Since we are not bundling the csb SDK, just transpiling TS to JS (like in lib), the SDK is not handling this import at all.
+// Actually `?url` is vite specific - which means that the vite bundler in app is handling this import and doing its thing, and our app runs.
+// But, if another app were to import this that didn't bundle via Vite, or if Vite changes something, this may break.
+import olmWasm from '@matrix-org/olm/olm.wasm?url'
+import Olm from '@matrix-org/olm'
 import {
     Account,
     InboundGroupSession,
@@ -9,74 +15,92 @@ import {
     Session,
     Utility,
 } from './encryptionTypes'
+import { isNodeEnv } from '@towns-protocol/dlog'
+
+type OlmLib = typeof Olm
 
 export class EncryptionDelegate {
-    private delegate: OlmImpl | undefined
-    public isInitialized = false
+    private readonly delegate: OlmLib
+    private _initialized = false
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    constructor() {}
+    public get initialized(): boolean {
+        return this._initialized
+    }
+
+    constructor(olmLib?: OlmLib) {
+        if (olmLib == undefined) {
+            this.delegate = Olm
+        } else {
+            this.delegate = olmLib
+        }
+    }
 
     public async init(): Promise<void> {
         // initializes Olm library. This should run before using any Olm classes.
-        if (this.delegate) {
+        if (this._initialized) {
             return
         }
-        this.delegate = await Olm.initAsync()
-        this.isInitialized = this.delegate !== undefined
+
+        if (isNodeEnv) {
+            await this.delegate.init()
+        } else {
+            await this.delegate.init({ locateFile: () => olmWasm as unknown })
+        }
+
+        this._initialized = typeof this.delegate.get_library_version === 'function'
     }
 
     public createAccount(): Account {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.Account()
     }
 
     public createSession(): Session {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.Session()
     }
 
     public createInboundGroupSession(): InboundGroupSession {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.InboundGroupSession()
     }
 
     public createOutboundGroupSession(): OutboundGroupSession {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.OutboundGroupSession()
     }
 
     public createPkEncryption(): PkEncryption {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.PkEncryption()
     }
 
     public createPkDecryption(): PkDecryption {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.PkDecryption()
     }
 
     public createPkSigning(): PkSigning {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.PkSigning()
     }
 
     public createUtility(): Utility {
-        if (!this.delegate) {
+        if (!this._initialized) {
             throw new Error('olm not initialized')
         }
         return new this.delegate.Utility()

--- a/packages/encryption/src/encryptionDevice.ts
+++ b/packages/encryption/src/encryptionDevice.ts
@@ -133,8 +133,7 @@ export class EncryptionDevice {
     public async init(opts?: EncryptionDeviceInitOpts): Promise<void> {
         const { fromExportedDevice, pickleKey } = opts ?? {}
         let e2eKeys
-        if (!this.delegate.isInitialized) {
-            this.delegate = new EncryptionDelegate()
+        if (!this.delegate.initialized) {
             await this.delegate.init()
         }
         const account = this.delegate.createAccount()

--- a/packages/encryption/src/encryptionTypes.ts
+++ b/packages/encryption/src/encryptionTypes.ts
@@ -7,7 +7,7 @@ import {
     PkSigning as OlmPkSigning,
     Session as OlmSession,
     Utility as OlmUtility,
-} from '@towns-protocol/olm'
+} from '@matrix-org/olm'
 
 import { EncryptedData } from '@towns-protocol/proto'
 

--- a/packages/encryption/src/groupDecryption.ts
+++ b/packages/encryption/src/groupDecryption.ts
@@ -5,7 +5,7 @@ import { GroupEncryptionAlgorithmId, GroupEncryptionSession } from './olmLib'
 import { EncryptedData, EncryptedDataVersion } from '@towns-protocol/proto'
 import { bin_fromBase64, dlogError } from '@towns-protocol/dlog'
 import { LRUCache } from 'lru-cache'
-import type { InboundGroupSession } from './encryptionTypes'
+import { InboundGroupSession } from '@matrix-org/olm'
 
 const logError = dlogError('csb:encryption:groupDecryption')
 

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,16 +1,11 @@
 import react from '@vitejs/plugin-react'
-import { defineConfig, loadEnv, searchForWorkspaceRoot } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { default as checker } from 'vite-plugin-checker'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { replaceCodePlugin } from 'vite-plugin-replace'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import wasm from 'vite-plugin-wasm'
 import path from 'path'
-
-// The encryption WASM module is imported dynamically.
-// Since it's common for developers to use a linked copy of @towns-protocol/vodozemac (which could reside anywhere on their file system),
-// Vite needs to be told to recognize it as a legitimate file access.
-const allow = [searchForWorkspaceRoot(process.cwd()), 'node_modules/@towns-protocol/olm']
 
 // https://vitejs.dev/config/
 export default ({ mode }: { mode: string }) => {
@@ -55,18 +50,9 @@ exports.randomFillSync = randomFillSync`,
         },
         server: {
             port: 3100,
-            fs: {
-                allow,
-            },
         },
         build: {
             target: 'esnext',
-            rollupOptions: {
-                external: ['@towns-protocol/olm'],
-            },
-        },
-        optimizeDeps: {
-            exclude: ['@towns-protocol/olm'],
         },
     })
 }

--- a/packages/stream-metadata/esbuild.config.mjs
+++ b/packages/stream-metadata/esbuild.config.mjs
@@ -15,7 +15,6 @@ build({
 	external: [
 		// esbuild cannot bundle native modules
 		'@datadog/native-metrics',
-		'@towns-protocol/olm',
 
 		// required if you use profiling
 		'@datadog/pprof',

--- a/packages/stress/esbuild.config.mjs
+++ b/packages/stress/esbuild.config.mjs
@@ -15,7 +15,6 @@ build({
     outdir: 'dist',
     outExtension: { '.js': '.cjs' },
     plugins: [esbuildPluginPino({ transports: ['pino-pretty'] })],
-    external: ['@towns-protocol/olm'],
     ignoreAnnotations: true,
     assetNames: '[name]',
     loader: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4302,6 +4302,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@matrix-org/olm@npm:^3.2.15":
+  version: 3.2.15
+  resolution: "@matrix-org/olm@npm:3.2.15"
+  checksum: 1548d2d72db08e53056425b92bcf5a02d5fa5917dc34d519c6d89c4f80a31f4c36da11d957e9b55302d34595f67cac50efd4b6ff725de1dd448c645a42589f74
+  languageName: node
+  linkType: hard
+
 "@mdx-js/mdx@npm:^2.1.5, @mdx-js/mdx@npm:^2.2.1":
   version: 2.3.0
   resolution: "@mdx-js/mdx@npm:2.3.0"
@@ -8502,8 +8509,8 @@ __metadata:
   dependencies:
     "@bufbuild/protobuf": ^2.2.2
     "@ethereumjs/util": ^8.0.1
+    "@matrix-org/olm": ^3.2.15
     "@towns-protocol/dlog": "workspace:^"
-    "@towns-protocol/olm": 3.2.28
     "@towns-protocol/proto": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
     "@types/lodash": ^4.14.186
@@ -8555,13 +8562,6 @@ __metadata:
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
-
-"@towns-protocol/olm@npm:3.2.28":
-  version: 3.2.28
-  resolution: "@towns-protocol/olm@npm:3.2.28"
-  checksum: 1ae8009b32b17e8bb88fedc0400d6dc1919e839513f0d233191de52b171bf20e868c4ea500902c86e007e3b3d02bf09931cd432885a9c6edad2a0ca2409de40c
-  languageName: node
-  linkType: hard
 
 "@towns-protocol/playground@workspace:packages/playground":
   version: 0.0.0-use.local


### PR DESCRIPTION
After doing pull_river.sh, I found that two tests wasn't passing. (https://github.com/HereNotThere/harmony/actions/runs/15354805793/job/43212662594?pr=9806)

I'm reverting so ppl can run pull_river.sh freely in harmony. I also need to recheck if we need to apply the changes from `vite.config.ts` into `vitest.config.ts` too.
