### PR TITLE
fix ci while arc-runner bug is fixed upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat
+              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat-openbsd
 
             - name: Show PostgreSQL max_connections
               run: psql -h localhost -p 5433 -U postgres -c 'SHOW max_connections;'
@@ -361,7 +361,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat
+              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat-openbsd
 
             - name: Show PostgreSQL max_connections
               run: psql -h localhost -p 5433 -U postgres -c 'SHOW max_connections;'
@@ -507,7 +507,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat
+              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat-openbsd
 
             - name: Show PostgreSQL max_connections
               run: psql -h localhost -p 5433 -U postgres -c 'SHOW max_connections;'
@@ -662,7 +662,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat libsecp256k1-dev
+              run: sudo apt update && sudo apt-get install -y postgresql-client zstd make gcc netcat-openbsd libsecp256k1-dev
 
             - name: Show PostgreSQL max_connections
               run: psql -h localhost -p 5433 -U postgres -c 'SHOW max_connections;'
@@ -731,7 +731,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y zstd make netcat libsecp256k1-dev gcc
+              run: sudo apt update && sudo apt-get install -y zstd make netcat libsecp256k1-dev gcc netcat-openbsd
 
             - name: Setup Go
               uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
                   version: ${{ env.FOUNDRY_VERSION }}
 
             - name: Install Binaries
-              run: sudo apt-get update && sudo apt-get -y install make zstd libsecp256k1-dev gcc
+              run: sudo apt-get update && sudo apt-get -y install make zstd libsecp256k1-dev gcc netcat-openbsd
 
             - uses: actions/setup-node@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     Common_CI:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_common_ci
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 30
 
         steps:
@@ -183,7 +183,7 @@ jobs:
     Multinode:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 30
         services:
             postgres-core:
@@ -333,7 +333,7 @@ jobs:
     Multinode_Ent:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 40
         services:
             postgres-core:
@@ -479,7 +479,7 @@ jobs:
     Multinode_Ent_Legacy:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent_legacy
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 40
         services:
             postgres-core:
@@ -619,7 +619,7 @@ jobs:
     Go_Tests:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_go
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 30
         services:
             postgres-core:
@@ -717,7 +717,7 @@ jobs:
     XChain_Integration:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_xchain_integration
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-x64-16core
         timeout-minutes: 30
 
         steps:
@@ -766,7 +766,7 @@ jobs:
                 XChain_Integration,
             ]
         if: failure()
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-x64-16core
         steps:
             - name: Slack notification
               if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     Common_CI:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_common_ci
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
 
         steps:
@@ -183,7 +183,7 @@ jobs:
     Multinode:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
         services:
             postgres-core:
@@ -333,7 +333,7 @@ jobs:
     Multinode_Ent:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 40
         services:
             postgres-core:
@@ -479,7 +479,7 @@ jobs:
     Multinode_Ent_Legacy:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent_legacy
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 40
         services:
             postgres-core:
@@ -619,7 +619,7 @@ jobs:
     Go_Tests:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_go
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
         services:
             postgres-core:
@@ -717,7 +717,7 @@ jobs:
     XChain_Integration:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_xchain_integration
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
 
         steps:
@@ -731,7 +731,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Install Binaries
-              run: sudo apt update && sudo apt-get install -y zstd make netcat libsecp256k1-dev gcc netcat-openbsd
+              run: sudo apt update && sudo apt-get install -y zstd make libsecp256k1-dev gcc netcat-openbsd
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -766,7 +766,7 @@ jobs:
                 XChain_Integration,
             ]
         if: failure()
-        runs-on: ubuntu-x64-16core
+        runs-on: ubuntu-latest-8-cores
         steps:
             - name: Slack notification
               if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     Common_CI:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_common_ci
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
 
         steps:
@@ -183,7 +183,7 @@ jobs:
     Multinode:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 30
         services:
             postgres-core:
@@ -333,7 +333,7 @@ jobs:
     Multinode_Ent:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 40
         services:
             postgres-core:
@@ -479,7 +479,7 @@ jobs:
     Multinode_Ent_Legacy:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent_legacy
-        runs-on: ['arc-runners']
+        runs-on: ubuntu-latest-8-cores
         timeout-minutes: 40
         services:
             postgres-core:


### PR DESCRIPTION
arc-runner pods keep crashing in GKE with an upstream error fetching from GH backend. This is blocking CI progress. Let's use gh hosted vm's until this issue is fixed. It is likely an issue with GH backend or gh-runner image as nothing else has changed with our deployment which runs a Helm chart for the runner system in GKE.
<img width="894" alt="Screenshot 2025-06-06 at 10 13 06 AM" src="https://github.com/user-attachments/assets/f8a06eb4-3336-4542-953e-5f20c329dab2" />
