### PR TITLE
Add number of retries to the returned error when a transaction fails.

### DIFF
--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -152,6 +152,7 @@ func (s *PostgresEventStore) txRunner(
 			).Func("pg.txRunner").
 				Message("transaction failed").
 				Tag("name", name).
+				Tag("numAttempts", backoff.NumAttempts).
 				Tags(tags...)
 		}
 


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

Add the number of execution attempts as a tag to the returned error when a postgres transaction fails.

This would be useful for confirming if we're seeing some rare serialization failures in the app registry service because the small tables are causing pg to utilize table scans as an optimization over finding rows by index. If this were the case I would not have expected to see multiple attempts here.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
