### PR TITLE
Add waitFor around all expected user content membership checks in tests

### DIFF
--- a/packages/sdk/src/tests/multi/withEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/withEntitlements.test.ts
@@ -105,7 +105,9 @@ describe('withEntitlements', () => {
         const bobUserStreamView = bob.stream(bobsUserStreamId)!.view
         expect(bobUserStreamView).toBeDefined()
         await waitFor(() =>
-            expect(bobUserStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true),
+            expect(bobUserStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(
+                true,
+            ),
         )
 
         const waitForStreamPromise = makeDonePromise()

--- a/packages/sdk/src/tests/multi/withEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/withEntitlements.test.ts
@@ -9,6 +9,7 @@ import {
     makeDonePromise,
     createVersionedSpace,
     getFreeSpacePricingSetup,
+    waitFor,
 } from '../testUtils'
 import {
     isValidStreamId,
@@ -103,7 +104,9 @@ describe('withEntitlements', () => {
         // Now there must be "joined space" event in the user stream.
         const bobUserStreamView = bob.stream(bobsUserStreamId)!.view
         expect(bobUserStreamView).toBeDefined()
-        expect(bobUserStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true)
+        await waitFor(() =>
+            expect(bobUserStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true),
+        )
 
         const waitForStreamPromise = makeDonePromise()
         bob.on('userJoinedStream', (streamId) => {
@@ -126,7 +129,11 @@ describe('withEntitlements', () => {
         await waitForStreamPromise.expectToSucceed()
         // Now there must be "joined channel" event in the user stream.
         expect(bobUserStreamView).toBeDefined()
-        expect(bobUserStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true)
+        await waitFor(() =>
+            expect(bobUserStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(
+                true,
+            ),
+        )
 
         // todo  getDevicesInRoom is randomly failing in ci renable https://linear.app/hnt-labs/issue/HNT-3439/getdevicesinroom-is-randomly-failing-in-ci
         // await expect(bob.sendMessage(channelId, 'Hello, world from Bob!')).resolves.not.toThrow()

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -518,7 +518,9 @@ export async function createSpaceAndDefaultChannel(
         channelId,
     )
     expect(channelReturnVal.streamId).toEqual(channelId)
-    expect(userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true)
+    await waitFor(() =>
+        expect(userStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(true),
+    )
 
     return {
         spaceId,


### PR DESCRIPTION
to help with flaky tests. kinda surprised this wasn't a problem before