### PR TITLE
node: add prom metrics for recon tasks

### DIFF
--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -380,6 +380,12 @@ func newRetryableReconciliationTasks(nextRetry time.Duration) *retryableReconcil
 	}
 }
 
+func (r *retryableReconciliationTasks) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.pendingTasksFifo.Len()
+}
+
 // Add adds or updates a retryable reconciliation task for the given streamId.
 // If a task already exists for the given stream  and the given streamRecord is newer the existing task is updated.
 func (r *retryableReconciliationTasks) Add(streamId StreamId, stream *Stream, streamRecord *river.StreamWithId) {


### PR DESCRIPTION
Add the following prometheus metrics:

```
scheduledGetRecordTasksGauge: params.Metrics.NewGaugeEx(
	"stream_cache_recon_scheduled_get_record_tasks",
	"Number of recon tasks scheduled to get stream record",
),
scheduledReconciliationTasksGauge: params.Metrics.NewGaugeEx(
	"stream_cache_recon_scheduled_recon_tasks",
	"Number of recon tasks scheduled",
),
retryableReconcilationTasksGauge: params.Metrics.NewGaugeEx(
	"stream_cache_recon_scheduled_recon_retryable_tasks",
	"Number of recon tasks scheduled for retry",
),
```