### PR TITLE
feat: add group expiration functionality to Executor

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployExecutorFacet.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployExecutorFacet.s.sol
@@ -13,7 +13,7 @@ library DeployExecutorFacet {
     using DynamicArrayLib for DynamicArrayLib.DynamicArray;
 
     function selectors() internal pure returns (bytes4[] memory res) {
-        DynamicArrayLib.DynamicArray memory arr = DynamicArrayLib.p().reserve(15);
+        DynamicArrayLib.DynamicArray memory arr = DynamicArrayLib.p().reserve(17);
 
         // Access Management
         arr.p(IExecutor.grantAccess.selector);
@@ -21,6 +21,8 @@ library DeployExecutorFacet {
         arr.p(IExecutor.renounceAccess.selector);
         arr.p(IExecutor.setGuardian.selector);
         arr.p(IExecutor.setGroupDelay.selector);
+        arr.p(IExecutor.setGroupExpiration.selector);
+        arr.p(IExecutor.grantAccessWithExpiration.selector);
 
         // Target Management
         arr.p(IExecutor.setTargetFunctionGroup.selector);

--- a/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
@@ -40,9 +40,33 @@ abstract contract ExecutorBase is IExecutorBase {
 
     /// @notice Creates a new group and marks it as active.
     /// @param groupId The ID of the group to create.
-    function _setGroupStatus(bytes32 groupId, bool status) internal {
-        _getGroup(groupId).setStatus(status);
+    /// @param status The status to set (active/inactive).
+    /// @param expiration Optional timestamp when the group should expire (0 for no expiration).
+    function _setGroupStatus(bytes32 groupId, bool status, uint48 expiration) internal {
+        Group storage group = _getGroup(groupId);
+        group.setStatus(status);
+        if (status && expiration > 0) {
+            if (expiration <= block.timestamp) revert InvalidExpiration();
+            group.expiration = expiration;
+        }
         emit GroupStatusSet(groupId, status);
+    }
+
+    /// @notice Creates a new group and marks it as active without expiration.
+    /// @param groupId The ID of the group to create.
+    /// @param status The status to set (active/inactive).
+    function _setGroupStatus(bytes32 groupId, bool status) internal {
+        _setGroupStatus(groupId, status, 0);
+    }
+
+    /// @notice Sets or extends the expiration for a group.
+    /// @param groupId The ID of the group.
+    /// @param expiration The new expiration timestamp.
+    function _setGroupExpiration(bytes32 groupId, uint48 expiration) internal {
+        if (expiration <= block.timestamp) revert InvalidExpiration();
+        Group storage group = _getGroup(groupId);
+        group.expiration = expiration;
+        emit GroupExpirationSet(groupId, expiration);
     }
 
     /// @notice Grants access to a group for an account.
@@ -124,30 +148,36 @@ abstract contract ExecutorBase is IExecutorBase {
         return _getGroup(groupId).getGrantDelay();
     }
 
+    /// @notice Checks if a group is active and not expired.
+    /// @param groupId The ID of the group.
+    /// @return True if the group is active and not expired.
+    function _isGroupActive(bytes32 groupId) internal view returns (bool) {
+        Group storage group = _getGroup(groupId);
+        if (!group.active) return false;
+        if (group.expiration == 0) return true;
+        return group.expiration > block.timestamp;
+    }
+
     /// @notice Checks if an account has access to a group.
     /// @param groupId The ID of the group.
     /// @param account The account to check.
     /// @return isMember True if the account is a member.
     /// @return executionDelay The execution delay for the account.
-    /// @return active True if the group is active.
+    /// @return active True if the group is active and not expired.
     function _hasGroupAccess(
         bytes32 groupId,
         address account
     ) internal view returns (bool isMember, uint32 executionDelay, bool active) {
         Group storage group = _getGroup(groupId);
-        (isMember, executionDelay, active) = group.hasAccess(account);
+        (isMember, executionDelay) = group.hasAccess(account);
+
+        // Check both active status and expiration
+        active = group.active && (group.expiration == 0 || group.expiration > block.timestamp);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           ACCESS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    /// @notice Checks if a group is active.
-    /// @param groupId The ID of the group.
-    /// @return True if the group is active.
-    function _isGroupActive(bytes32 groupId) internal view returns (bool) {
-        return _getGroup(groupId).active;
-    }
 
     /// @notice Gets access details for an account in a group.
     /// @param groupId The ID of the group.

--- a/packages/contracts/src/spaces/facets/executor/ExecutorFacet.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorFacet.sol
@@ -41,6 +41,17 @@ contract ExecutorFacet is OwnableBase, ExecutorBase, IExecutor, Facet {
     }
 
     /// @inheritdoc IExecutor
+    function grantAccessWithExpiration(
+        bytes32 groupId,
+        address account,
+        uint32 delay,
+        uint48 expiration
+    ) external onlyOwner returns (bool newMember) {
+        _setGroupStatus(groupId, true, expiration);
+        return _grantGroupAccess(groupId, account, _getGroupGrantDelay(groupId), delay);
+    }
+
+    /// @inheritdoc IExecutor
     function revokeAccess(bytes32 groupId, address account) external onlyOwner {
         _revokeGroupAccess(groupId, account);
     }
@@ -58,6 +69,11 @@ contract ExecutorFacet is OwnableBase, ExecutorBase, IExecutor, Facet {
     /// @inheritdoc IExecutor
     function setGroupDelay(bytes32 groupId, uint32 delay) external onlyOwner {
         _setGroupGrantDelay(groupId, delay, 0);
+    }
+
+    /// @inheritdoc IExecutor
+    function setGroupExpiration(bytes32 groupId, uint48 expiration) external onlyOwner {
+        _setGroupExpiration(groupId, expiration);
     }
 
     /// @inheritdoc IExecutor

--- a/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
@@ -4,10 +4,8 @@ pragma solidity ^0.8.23;
 // interfaces
 
 // types
-import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
 
 // libraries
-import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 
 // types
 import {Group, Schedule, Target} from "./IExecutor.sol";

--- a/packages/contracts/test/spaces/account/Executor.t.sol
+++ b/packages/contracts/test/spaces/account/Executor.t.sol
@@ -6,12 +6,9 @@ import {TestUtils} from "@towns-protocol/diamond/test/TestUtils.sol";
 import {DeployFacet} from "scripts/common/DeployFacet.s.sol";
 import {DeployDiamond} from "@towns-protocol/diamond/scripts/deployments/diamonds/DeployDiamond.s.sol";
 import {DeployExecutorFacet} from "scripts/deployments/facets/DeployExecutorFacet.s.sol";
-import {BaseSetup} from "test/spaces/BaseSetup.sol";
 
 //interfaces
 import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
-import {IDiamondCut} from "@towns-protocol/diamond/src/facets/cut/IDiamondCut.sol";
-import {IDiamondLoupe} from "@towns-protocol/diamond/src/facets/loupe/IDiamondLoupe.sol";
 import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {IExecutorBase} from "src/spaces/facets/executor/IExecutor.sol";
 
@@ -161,5 +158,102 @@ contract ExecutorTest is IOwnableBase, TestUtils, IDiamond {
 
         // Assert that the receiver received the token
         assertEq(mockERC721.balanceOf(receiver), 1);
+    }
+
+    function test_grantAccessWithExpiration() external {
+        bytes32 groupId = _randomBytes32();
+        address account = _randomAddress();
+        uint32 executionDelay = 100;
+        uint48 expiration = uint48(block.timestamp + 1 days);
+        uint48 lastAccess = Time.timestamp() + executor.getGroupDelay(groupId);
+
+        vm.prank(founder);
+        vm.expectEmit(address(executor));
+        emit IExecutorBase.GroupAccessGranted(groupId, account, executionDelay, lastAccess, true);
+        bool newMember = executor.grantAccessWithExpiration(
+            groupId,
+            account,
+            executionDelay,
+            expiration
+        );
+        assertEq(newMember, true);
+
+        // Check access is granted
+        (bool isMember, uint32 delay, bool active) = executor.hasAccess(groupId, account);
+        assertEq(isMember, true);
+        assertEq(delay, executionDelay);
+        assertEq(active, true);
+
+        // Warp past expiration
+        vm.warp(block.timestamp + 2 days);
+
+        // Check access is expired
+        (isMember, delay, active) = executor.hasAccess(groupId, account);
+        assertEq(isMember, true);
+        assertEq(delay, executionDelay);
+        assertEq(active, false);
+    }
+
+    function test_revertWhen_grantAccessWithExpiration_invalidExpiration() external {
+        bytes32 groupId = _randomBytes32();
+        address account = _randomAddress();
+        uint32 executionDelay = 100;
+        uint48 expiration = uint48(block.timestamp - 1); // Past expiration
+
+        vm.prank(founder);
+        vm.expectRevert(IExecutorBase.InvalidExpiration.selector);
+        executor.grantAccessWithExpiration(groupId, account, executionDelay, expiration);
+    }
+
+    function test_extendExpiration() external {
+        bytes32 groupId = _randomBytes32();
+        address account = _randomAddress();
+        uint32 executionDelay = 100;
+        uint48 initialExpiration = uint48(block.timestamp + 1 days);
+        uint48 newExpiration = uint48(block.timestamp + 2 days);
+
+        // Grant initial access with expiration
+        vm.startPrank(founder);
+        executor.grantAccessWithExpiration(groupId, account, executionDelay, initialExpiration);
+
+        // Extend expiration
+        vm.expectEmit(address(executor));
+        emit IExecutorBase.GroupExpirationSet(groupId, newExpiration);
+        executor.setGroupExpiration(groupId, newExpiration);
+        vm.stopPrank();
+
+        // Warp past initial expiration but before new expiration
+        vm.warp(block.timestamp + 1.5 days);
+
+        // Check access is still active
+        (, , bool active) = executor.hasAccess(groupId, account);
+        assertEq(active, true);
+    }
+
+    function test_reactivateExpiredGroup() external {
+        bytes32 groupId = _randomBytes32();
+        address account = _randomAddress();
+        uint32 executionDelay = 100;
+        uint48 initialExpiration = uint48(block.timestamp + 1 days);
+        uint48 newExpiration = uint48(block.timestamp + 3 days);
+
+        // Grant initial access with expiration
+        vm.startPrank(founder);
+        executor.grantAccessWithExpiration(groupId, account, executionDelay, initialExpiration);
+
+        // Warp past expiration
+        vm.warp(block.timestamp + 2 days);
+
+        // Check access is expired
+        (, , bool active) = executor.hasAccess(groupId, account);
+        assertEq(active, false);
+
+        // Reactivate with new expiration
+        executor.grantAccessWithExpiration(groupId, account, executionDelay, newExpiration);
+
+        // Check access is active again
+        (, , active) = executor.hasAccess(groupId, account);
+        assertEq(active, true);
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
### Description

Added group expiration functionality to the Executor facet, allowing groups to have a time-limited lifespan. This enables temporary access grants that automatically expire without requiring manual revocation.

### Changes

- Added `expiration` field to the `Group` struct to track when a group becomes inactive
- Implemented `grantAccessWithExpiration` method to create groups with an expiration date
- Added `setGroupExpiration` method to modify a group's expiration timestamp
- Enhanced `_isGroupActive` and `hasGroupAccess` to check expiration status
- Updated group access validation to consider both active status and expiration time
- Added appropriate events and error handling for expiration-related operations

### Checklist

- [x] Tests added for expiration functionality
- [x] Added tests for extending expiration and reactivating expired groups
- [x] Updated selectors array to include new function selectors