### PR TITLE
Correct Spelling Errors in Auth-Related Comments

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -260,7 +260,7 @@ func NewChainAuth(
 		return nil, err
 	}
 
-	// seperate cache for entitlement manager as the timeouts are shorter
+	// separate cache for entitlement manager as the timeouts are shorter
 	entitlementManagerCache, err := newEntitlementManagerCache(ctx, blockchain.Config)
 	if err != nil {
 		return nil, err

--- a/core/node/auth/banning.go
+++ b/core/node/auth/banning.go
@@ -83,7 +83,7 @@ func (b *banning) IsBanned(ctx context.Context, wallets []common.Address) (bool,
 					Func("IsBanned").
 					Message("Failed to get owner of banned token")
 			}
-			// Ignore burned tokens or any resopnse that indicates a token id out of bounds
+			// Ignore burned tokens or any response that indicates a token id out of bounds
 			zeroAddress := common.Address{}
 			if !tokenOwnership.Burned && tokenOwnership.Addr != zeroAddress {
 				bannedAddresses[tokenOwnership.Addr] = struct{}{}


### PR DESCRIPTION
### Description




This pull request addresses and fixes spelling errors found in code comments within the authentication logic:
- Updated a comment in `auth_impl.go` to use the correct spelling "separate".
- Corrected the word "resopnse" to "response" in a comment in `banning.go`.

These improvements enhance the readability and professionalism of the codebase without impacting any functionality.