### PR TITLE
fix: stream metadata dockerbuild

### DIFF
--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -40,10 +40,13 @@ RUN yarn run turbo build --filter @towns-protocol/stream-metadata
 FROM node:lts-alpine3.20 as runner
 COPY --from=builder /river/packages/stream-metadata/dist /river/packages/stream-metadata/dist
 
-# install dd-trace again (because the bundler excludes some of the sub-dependencies)
+# install external dependencies that were excluded from the bundle
 WORKDIR /river/packages/stream-metadata
 RUN yarn init --yes
-RUN yarn add dd-trace@^5.19.0
+# We need to install @towns-protocol/olm here because esbuild
+# isnt smart enough to read the export field in package json
+# and get the node specific import in the bundle step
+RUN yarn add dd-trace@^5.19.0 @towns-protocol/olm@3.2.28
 
 # run the service
 ARG GIT_SHA


### PR DESCRIPTION
So stream-metadata build failed to deploy because we're not pushing `node_modules` in the Dockerfile.

I copy pasted the same approach that we're using to `dd-trace`. Adding it into node_modules in the Dockerfile.

We need to mark `@towns-protocol/olm` as external since esbuild doesn't seem to respect the `"node"` export in `@towns-protocol/olm` package.json exports  


I'll try to think and investigate other possible solutions.. Maybe [rolldown](https://rolldown.rs/) respects the `"node"` export? 