### PR TITLE
Add reference equality check before dispatching events in observable

### DIFF
--- a/packages/sdk/src/observable/observable.ts
+++ b/packages/sdk/src/observable/observable.ts
@@ -19,6 +19,9 @@ export class Observable<T> {
     }
 
     setValue(newValue: T) {
+        if (this._value === newValue) {
+            return
+        }
         const prevValue = this._value
         this._value = newValue
         this.notify(prevValue)


### PR DESCRIPTION
seems sane that a user would expect the events to not fire if nothing changed.