### PR TITLE
Revert error splatting in waitFor

### DIFF
--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -1064,10 +1064,7 @@ export function waitFor<T extends void | boolean>(
                         },
                         (err) => {
                             promiseStatus = 'rejected'
-                            // splat the error to get a stack trace, i don't know why this works
-                            lastError = {
-                                ...err,
-                            }
+                            lastError = err
                         },
                     )
                 } else {


### PR DESCRIPTION
stopped needing this after the vite test migration