### PR TITLE
refactor: move app installation logic from AppAccount to AppRegistry

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployAppAccount.s.sol
@@ -12,7 +12,7 @@ import {AppAccount} from "src/spaces/facets/account/AppAccount.sol";
 
 library DeployAppAccount {
     function selectors() internal pure returns (bytes4[] memory _selectors) {
-        _selectors = new bytes4[](10);
+        _selectors = new bytes4[](9);
         _selectors[0] = AppAccount.execute.selector;
         _selectors[1] = AppAccount.installApp.selector;
         _selectors[2] = AppAccount.uninstallApp.selector;
@@ -21,8 +21,7 @@ library DeployAppAccount {
         _selectors[5] = AppAccount.getInstalledApps.selector;
         _selectors[6] = AppAccount.getAppId.selector;
         _selectors[7] = AppAccount.getAppClients.selector;
-        _selectors[8] = AppAccount.getAppPrice.selector;
-        _selectors[9] = AppAccount.enableApp.selector;
+        _selectors[8] = AppAccount.enableApp.selector;
     }
 
     function makeCut(

--- a/packages/contracts/scripts/deployments/facets/DeployAppRegistryFacet.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployAppRegistryFacet.s.sol
@@ -16,14 +16,17 @@ library DeployAppRegistryFacet {
     using DynamicArrayLib for DynamicArrayLib.DynamicArray;
 
     function selectors() internal pure returns (bytes4[] memory res) {
-        DynamicArrayLib.DynamicArray memory arr = DynamicArrayLib.p().reserve(10);
+        DynamicArrayLib.DynamicArray memory arr = DynamicArrayLib.p().reserve(13);
         arr.p(AppRegistryFacet.getAppSchema.selector);
         arr.p(AppRegistryFacet.getAppSchemaId.selector);
-        arr.p(AppRegistryFacet.getAttestation.selector);
+        arr.p(AppRegistryFacet.getAppById.selector);
         arr.p(AppRegistryFacet.getLatestAppId.selector);
         arr.p(AppRegistryFacet.registerApp.selector);
         arr.p(AppRegistryFacet.removeApp.selector);
         arr.p(AppRegistryFacet.createApp.selector);
+        arr.p(AppRegistryFacet.installApp.selector);
+        arr.p(AppRegistryFacet.uninstallApp.selector);
+        arr.p(AppRegistryFacet.getAppPrice.selector);
         arr.p(AppRegistryFacet.adminRegisterAppSchema.selector);
         arr.p(AppRegistryFacet.adminBanApp.selector);
         arr.p(AppRegistryFacet.isAppBanned.selector);

--- a/packages/contracts/src/apps/facets/registry/AppRegistryFacet.sol
+++ b/packages/contracts/src/apps/facets/registry/AppRegistryFacet.sol
@@ -77,6 +77,28 @@ contract AppRegistryFacet is IAppRegistry, AppRegistryBase, OwnableBase, Reentra
         return _createApp(params);
     }
 
+    /// @notice Install an app
+    /// @param app The app address to install
+    /// @param account The account to install the app to
+    /// @param data The data to pass to the app's onInstall function
+    function installApp(
+        address app,
+        address account,
+        bytes calldata data
+    ) external payable nonReentrant {
+        _onlyAllowed(account);
+        return _installApp(app, account, data);
+    }
+
+    /// @notice Uninstall an app
+    /// @param app The app address to uninstall
+    /// @param account The account to uninstall the app from
+    /// @param data The data to pass to the app's onUninstall function
+    function uninstallApp(address app, address account, bytes calldata data) external nonReentrant {
+        _onlyAllowed(account);
+        return _uninstallApp(app, account, data);
+    }
+
     /// @notice Get the schema structure used for registering modules
     /// @return The schema structure
     function getAppSchema() external view returns (string memory) {
@@ -91,9 +113,16 @@ contract AppRegistryFacet is IAppRegistry, AppRegistryBase, OwnableBase, Reentra
 
     /// @notice Get the attestation for a app
     /// @param appId The app ID
-    /// @return attestation The attestation
-    function getAttestation(bytes32 appId) external view returns (Attestation memory attestation) {
-        return _getApp(appId);
+    /// @return app The app
+    function getAppById(bytes32 appId) external view returns (App memory app) {
+        return _getAppById(appId);
+    }
+
+    /// @notice Get the total price of an app
+    /// @param app The app address
+    /// @return price The price of the app with protocol fee
+    function getAppPrice(address app) external view returns (uint256 price) {
+        return _getAppPrice(app);
     }
 
     /// @notice Get the latest version ID for a app

--- a/packages/contracts/src/spaces/facets/account/AppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccount.sol
@@ -36,12 +36,15 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @inheritdoc IAppAccount
-    function installApp(
-        address app,
-        bytes calldata data,
-        AppParams calldata params
-    ) external payable nonReentrant onlyOwner {
-        _installApp(app, params.delays, data);
+    function installApp(bytes32 appId, bytes calldata data) external nonReentrant {
+        _onlyRegistry(msg.sender);
+        _installApp(appId, data);
+    }
+
+    /// @inheritdoc IAppAccount
+    function uninstallApp(bytes32 appId, bytes calldata data) external {
+        _onlyRegistry(msg.sender);
+        _uninstallApp(appId, data);
     }
 
     /// @inheritdoc IAppAccount
@@ -55,28 +58,18 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
     }
 
     /// @inheritdoc IAppAccount
-    function uninstallApp(address app, bytes calldata data) external onlyOwner {
-        _uninstallApp(app, data);
-    }
-
-    /// @inheritdoc IAppAccount
     function getInstalledApps() external view returns (address[] memory) {
         return _getApps();
     }
 
     /// @inheritdoc IAppAccount
     function getAppId(address app) external view returns (bytes32) {
-        return _getAppId(app);
+        return _getInstalledAppId(app);
     }
 
     /// @inheritdoc IAppAccount
     function getAppClients(address app) external view returns (address[] memory) {
         return _getClients(app);
-    }
-
-    /// @inheritdoc IAppAccount
-    function getAppPrice(address app) external view returns (uint256) {
-        return _getTotalRequiredPayment(app);
     }
 
     /// @inheritdoc IAppAccount

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -1,67 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-
 // interfaces
 
 // libraries
 
 // contracts
 interface IAppAccountBase {
-    struct App {
-        bytes32 appId;
-        address module;
-        address owner;
-        address[] clients;
-        bytes32[] permissions;
-        ExecutionManifest manifest;
-        uint256 installPrice;
-        uint64 accessDuration;
-    }
-
-    /// @notice Params for installing an app
-    /// @param delays The delays for the app
-    struct AppParams {
-        Delays delays;
-    }
-
-    /// @notice Delays for the app
-    /// @param grantDelay The delay before the app can be granted access to the group
-    /// @param executionDelay The delay before the app can execute a transaction
-    struct Delays {
-        uint32 grantDelay;
-        uint32 executionDelay;
-    }
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           ERRORS                           */
-    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-    error UnauthorizedApp(address app);
     error InvalidAppAddress(address app);
     error InvalidManifest(address app);
     error UnauthorizedSelector();
     error NotEnoughEth();
     error AppAlreadyInstalled();
-    error InvalidAppId();
-    error AppNotInstalled();
-    error AppNotRegistered();
-    error AppRevoked();
-    error InsufficientPayment();
-    error InvalidOwner();
-    error InvalidRecipient();
+    error UnauthorizedApp(address app);
+    error InvalidCaller();
 }
 
 interface IAppAccount is IAppAccountBase {
-    /// @notice Installs an app with the given parameters
-    /// @param app The address of the app to install
+    /// @notice Installs an app
+    /// @param appId The ID of the app to install
     /// @param data The initialization data for the app
-    /// @param params The parameters for the app installation including delays
-    function installApp(
-        address app,
-        bytes calldata data,
-        AppParams calldata params
-    ) external payable;
+    function installApp(bytes32 appId, bytes calldata data) external;
 
     /// @notice Enables an app
     /// @param app The address of the app to enable
@@ -72,9 +31,9 @@ interface IAppAccount is IAppAccountBase {
     function disableApp(address app) external;
 
     /// @notice Uninstalls an app
-    /// @param app The address of the app to uninstall
+    /// @param appId The ID of the app to uninstall
     /// @param data The data required for app uninstallation
-    function uninstallApp(address app, bytes calldata data) external;
+    function uninstallApp(bytes32 appId, bytes calldata data) external;
 
     /// @notice Gets the ID of an app
     /// @param app The address of the app to get the ID of
@@ -89,11 +48,6 @@ interface IAppAccount is IAppAccountBase {
     /// @param app The address of the app to get the clients of
     /// @return The clients of the app
     function getAppClients(address app) external view returns (address[] memory);
-
-    /// @notice Gets the price of an app
-    /// @param app The address of the app to get the price of
-    /// @return The price of the app
-    function getAppPrice(address app) external view returns (uint256);
 
     /// @notice Checks if a client is entitled to a permission for an app
     /// @param app The address of the app to check

--- a/packages/contracts/test/attest/AppRegistry.t.sol
+++ b/packages/contracts/test/attest/AppRegistry.t.sol
@@ -9,9 +9,13 @@ import {ISchemaResolver} from "@ethereum-attestation-service/eas-contracts/resol
 import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {IAppRegistryBase} from "src/apps/facets/registry/IAppRegistry.sol";
 import {IAttestationRegistryBase} from "src/apps/facets/attest/IAttestationRegistry.sol";
+import {IERC6900Account} from "@erc6900/reference-implementation/interfaces/IERC6900Account.sol";
+import {IPlatformRequirements} from "src/factory/facets/platform/requirements/IPlatformRequirements.sol";
 
 //libraries
 import {Attestation} from "@ethereum-attestation-service/eas-contracts/Common.sol";
+import {BasisPoints} from "src/utils/libraries/BasisPoints.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 // types
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
@@ -19,44 +23,69 @@ import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IE
 //contracts
 import {AppRegistryFacet} from "src/apps/facets/registry/AppRegistryFacet.sol";
 import {MockPlugin} from "test/mocks/MockPlugin.sol";
+import {AppAccount} from "src/spaces/facets/account/AppAccount.sol";
+import {MockModule} from "test/mocks/MockModule.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBase {
-    address internal developer;
-
-    AppRegistryFacet internal facet;
+    AppRegistryFacet internal registry;
+    AppAccount internal appAccount;
+    MockModule internal mockModule;
 
     uint256 private DEFAULT_INSTALL_PRICE = 0.001 ether;
     uint64 private DEFAULT_ACCESS_DURATION = 365 days;
+    address private DEFAULT_CLIENT;
+    address private DEFAULT_DEV;
+    bytes32 private DEFAULT_APP_ID;
 
     function setUp() public override {
         super.setUp();
-        facet = AppRegistryFacet(appRegistry);
+        registry = AppRegistryFacet(appRegistry);
+        appAccount = AppAccount(everyoneSpace);
+
+        DEFAULT_CLIENT = _randomAddress();
+        DEFAULT_DEV = _randomAddress();
+
+        MockModule mockModuleV1 = new MockModule();
+
+        vm.prank(DEFAULT_DEV);
+        mockModule = MockModule(
+            address(
+                new ERC1967Proxy(
+                    address(mockModuleV1),
+                    abi.encodeWithSelector(MockModule.initialize.selector, false, false, false, 0)
+                )
+            )
+        );
     }
 
-    // ==================== SCHEMA TESTS ====================
+    modifier givenAppIsRegistered() {
+        address[] memory clients = new address[](1);
+        clients[0] = DEFAULT_CLIENT;
+
+        vm.prank(DEFAULT_DEV);
+        DEFAULT_APP_ID = registry.registerApp(address(mockModule), clients);
+        _;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SCHEMA TESTS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function test_getAppSchema() external view {
-        string memory schema = facet.getAppSchema();
+        string memory schema = registry.getAppSchema();
         assertEq(
             schema,
             "address app, address owner, address[] clients, bytes32[] permissions, ExecutionManifest manifest"
         );
     }
 
-    // ==================== MODULE REGISTRATION TESTS ====================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   MODULE REGISTRATION TESTS                */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    function test_registerApp() external {
-        address owner = _randomAddress();
-
-        vm.prank(owner);
-        address app = address(new MockPlugin(owner));
-
-        address[] memory clients = new address[](1);
-        clients[0] = _randomAddress();
-
-        vm.prank(owner);
-        bytes32 uid = facet.registerApp(app, clients);
-        assertEq(uid, facet.getLatestAppId(app));
+    function test_registerApp() external givenAppIsRegistered {
+        assertEq(DEFAULT_APP_ID, registry.getLatestAppId(address(mockModule)));
     }
 
     function test_revertWhen_registerApp_EmptyApp() external {
@@ -68,7 +97,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         // App address cannot be zero
         vm.prank(owner);
         vm.expectRevert(InvalidAddressInput.selector);
-        facet.registerApp(address(0), clients);
+        registry.registerApp(address(0), clients);
     }
 
     function test_revertWhen_registerApp_EmptyClients() external {
@@ -80,10 +109,12 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         // Client list cannot be empty
         vm.prank(owner);
         vm.expectRevert(InvalidArrayInput.selector);
-        facet.registerApp(app, clients);
+        registry.registerApp(app, clients);
     }
 
-    // ==================== MODULE INFORMATION TESTS ====================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   MODULE INFORMATION TESTS                 */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function test_getAppClients() external {
         address owner = _randomAddress();
@@ -96,19 +127,18 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         clients[1] = _randomAddress();
 
         vm.prank(owner);
-        bytes32 appId = facet.registerApp(app, clients);
+        bytes32 appId = registry.registerApp(app, clients);
 
-        Attestation memory att = facet.getAttestation(appId);
-        (, , address[] memory retrievedClients, , ) = abi.decode(
-            att.data,
-            (address, address, address[], bytes32[], ExecutionManifest)
-        );
+        App memory appInfo = registry.getAppById(appId);
+        address[] memory retrievedClients = appInfo.clients;
         assertEq(retrievedClients.length, clients.length);
         assertEq(retrievedClients[0], clients[0]);
         assertEq(retrievedClients[1], clients[1]);
     }
 
-    // ==================== MODULE REVOCATION TESTS ====================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   MODULE REVOCATION TESTS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function test_removeApp() external {
         address owner = _randomAddress();
@@ -120,10 +150,10 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         clients[0] = _randomAddress();
 
         vm.prank(owner);
-        bytes32 appId = facet.registerApp(app, clients);
+        bytes32 appId = registry.registerApp(app, clients);
 
         vm.prank(owner);
-        bytes32 revokedUid = facet.removeApp(appId);
+        bytes32 revokedUid = registry.removeApp(appId);
 
         assertEq(revokedUid, appId);
     }
@@ -139,17 +169,17 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         clients[0] = _randomAddress();
 
         vm.prank(owner);
-        bytes32 appId = facet.registerApp(app, clients);
+        bytes32 appId = registry.registerApp(app, clients);
 
         vm.prank(notOwner);
         vm.expectRevert(InvalidRevoker.selector);
-        facet.removeApp(appId);
+        registry.removeApp(appId);
     }
 
     function test_revertWhen_removeApp_AppNotRegistered() external {
         bytes32 appId = bytes32(0);
         vm.expectRevert(InvalidAppId.selector);
-        facet.removeApp(appId);
+        registry.removeApp(appId);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -177,15 +207,12 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         });
 
         vm.prank(owner);
-        (address app, bytes32 appId) = facet.createApp(appData);
+        (address app, bytes32 appId) = registry.createApp(appData);
 
-        Attestation memory att = facet.getAttestation(appId);
-        (address module, , , , ) = abi.decode(
-            att.data,
-            (address, address, address[], bytes32[], ExecutionManifest)
-        );
+        App memory appInfo = registry.getAppById(appId);
+        address module = appInfo.module;
 
-        assertEq(appId, facet.getLatestAppId(app));
+        assertEq(appId, registry.getLatestAppId(app));
         assertEq(module, app);
     }
 
@@ -204,7 +231,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         });
         vm.prank(owner);
         vm.expectRevert(InvalidAppName.selector);
-        facet.createApp(appData);
+        registry.createApp(appData);
     }
 
     function test_revertWhen_createApp_EmptyPermissions() external {
@@ -221,7 +248,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         });
         vm.prank(owner);
         vm.expectRevert(InvalidArrayInput.selector);
-        facet.createApp(appData);
+        registry.createApp(appData);
     }
 
     function test_revertWhen_createApp_EmptyClients() external {
@@ -238,7 +265,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         });
         vm.prank(owner);
         vm.expectRevert(InvalidArrayInput.selector);
