### PR TITLE
Fix equality test in syncedStream.test.ts

### DIFF
--- a/packages/sdk/src/tests/multi_ne/syncedStream.test.ts
+++ b/packages/sdk/src/tests/multi_ne/syncedStream.test.ts
@@ -67,7 +67,7 @@ describe('syncedStream', () => {
         // check that the events are the same
         const aliceEvents = aliceStream.view.timeline.map((e) => e.hashStr)
         const bobEvents = bobStreamFresh.view.timeline.map((e) => e.hashStr)
-        await waitFor(() => aliceEvents.sort() === bobEvents.sort())
+        await waitFor(() => expect(aliceEvents.sort()).toStrictEqual(bobEvents.sort()))
 
         const bobEventCount = bobEvents.length
         // Alice sends another 5 messages


### PR DESCRIPTION
this was just wrong, wait for was just returning after 10 seconds because these references are never equal