-        facet.createApp(appData);
+        registry.createApp(appData);
     }
 
     function test_revertWhen_createApp_ZeroAddressClient() external {
@@ -257,23 +284,230 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         });
         vm.prank(owner);
         vm.expectRevert(InvalidAddressInput.selector);
-        facet.createApp(appData);
+        registry.createApp(appData);
     }
 
-    // ==================== ADMIN FUNCTIONS TESTS ====================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      INSTALL APP TESTS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function test_installApp() external givenAppIsRegistered {
+        App memory appInfo = registry.getAppById(DEFAULT_APP_ID);
+
+        uint256 totalRequired = registry.getAppPrice(address(mockModule));
+
+        vm.deal(founder, totalRequired);
+
+        vm.prank(founder);
+        vm.expectEmit(address(appAccount));
+        emit IERC6900Account.ExecutionInstalled(address(mockModule), appInfo.manifest);
+        registry.installApp{value: totalRequired}(address(mockModule), address(appAccount), "");
+    }
+
+    function test_revertWhen_installApp_notAllowed() external givenAppIsRegistered {
+        vm.prank(_randomAddress());
+        vm.expectRevert(NotAllowed.selector);
+        registry.installApp(address(mockModule), address(appAccount), "");
+    }
+
+    function test_revertWhen_installApp_appNotRegistered() external {
+        vm.expectRevert(AppNotRegistered.selector);
+        vm.prank(founder);
+        registry.installApp(address(mockModule), address(appAccount), "");
+    }
+
+    function test_revertWhen_installApp_insufficientPayment() external givenAppIsRegistered {
+        uint256 price = 1 ether;
+        _setupAppWithPrice(price);
+
+        uint256 requiredAmount = registry.getAppPrice(address(mockModule));
+        uint256 insufficientAmount = requiredAmount - 1;
+
+        hoax(founder, insufficientAmount);
+        vm.expectRevert(InsufficientPayment.selector);
+        registry.installApp{value: insufficientAmount}(
+            address(mockModule),
+            address(appAccount),
+            ""
+        );
+    }
+
+    function test_installApp_withFreeApp() external givenAppIsRegistered {
+        _setupAppWithPrice(0);
+
+        uint256 requiredAmount = registry.getAppPrice(address(mockModule));
+
+        vm.expectEmit(address(appAccount));
+        emit IERC6900Account.ExecutionInstalled(
+            address(mockModule),
+            mockModule.executionManifest()
+        );
+        hoax(founder, requiredAmount);
+        registry.installApp{value: requiredAmount}(address(mockModule), address(appAccount), "");
+
+        uint256 protocolFee = _getProtocolFee(0);
+
+        // Verify protocol fee was paid
+        assertEq(address(deployer).balance, protocolFee);
+    }
+
+    function test_installApp_withPaidApp() external givenAppIsRegistered {
+        uint256 price = 1 ether;
+        _setupAppWithPrice(price);
+
+        uint256 protocolFee = _getProtocolFee(price);
+        uint256 devInitialBalance = address(DEFAULT_DEV).balance;
+
+        uint256 totalPrice = registry.getAppPrice(address(mockModule));
+
+        vm.expectEmit(address(appAccount));
+        emit IERC6900Account.ExecutionInstalled(
+            address(mockModule),
+            mockModule.executionManifest()
+        );
+        hoax(founder, totalPrice);
+        registry.installApp{value: totalPrice}(address(mockModule), address(appAccount), "");
+
+        // Verify fee distribution
+        assertEq(address(deployer).balance, protocolFee);
+        assertEq(address(DEFAULT_DEV).balance - devInitialBalance, totalPrice - protocolFee);
+        assertEq(address(appAccount).balance, 0);
+    }
+
+    function test_installApp_whenProtocolFeeEqualsPrice() external givenAppIsRegistered {
+        // Get minimum protocol fee
+        uint256 minFee = IPlatformRequirements(spaceFactory).getMembershipFee();
+        _setupAppWithPrice(minFee);
+
+        uint256 devInitialBalance = address(DEFAULT_DEV).balance;
+
+        uint256 totalPrice = registry.getAppPrice(address(mockModule));
+
+        vm.expectEmit(address(appAccount));
+        emit IERC6900Account.ExecutionInstalled(
+            address(mockModule),
+            mockModule.executionManifest()
+        );
+
+        hoax(founder, totalPrice);
+        registry.installApp{value: totalPrice}(address(mockModule), address(appAccount), "");
+
+        assertEq(address(deployer).balance, minFee);
+        assertEq(address(DEFAULT_DEV).balance - devInitialBalance, totalPrice - minFee);
+        assertEq(address(appAccount).balance, 0);
+    }
+
+    function test_installApp_whenBpsHigherThanMinFee() external givenAppIsRegistered {
+        uint256 price = 100 ether;
+        _setupAppWithPrice(price);
+
+        uint256 protocolFee = _getProtocolFee(price);
+        uint256 minFee = IPlatformRequirements(spaceFactory).getMembershipFee();
+        uint256 devInitialBalance = address(DEFAULT_DEV).balance;
+
+        uint256 totalPrice = registry.getAppPrice(address(mockModule));
+
+        hoax(founder, totalPrice);
+        registry.installApp{value: totalPrice}(address(mockModule), address(appAccount), "");
+
+        assertEq(address(deployer).balance, protocolFee);
+        assertTrue(protocolFee > minFee);
+        assertEq(address(DEFAULT_DEV).balance - devInitialBalance, totalPrice - protocolFee);
+        assertEq(address(appAccount).balance, 0);
+    }
+
+    function test_installApp_whenBpsLowerThanMinFee() external givenAppIsRegistered {
+        uint256 price = 0.01 ether;
+        _setupAppWithPrice(price);
+
+        uint256 protocolFee = _getProtocolFee(price);
+        uint256 minFee = IPlatformRequirements(spaceFactory).getMembershipFee();
+        uint256 bpsFee = BasisPoints.calculate(
+            price,
+            IPlatformRequirements(spaceFactory).getMembershipBps()
+        );
+        uint256 devInitialBalance = address(DEFAULT_DEV).balance;
+
+        uint256 totalPrice = registry.getAppPrice(address(mockModule));
+
+        hoax(founder, totalPrice);
+        registry.installApp{value: totalPrice}(address(mockModule), address(appAccount), "");
+
+        assertEq(address(deployer).balance, protocolFee);
+        assertTrue(bpsFee < minFee);
+        assertEq(protocolFee, minFee);
+        assertEq(address(DEFAULT_DEV).balance - devInitialBalance, totalPrice - protocolFee);
+        assertEq(address(appAccount).balance, 0);
+    }
+
+    function test_installApp_withExcessPayment() external givenAppIsRegistered {
+        uint256 price = 1 ether;
+        _setupAppWithPrice(price);
+
+        uint256 totalPrice = registry.getAppPrice(address(mockModule));
+        uint256 protocolFee = _getProtocolFee(price);
+        uint256 devInitialBalance = address(DEFAULT_DEV).balance;
+
+        uint256 excess = 0.5 ether;
+        uint256 payment = totalPrice + excess;
+        uint256 founderInitialBalance = address(founder).balance;
+
+        hoax(founder, payment);
+        registry.installApp{value: payment}(address(mockModule), address(appAccount), "");
+
+        // Verify excess was refunded
+        assertEq(address(founder).balance - founderInitialBalance, excess);
+        assertEq(address(DEFAULT_DEV).balance - devInitialBalance, totalPrice - protocolFee);
+        assertEq(address(appAccount).balance, 0);
+    }
+
+    function test_revertWhen_installApp_appRevoked() external givenAppIsRegistered {
+        uint256 price = registry.getAppPrice(address(mockModule));
+
+        vm.prank(DEFAULT_DEV);
+        registry.removeApp(DEFAULT_APP_ID);
+
+        hoax(founder, price);
+        vm.expectRevert(AppRevoked.selector);
+        registry.installApp{value: price}(address(mockModule), address(appAccount), "");
+    }
+
+    function test_revertWhen_uninstallApp_notAllowed() external givenAppIsRegistered {
+        vm.prank(_randomAddress());
+        vm.expectRevert(NotAllowed.selector);
+        registry.uninstallApp(address(mockModule), address(appAccount), "");
+    }
+
+    function test_revertWhen_uninstallApp_appNotRegistered() external {
+        vm.prank(founder);
+        vm.expectRevert(AppNotRegistered.selector);
+        registry.uninstallApp(address(mockModule), address(appAccount), "");
+    }
+
+    function test_getAppById_getRevokedApp() external givenAppIsRegistered {
+        vm.prank(DEFAULT_DEV);
+        registry.removeApp(DEFAULT_APP_ID);
+
+        App memory app = registry.getAppById(DEFAULT_APP_ID);
+        assertEq(app.appId, DEFAULT_APP_ID);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         ADMIN TESTS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function test_adminRegisterAppSchema() external {
         string memory newSchema = "address app, bytes32 newSchema";
 
         vm.startPrank(deployer);
-        bytes32 newSchemaId = facet.adminRegisterAppSchema(
+        bytes32 newSchemaId = registry.adminRegisterAppSchema(
             newSchema,
             ISchemaResolver(address(0)),
             true
         );
         vm.stopPrank();
 
-        assertEq(facet.getAppSchemaId(), newSchemaId);
+        assertEq(registry.getAppSchemaId(), newSchemaId);
     }
 
     function test_adminBanApp() external {
@@ -286,13 +520,13 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         clients[0] = _randomAddress();
 
         vm.prank(owner);
-        bytes32 appId = facet.registerApp(app, clients);
+        bytes32 appId = registry.registerApp(app, clients);
 
         vm.prank(deployer);
-        bytes32 bannedUid = facet.adminBanApp(app);
+        bytes32 bannedUid = registry.adminBanApp(app);
 
         assertEq(bannedUid, appId);
-        assertEq(facet.getLatestAppId(app), bytes32(0));
+        assertEq(registry.getLatestAppId(app), bytes32(0));
     }
 
     function test_adminBanApp_onlyOwner() external {
@@ -301,7 +535,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
 
         vm.prank(notOwner);
         vm.expectRevert(abi.encodeWithSelector(IOwnableBase.Ownable__NotOwner.selector, notOwner));
-        facet.adminBanApp(app);
+        registry.adminBanApp(app);
     }
 
     function test_revertWhen_adminBanApp_AppNotRegistered() external {
@@ -310,6 +544,22 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         // Even the admin cannot ban a app that doesn't exist
         vm.prank(deployer);
         vm.expectRevert(AppNotRegistered.selector);
-        facet.adminBanApp(app);
+        registry.adminBanApp(app);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           Utils                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+    function _setupAppWithPrice(uint256 price) internal {
+        vm.prank(DEFAULT_DEV);
+        mockModule.setPrice(price);
+    }
+
+    function _getProtocolFee(uint256 installPrice) internal view returns (uint256) {
+        IPlatformRequirements platform = IPlatformRequirements(spaceFactory);
+        uint256 minPrice = platform.getMembershipFee();
+        if (installPrice == 0) return minPrice;
+        uint256 basisPointsFee = BasisPoints.calculate(installPrice, platform.getMembershipBps());
+        return FixedPointMathLib.max(basisPointsFee, minPrice);
     }
 }

--- a/packages/generated/dev/abis/IAppRegistry.abi.json
+++ b/packages/generated/dev/abis/IAppRegistry.abi.json
@@ -100,6 +100,113 @@
   },
   {
     "type": "function",
+    "name": "getAppById",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IAppRegistryBase.App",
+        "components": [
+          {
+            "name": "appId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "module",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "clients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "permissions",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "manifest",
+            "type": "tuple",
+            "internalType": "struct ExecutionManifest",
+            "components": [
+              {
+                "name": "executionFunctions",
+                "type": "tuple[]",
+                "internalType": "struct ManifestExecutionFunction[]",
+                "components": [
+                  {
+                    "name": "executionSelector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  },
+                  {
+                    "name": "skipRuntimeValidation",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "allowGlobalValidation",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "executionHooks",
+                "type": "tuple[]",
+                "internalType": "struct ManifestExecutionHook[]",
+                "components": [
+                  {
+                    "name": "executionSelector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  },
+                  {
+                    "name": "entityId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "isPreHook",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "isPostHook",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "interfaceIds",
+                "type": "bytes4[]",
+                "internalType": "bytes4[]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getAppSchema",
     "inputs": [],
     "outputs": [
@@ -126,77 +233,6 @@
   },
   {
     "type": "function",
-    "name": "getAttestation",
-    "inputs": [
-      {
-        "name": "appId",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Attestation",
-        "components": [
-          {
-            "name": "uid",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "schema",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "time",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "expirationTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "revocationTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "refUID",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "recipient",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "attester",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "revocable",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "data",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getLatestAppId",
     "inputs": [
       {
@@ -213,6 +249,29 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "installApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
     "type": "function",
@@ -316,6 +375,31 @@
   },
   {
     "type": "event",
+    "name": "AppInstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "AppRegistered",
     "inputs": [
       {
@@ -341,6 +425,31 @@
         "name": "uid",
         "type": "bytes32",
         "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppUninstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
         "internalType": "bytes32"
       }
     ],
@@ -396,6 +505,11 @@
   },
   {
     "type": "error",
+    "name": "AppNotInstalled",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "AppNotRegistered",
     "inputs": []
   },
@@ -407,6 +521,11 @@
   {
     "type": "error",
     "name": "BannedApp",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPayment",
     "inputs": []
   },
   {
@@ -437,6 +556,11 @@
   {
     "type": "error",
     "name": "InvalidPrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAllowed",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/IAppRegistry.abi.ts
+++ b/packages/generated/dev/abis/IAppRegistry.abi.ts
@@ -100,6 +100,113 @@ export default [
   },
   {
     "type": "function",
+    "name": "getAppById",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IAppRegistryBase.App",
+        "components": [
+          {
+            "name": "appId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "module",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "clients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "permissions",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "manifest",
+            "type": "tuple",
+            "internalType": "struct ExecutionManifest",
+            "components": [
+              {
+                "name": "executionFunctions",
+                "type": "tuple[]",
+                "internalType": "struct ManifestExecutionFunction[]",
+                "components": [
+                  {
+                    "name": "executionSelector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  },
+                  {
+                    "name": "skipRuntimeValidation",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "allowGlobalValidation",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "executionHooks",
+                "type": "tuple[]",
+                "internalType": "struct ManifestExecutionHook[]",
+                "components": [
+                  {
+                    "name": "executionSelector",
+                    "type": "bytes4",
+                    "internalType": "bytes4"
+                  },
+                  {
+                    "name": "entityId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "isPreHook",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "isPostHook",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "interfaceIds",
+                "type": "bytes4[]",
+                "internalType": "bytes4[]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getAppSchema",
     "inputs": [],
     "outputs": [
@@ -126,77 +233,6 @@ export default [
   },
   {
     "type": "function",
-    "name": "getAttestation",
-    "inputs": [
-      {
-        "name": "appId",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Attestation",
-        "components": [
-          {
-            "name": "uid",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "schema",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "time",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "expirationTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "revocationTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "refUID",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "recipient",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "attester",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "revocable",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "data",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getLatestAppId",
     "inputs": [
       {
@@ -213,6 +249,29 @@ export default [
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "installApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
     "type": "function",
@@ -316,6 +375,31 @@ export default [
   },
   {
     "type": "event",
+    "name": "AppInstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "AppRegistered",
     "inputs": [
       {
@@ -341,6 +425,31 @@ export default [
         "name": "uid",
         "type": "bytes32",
         "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppUninstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
         "internalType": "bytes32"
       }
     ],
@@ -396,6 +505,11 @@ export default [
   },
   {
     "type": "error",
+    "name": "AppNotInstalled",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "AppNotRegistered",
     "inputs": []
   },
@@ -407,6 +521,11 @@ export default [
   {
     "type": "error",
     "name": "BannedApp",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPayment",
     "inputs": []
   },
   {
@@ -437,6 +556,11 @@ export default [
   {
     "type": "error",
     "name": "InvalidPrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAllowed",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/IAppRegistryBase.abi.json
+++ b/packages/generated/dev/abis/IAppRegistryBase.abi.json
@@ -39,6 +39,31 @@
   },
   {
     "type": "event",
+    "name": "AppInstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "AppRegistered",
     "inputs": [
       {
@@ -64,6 +89,31 @@
         "name": "uid",
         "type": "bytes32",
         "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppUninstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
         "internalType": "bytes32"
       }
     ],
@@ -119,6 +169,11 @@
   },
   {
     "type": "error",
+    "name": "AppNotInstalled",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "AppNotRegistered",
     "inputs": []
   },
@@ -130,6 +185,11 @@
   {
     "type": "error",
     "name": "BannedApp",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPayment",
     "inputs": []
   },
   {
@@ -160,6 +220,11 @@
   {
     "type": "error",
     "name": "InvalidPrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAllowed",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/IAppRegistryBase.abi.ts
+++ b/packages/generated/dev/abis/IAppRegistryBase.abi.ts
@@ -39,6 +39,31 @@ export default [
   },
   {
     "type": "event",
+    "name": "AppInstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "AppRegistered",
     "inputs": [
       {
@@ -64,6 +89,31 @@ export default [
         "name": "uid",
         "type": "bytes32",
         "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppUninstalled",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appId",
+        "type": "bytes32",
+        "indexed": true,
         "internalType": "bytes32"
       }
     ],
@@ -119,6 +169,11 @@ export default [
   },
   {
     "type": "error",
+    "name": "AppNotInstalled",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "AppNotRegistered",
     "inputs": []
   },
@@ -130,6 +185,11 @@ export default [
   {
     "type": "error",
     "name": "BannedApp",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPayment",
     "inputs": []
   },
   {
@@ -160,6 +220,11 @@ export default [
   {
     "type": "error",
     "name": "InvalidPrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAllowed",
     "inputs": []
   },
   {

--- a/packages/generated/dev/typings/IAppRegistry.ts
+++ b/packages/generated/dev/typings/IAppRegistry.ts
@@ -28,41 +28,55 @@ import type {
   PromiseOrValue,
 } from "./common";
 
-export type AttestationStruct = {
-  uid: PromiseOrValue<BytesLike>;
-  schema: PromiseOrValue<BytesLike>;
-  time: PromiseOrValue<BigNumberish>;
-  expirationTime: PromiseOrValue<BigNumberish>;
-  revocationTime: PromiseOrValue<BigNumberish>;
-  refUID: PromiseOrValue<BytesLike>;
-  recipient: PromiseOrValue<string>;
-  attester: PromiseOrValue<string>;
-  revocable: PromiseOrValue<boolean>;
-  data: PromiseOrValue<BytesLike>;
+export type ManifestExecutionFunctionStruct = {
+  executionSelector: PromiseOrValue<BytesLike>;
+  skipRuntimeValidation: PromiseOrValue<boolean>;
+  allowGlobalValidation: PromiseOrValue<boolean>;
 };
 
-export type AttestationStructOutput = [
-  string,
-  string,
-  BigNumber,
-  BigNumber,
-  BigNumber,
-  string,
-  string,
+export type ManifestExecutionFunctionStructOutput = [
   string,
   boolean,
-  string
+  boolean
 ] & {
-  uid: string;
-  schema: string;
-  time: BigNumber;
-  expirationTime: BigNumber;
-  revocationTime: BigNumber;
-  refUID: string;
-  recipient: string;
-  attester: string;
-  revocable: boolean;
-  data: string;
+  executionSelector: string;
+  skipRuntimeValidation: boolean;
+  allowGlobalValidation: boolean;
+};
+
+export type ManifestExecutionHookStruct = {
+  executionSelector: PromiseOrValue<BytesLike>;
+  entityId: PromiseOrValue<BigNumberish>;
+  isPreHook: PromiseOrValue<boolean>;
+  isPostHook: PromiseOrValue<boolean>;
+};
+
+export type ManifestExecutionHookStructOutput = [
+  string,
+  number,
+  boolean,
+  boolean
+] & {
+  executionSelector: string;
+  entityId: number;
+  isPreHook: boolean;
+  isPostHook: boolean;
+};
+
+export type ExecutionManifestStruct = {
+  executionFunctions: ManifestExecutionFunctionStruct[];
+  executionHooks: ManifestExecutionHookStruct[];
+  interfaceIds: PromiseOrValue<BytesLike>[];
+};
+
+export type ExecutionManifestStructOutput = [
+  ManifestExecutionFunctionStructOutput[],
+  ManifestExecutionHookStructOutput[],
+  string[]
+] & {
+  executionFunctions: ManifestExecutionFunctionStructOutput[];
+  executionHooks: ManifestExecutionHookStructOutput[];
+  interfaceIds: string[];
 };
 
 export declare namespace IAppRegistryBase {
@@ -87,6 +101,31 @@ export declare namespace IAppRegistryBase {
     installPrice: BigNumber;
     accessDuration: BigNumber;
   };
+
+  export type AppStruct = {
+    appId: PromiseOrValue<BytesLike>;
+    module: PromiseOrValue<string>;
+    owner: PromiseOrValue<string>;
+    clients: PromiseOrValue<string>[];
+    permissions: PromiseOrValue<BytesLike>[];
+    manifest: ExecutionManifestStruct;
+  };
+
+  export type AppStructOutput = [
+    string,
+    string,
+    string,
+    string[],
+    string[],
+    ExecutionManifestStructOutput
+  ] & {
+    appId: string;
+    module: string;
+    owner: string;
+    clients: string[];
+    permissions: string[];
+    manifest: ExecutionManifestStructOutput;
+  };
 }
 
 export interface IAppRegistryInterface extends utils.Interface {
@@ -94,10 +133,11 @@ export interface IAppRegistryInterface extends utils.Interface {
     "adminBanApp(address)": FunctionFragment;
     "adminRegisterAppSchema(string,address,bool)": FunctionFragment;
     "createApp((string,bytes32[],address[],uint256,uint64))": FunctionFragment;
+    "getAppById(bytes32)": FunctionFragment;
     "getAppSchema()": FunctionFragment;
     "getAppSchemaId()": FunctionFragment;
-    "getAttestation(bytes32)": FunctionFragment;
     "getLatestAppId(address)": FunctionFragment;
+    "installApp(address,address,bytes)": FunctionFragment;
     "isAppBanned(address)": FunctionFragment;
     "registerApp(address,address[])": FunctionFragment;
     "removeApp(bytes32)": FunctionFragment;
@@ -108,10 +148,11 @@ export interface IAppRegistryInterface extends utils.Interface {
       | "adminBanApp"
       | "adminRegisterAppSchema"
       | "createApp"
+      | "getAppById"
       | "getAppSchema"
       | "getAppSchemaId"
-      | "getAttestation"
       | "getLatestAppId"
+      | "installApp"
       | "isAppBanned"
       | "registerApp"
       | "removeApp"
@@ -134,6 +175,10 @@ export interface IAppRegistryInterface extends utils.Interface {
     values: [IAppRegistryBase.AppParamsStruct]
   ): string;
   encodeFunctionData(
+    functionFragment: "getAppById",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "getAppSchema",
     values?: undefined
   ): string;
@@ -142,12 +187,16 @@ export interface IAppRegistryInterface extends utils.Interface {
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "getAttestation",
-    values: [PromiseOrValue<BytesLike>]
-  ): string;
-  encodeFunctionData(
     functionFragment: "getLatestAppId",
     values: [PromiseOrValue<string>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "installApp",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
   ): string;
   encodeFunctionData(
     functionFragment: "isAppBanned",
@@ -171,6 +220,7 @@ export interface IAppRegistryInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "createApp", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "getAppById", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "getAppSchema",
     data: BytesLike
@@ -180,13 +230,10 @@ export interface IAppRegistryInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "getAttestation",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "getLatestAppId",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "installApp", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "isAppBanned",
     data: BytesLike
@@ -200,16 +247,20 @@ export interface IAppRegistryInterface extends utils.Interface {
   events: {
     "AppBanned(address,bytes32)": EventFragment;
     "AppCreated(address,bytes32)": EventFragment;
+    "AppInstalled(address,address,bytes32)": EventFragment;
     "AppRegistered(address,bytes32)": EventFragment;
     "AppSchemaSet(bytes32)": EventFragment;
+    "AppUninstalled(address,address,bytes32)": EventFragment;
     "AppUnregistered(address,bytes32)": EventFragment;
     "AppUpdated(address,bytes32)": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "AppBanned"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AppCreated"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "AppInstalled"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AppRegistered"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AppSchemaSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "AppUninstalled"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AppUnregistered"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AppUpdated"): EventFragment;
 }
@@ -233,6 +284,18 @@ export type AppCreatedEvent = TypedEvent<
 
 export type AppCreatedEventFilter = TypedEventFilter<AppCreatedEvent>;
 
+export interface AppInstalledEventObject {
+  app: string;
+  account: string;
+  appId: string;
+}
+export type AppInstalledEvent = TypedEvent<
+  [string, string, string],
+  AppInstalledEventObject
+>;
+
+export type AppInstalledEventFilter = TypedEventFilter<AppInstalledEvent>;
+
 export interface AppRegisteredEventObject {
   app: string;
   uid: string;
@@ -250,6 +313,18 @@ export interface AppSchemaSetEventObject {
 export type AppSchemaSetEvent = TypedEvent<[string], AppSchemaSetEventObject>;
 
 export type AppSchemaSetEventFilter = TypedEventFilter<AppSchemaSetEvent>;
+
+export interface AppUninstalledEventObject {
+  app: string;
+  account: string;
+  appId: string;
+}
+export type AppUninstalledEvent = TypedEvent<
+  [string, string, string],
+  AppUninstalledEventObject
+>;
+
+export type AppUninstalledEventFilter = TypedEventFilter<AppUninstalledEvent>;
 
 export interface AppUnregisteredEventObject {
   app: string;
@@ -317,19 +392,26 @@ export interface IAppRegistry extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    getAppById(
+      appId: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[IAppRegistryBase.AppStructOutput]>;
+
     getAppSchema(overrides?: CallOverrides): Promise<[string]>;
 
     getAppSchemaId(overrides?: CallOverrides): Promise<[string]>;
-
-    getAttestation(
-      appId: PromiseOrValue<BytesLike>,
-      overrides?: CallOverrides
-    ): Promise<[AttestationStructOutput]>;
 
     getLatestAppId(
       app: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<[string]>;
+
+    installApp(
+      app: PromiseOrValue<string>,
+      account: PromiseOrValue<string>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     isAppBanned(
       app: PromiseOrValue<string>,
@@ -365,19 +447,26 @@ export interface IAppRegistry extends BaseContract {
     overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  getAppById(
+    appId: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<IAppRegistryBase.AppStructOutput>;
+
   getAppSchema(overrides?: CallOverrides): Promise<string>;
 
   getAppSchemaId(overrides?: CallOverrides): Promise<string>;
-
-  getAttestation(
-    appId: PromiseOrValue<BytesLike>,
-    overrides?: CallOverrides
-  ): Promise<AttestationStructOutput>;
 
   getLatestAppId(
     app: PromiseOrValue<string>,
     overrides?: CallOverrides
   ): Promise<string>;
+
+  installApp(
+    app: PromiseOrValue<string>,
+    account: PromiseOrValue<string>,
+    data: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   isAppBanned(
     app: PromiseOrValue<string>,
@@ -413,19 +502,26 @@ export interface IAppRegistry extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string, string] & { app: string; appId: string }>;
 
+    getAppById(
+      appId: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<IAppRegistryBase.AppStructOutput>;
+
     getAppSchema(overrides?: CallOverrides): Promise<string>;
 
     getAppSchemaId(overrides?: CallOverrides): Promise<string>;
-
-    getAttestation(
-      appId: PromiseOrValue<BytesLike>,
-      overrides?: CallOverrides
-    ): Promise<AttestationStructOutput>;
 
     getLatestAppId(
       app: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<string>;
+
+    installApp(
+      app: PromiseOrValue<string>,
+      account: PromiseOrValue<string>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
 
     isAppBanned(
       app: PromiseOrValue<string>,
@@ -463,6 +559,17 @@ export interface IAppRegistry extends BaseContract {
       uid?: null
     ): AppCreatedEventFilter;
 
+    "AppInstalled(address,address,bytes32)"(
+      app?: PromiseOrValue<string> | null,
+      account?: PromiseOrValue<string> | null,
+      appId?: PromiseOrValue<BytesLike> | null
+    ): AppInstalledEventFilter;
+    AppInstalled(
+      app?: PromiseOrValue<string> | null,
+      account?: PromiseOrValue<string> | null,
+      appId?: PromiseOrValue<BytesLike> | null
+    ): AppInstalledEventFilter;
+
     "AppRegistered(address,bytes32)"(
       app?: PromiseOrValue<string> | null,
       uid?: null
@@ -474,6 +581,17 @@ export interface IAppRegistry extends BaseContract {
 
     "AppSchemaSet(bytes32)"(uid?: null): AppSchemaSetEventFilter;
     AppSchemaSet(uid?: null): AppSchemaSetEventFilter;
+
+    "AppUninstalled(address,address,bytes32)"(
+      app?: PromiseOrValue<string> | null,
+      account?: PromiseOrValue<string> | null,
+      appId?: PromiseOrValue<BytesLike> | null
+    ): AppUninstalledEventFilter;
+    AppUninstalled(
+      app?: PromiseOrValue<string> | null,
+      account?: PromiseOrValue<string> | null,
+      appId?: PromiseOrValue<BytesLike> | null
+    ): AppUninstalledEventFilter;
 
     "AppUnregistered(address,bytes32)"(
       app?: PromiseOrValue<string> | null,
@@ -512,18 +630,25 @@ export interface IAppRegistry extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    getAppSchema(overrides?: CallOverrides): Promise<BigNumber>;
-
-    getAppSchemaId(overrides?: CallOverrides): Promise<BigNumber>;
-
-    getAttestation(
+    getAppById(
       appId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    getAppSchema(overrides?: CallOverrides): Promise<BigNumber>;
+
+    getAppSchemaId(overrides?: CallOverrides): Promise<BigNumber>;
+
     getLatestAppId(
       app: PromiseOrValue<string>,
       overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    installApp(
+      app: PromiseOrValue<string>,
+      account: PromiseOrValue<string>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     isAppBanned(
@@ -561,18 +686,25 @@ export interface IAppRegistry extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    getAppSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    getAppSchemaId(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    getAttestation(
+    getAppById(
       appId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    getAppSchema(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    getAppSchemaId(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
     getLatestAppId(
       app: PromiseOrValue<string>,
       overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    installApp(
+      app: PromiseOrValue<string>,
+      account: PromiseOrValue<string>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     isAppBanned(

--- a/packages/generated/dev/typings/factories/IAppRegistry__factory.ts
+++ b/packages/generated/dev/typings/factories/IAppRegistry__factory.ts
@@ -108,6 +108,113 @@ const _abi = [
   },
   {
     type: "function",
+    name: "getAppById",
+    inputs: [
+      {
+        name: "appId",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        internalType: "struct IAppRegistryBase.App",
+        components: [
+          {
+            name: "appId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "module",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "owner",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "clients",
+            type: "address[]",
+            internalType: "address[]",
+          },
+          {
+            name: "permissions",
+            type: "bytes32[]",
+            internalType: "bytes32[]",
+          },
+          {
+            name: "manifest",
+            type: "tuple",
+            internalType: "struct ExecutionManifest",
+            components: [
+              {
+                name: "executionFunctions",
+                type: "tuple[]",
+                internalType: "struct ManifestExecutionFunction[]",
+                components: [
+                  {
+                    name: "executionSelector",
+                    type: "bytes4",
+                    internalType: "bytes4",
+                  },
+                  {
+                    name: "skipRuntimeValidation",
+                    type: "bool",
+                    internalType: "bool",
+                  },
+                  {
+                    name: "allowGlobalValidation",
+                    type: "bool",
+                    internalType: "bool",
+                  },
+                ],
+              },
+              {
+                name: "executionHooks",
+                type: "tuple[]",
+                internalType: "struct ManifestExecutionHook[]",
+                components: [
+                  {
+                    name: "executionSelector",
+                    type: "bytes4",
+                    internalType: "bytes4",
+                  },
+                  {
+                    name: "entityId",
+                    type: "uint32",
+                    internalType: "uint32",
+                  },
+                  {
+                    name: "isPreHook",
+                    type: "bool",
+                    internalType: "bool",
+                  },
+                  {
+                    name: "isPostHook",
+                    type: "bool",
+                    internalType: "bool",
+                  },
+                ],
+              },
+              {
+                name: "interfaceIds",
+                type: "bytes4[]",
+                internalType: "bytes4[]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "getAppSchema",
     inputs: [],
     outputs: [
@@ -134,77 +241,6 @@ const _abi = [
   },
   {
     type: "function",
-    name: "getAttestation",
-    inputs: [
-      {
-        name: "appId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "tuple",
-        internalType: "struct Attestation",
-        components: [
-          {
-            name: "uid",
-            type: "bytes32",
-            internalType: "bytes32",
-          },
-          {
-            name: "schema",
-            type: "bytes32",
-            internalType: "bytes32",
-          },
-          {
-            name: "time",
-            type: "uint64",
-            internalType: "uint64",
-          },
-          {
-            name: "expirationTime",
-            type: "uint64",
-            internalType: "uint64",
-          },
-          {
-            name: "revocationTime",
-            type: "uint64",
-            internalType: "uint64",
-          },
-          {
-            name: "refUID",
-            type: "bytes32",
-            internalType: "bytes32",
-          },
-          {
-            name: "recipient",
-            type: "address",
-            internalType: "address",
-          },
-          {
-            name: "attester",
-            type: "address",
-            internalType: "address",
-          },
-          {
-            name: "revocable",
-            type: "bool",
-            internalType: "bool",
-          },
-          {
-            name: "data",
-            type: "bytes",
-            internalType: "bytes",
-          },
-        ],
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
     name: "getLatestAppId",
     inputs: [
       {
@@ -221,6 +257,29 @@ const _abi = [
       },
     ],
     stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "installApp",
+    inputs: [
+      {
+        name: "app",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
   },
   {
     type: "function",
@@ -324,6 +383,31 @@ const _abi = [
   },
   {
     type: "event",
+    name: "AppInstalled",
+    inputs: [
+      {
+        name: "app",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "appId",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
     name: "AppRegistered",
     inputs: [
       {
@@ -349,6 +433,31 @@ const _abi = [
         name: "uid",
         type: "bytes32",
         indexed: false,
+        internalType: "bytes32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "AppUninstalled",
+    inputs: [
+      {
+        name: "app",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "appId",
+        type: "bytes32",
+        indexed: true,
         internalType: "bytes32",
       },
     ],
@@ -404,6 +513,11 @@ const _abi = [
   },
   {
     type: "error",
+    name: "AppNotInstalled",
+    inputs: [],
+  },
+  {
+    type: "error",
     name: "AppNotRegistered",
     inputs: [],
   },
@@ -415,6 +529,11 @@ const _abi = [
   {
     type: "error",
     name: "BannedApp",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InsufficientPayment",
     inputs: [],
   },
   {
@@ -445,6 +564,11 @@ const _abi = [
   {
     type: "error",
     name: "InvalidPrice",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotAllowed",
     inputs: [],
   },
   {


### PR DESCRIPTION
### Description

Refactored app installation flow by moving installation logic from AppAccount to AppRegistry. This centralizes payment processing and app management, creating a more consistent user experience and simplifying the installation process.

### Changes

- Moved app installation and uninstallation logic from AppAccount to AppRegistry
- Removed `getAppPrice` from AppAccount and added it to AppRegistry
- Added `getAppById` method to AppRegistry to replace `getAttestation`
- Updated AppAccount to only accept installation calls from the registry
- Simplified app data structures and removed redundant fields
- Added proper payment handling with protocol fees in the registry
- Updated tests to reflect the new installation flow

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines