### PR TITLE
move sdk crypto functions into a isolated package

### DIFF
--- a/packages/sdk-crypto/.eslintrc.json
+++ b/packages/sdk-crypto/.eslintrc.json
@@ -1,0 +1,65 @@
+{
+    "root": true,
+    "extends": [
+        "eslint:recommended",
+        "plugin:import-x/recommended",
+        "plugin:import-x/typescript",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:prettier/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": { "project": ["./tsconfig.json"] },
+    "plugins": ["@typescript-eslint", "import-x", "eslint-plugin-tsdoc"],
+    "ignorePatterns": ["dist/**", ".turbo/**", "node_modules/**", "vitest.*"],
+    "rules": {
+        "no-console": "error",
+        "import-x/no-extraneous-dependencies": [
+            "error",
+            {
+                "packageDir": "."
+            }
+        ],
+        "@typescript-eslint/require-await": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_",
+                "destructuredArrayIgnorePattern": "^_",
+                "caughtErrors": "none"
+            }
+        ],
+        "@typescript-eslint/restrict-template-expressions": [
+            "error",
+            {
+                "allowNever": true,
+                "allowBoolean": true,
+                "allowNumber": true,
+                "allowAny": true,
+                "allowNullish": true
+            }
+        ],
+        "@typescript-eslint/no-empty-function": [
+            "error",
+            {
+                "allow": ["arrowFunctions"]
+            }
+        ],
+        "@typescript-eslint/ban-ts-comment": "off",
+        "tsdoc/syntax": "warn"
+    },
+    "overrides": [
+        {
+            "files": ["**/*.test.*", "**/*.test_util.*"],
+            "rules": {
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-non-null-assertion": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "tsdoc/syntax": "off"
+            }
+        }
+    ]
+}

--- a/packages/sdk-crypto/README.md
+++ b/packages/sdk-crypto/README.md
@@ -1,0 +1,5 @@
+# @towns-protocol/sdk-crypto
+
+This package provides a set of cryptographic functions used in the Towns Protocol SDK.
+
+It's required to be a package so we can properly bundle the code for the web and node.

--- a/packages/sdk-crypto/package.json
+++ b/packages/sdk-crypto/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "@towns-protocol/sdk-crypto",
+    "version": "0.0.236",
+    "packageManager": "yarn@3.8.0",
+    "type": "module",
+    "publishConfig": {
+        "access": "public"
+    },
+    "main": "./dist/web/index.cjs",
+    "module": "./dist/web/index.js",
+    "types": "./dist/web/index.d.ts",
+    "sideEffects": false,
+    "exports": {
+        ".": {
+            "types": "./dist/web/index.d.ts",
+            "node": "./dist/node/index.js",
+            "default": "./dist/web/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "scripts": {
+        "build": "tsdown",
+        "cb": "yarn clean && yarn build",
+        "clean": "rm -rf dist",
+        "lint": "eslint --format unix ./src  --max-warnings=0",
+        "lint:fix": "yarn lint --fix",
+        "test": "vitest",
+        "test:unit": "vitest run",
+        "watch": "tsdown --watch"
+    },
+    "dependencies": {
+        "@towns-protocol/dlog": "workspace:^",
+        "@towns-protocol/encryption": "workspace:^",
+        "@towns-protocol/proto": "workspace:^"
+    },
+    "devDependencies": {
+        "@bufbuild/protobuf": "^2.2.2",
+        "@types/node": "^20.14.8",
+        "@typescript-eslint/eslint-plugin": "^8.29.0",
+        "@typescript-eslint/parser": "^8.29.0",
+        "eslint": "^8.57.1",
+        "eslint-import-resolver-typescript": "^4.3.2",
+        "eslint-plugin-import-x": "^4.10.2",
+        "eslint-plugin-tsdoc": "^0.3.0",
+        "happy-dom": "^15.11.7",
+        "tsdown": "^0.12.3",
+        "typescript": "^5.8.2",
+        "vitest": "3.2.3"
+    },
+    "files": [
+        "/dist"
+    ]
+}

--- a/packages/sdk-crypto/src/node/crypto.test.ts
+++ b/packages/sdk-crypto/src/node/crypto.test.ts
@@ -1,0 +1,251 @@
+import { describe, test, expect } from 'vitest'
+import { EncryptedDataSchema } from '@towns-protocol/proto'
+import { AES_GCM_DERIVED_ALGORITHM } from '@towns-protocol/encryption'
+import {
+    uint8ArrayToBase64,
+    base64ToUint8Array,
+    deriveKeyAndIV,
+    encryptAESGCM,
+    decryptAESGCM,
+    decryptDerivedAESGCM,
+} from './index'
+import { create } from '@bufbuild/protobuf'
+
+const testData = new TextEncoder().encode('Hello, World! This is a test message.')
+const testString = 'Hello, World!'
+const testBase64 = 'SGVsbG8sIFdvcmxkIQ=='
+const testKeyPhrase = 'test-passphrase-123'
+
+describe('Crypto Functions', () => {
+    describe('Base64 Conversion', () => {
+        test('uint8ArrayToBase64 should convert Uint8Array to base64', () => {
+            const uint8Array = new TextEncoder().encode(testString)
+            const result = uint8ArrayToBase64(uint8Array)
+            expect(result).toBe(testBase64)
+        })
+
+        test('base64ToUint8Array should convert base64 to Uint8Array', () => {
+            const result = base64ToUint8Array(testBase64)
+            const decoded = new TextDecoder().decode(result)
+            expect(decoded).toBe(testString)
+        })
+
+        test('round-trip conversion should preserve data', () => {
+            const original = new Uint8Array([1, 2, 3, 4, 5, 255, 0, 128])
+            const base64 = uint8ArrayToBase64(original)
+            const restored = base64ToUint8Array(base64)
+            expect(restored).toEqual(original)
+        })
+
+        test('should handle empty arrays', () => {
+            const empty = new Uint8Array(0)
+            const base64 = uint8ArrayToBase64(empty)
+            const restored = base64ToUint8Array(base64)
+            expect(restored).toEqual(empty)
+        })
+    })
+
+    describe('Key Derivation', () => {
+        test('deriveKeyAndIV should derive consistent key and IV from string', async () => {
+            const result1 = await deriveKeyAndIV(testKeyPhrase)
+            const result2 = await deriveKeyAndIV(testKeyPhrase)
+
+            expect(result1.key).toEqual(result2.key)
+            expect(result1.iv).toEqual(result2.iv)
+            expect(result1.key.length).toBe(32) // AES-256 key
+            expect(result1.iv.length).toBe(12) // AES-GCM IV
+        })
+
+        test('deriveKeyAndIV should derive from Uint8Array', async () => {
+            const keyBuffer = new TextEncoder().encode(testKeyPhrase)
+            const result1 = await deriveKeyAndIV(keyBuffer)
+            const result2 = await deriveKeyAndIV(testKeyPhrase)
+
+            expect(result1.key).toEqual(result2.key)
+            expect(result1.iv).toEqual(result2.iv)
+        })
+
+        test('different key phrases should produce different keys', async () => {
+            const result1 = await deriveKeyAndIV('password1')
+            const result2 = await deriveKeyAndIV('password2')
+
+            expect(result1.key).not.toEqual(result2.key)
+            expect(result1.iv).not.toEqual(result2.iv)
+        })
+    })
+
+    describe('AES-GCM Encryption', () => {
+        test('encryptAESGCM should encrypt data with generated key and IV', async () => {
+            const result = await encryptAESGCM(testData)
+
+            expect(result.ciphertext).toBeDefined()
+            expect(result.iv).toBeDefined()
+            expect(result.secretKey).toBeDefined()
+            expect(result.secretKey.length).toBe(32)
+            expect(result.iv.length).toBe(12)
+            expect(result.ciphertext).not.toEqual(testData)
+        })
+
+        test('encryptAESGCM should use provided key and IV', async () => {
+            const key = new Uint8Array(32).fill(1)
+            const iv = new Uint8Array(12).fill(2)
+
+            const result = await encryptAESGCM(testData, key, iv)
+
+            expect(result.secretKey).toEqual(key)
+            expect(result.iv).toEqual(iv)
+        })
+
+        test('encryptAESGCM should throw on empty data', async () => {
+            await expect(encryptAESGCM(new Uint8Array(0))).rejects.toThrow(
+                'Cannot encrypt undefined or empty data',
+            )
+        })
+
+        test('encryptAESGCM should throw on invalid key length', async () => {
+            const shortKey = new Uint8Array(16) // Too short
+            await expect(encryptAESGCM(testData, shortKey)).rejects.toThrow('Invalid key length')
+        })
+
+        test('encryptAESGCM should throw on invalid IV length', async () => {
+            const key = new Uint8Array(32)
+            const shortIV = new Uint8Array(8) // Too short
+            await expect(encryptAESGCM(testData, key, shortIV)).rejects.toThrow('Invalid IV length')
+        })
+    })
+
+    describe('AES-GCM Decryption', () => {
+        test('decryptAESGCM should decrypt encrypted data', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptAESGCM should decrypt base64 encoded data', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const base64Ciphertext = uint8ArrayToBase64(ciphertext)
+            const decrypted = await decryptAESGCM(base64Ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptAESGCM should throw on invalid key length', async () => {
+            const { ciphertext, iv } = await encryptAESGCM(testData)
+            const shortKey = new Uint8Array(16)
+
+            await expect(decryptAESGCM(ciphertext, shortKey, iv)).rejects.toThrow(
+                'Invalid key length',
+            )
+        })
+
+        test('decryptAESGCM should throw on invalid IV length', async () => {
+            const { ciphertext, secretKey } = await encryptAESGCM(testData)
+            const shortIV = new Uint8Array(8)
+
+            await expect(decryptAESGCM(ciphertext, secretKey, shortIV)).rejects.toThrow(
+                'Invalid IV length',
+            )
+        })
+
+        test('decryptAESGCM should throw on tampered ciphertext', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const tamperedCiphertext = new Uint8Array(ciphertext)
+            tamperedCiphertext[0] = tamperedCiphertext[0] ^ 1 // Flip a bit
+
+            await expect(decryptAESGCM(tamperedCiphertext, secretKey, iv)).rejects.toThrow()
+        })
+    })
+
+    describe('Derived Key Decryption', () => {
+        test('decryptDerivedAESGCM should decrypt with key phrase', async () => {
+            const { key, iv } = await deriveKeyAndIV(testKeyPhrase)
+            const { ciphertext } = await encryptAESGCM(testData, key, iv)
+
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: AES_GCM_DERIVED_ALGORITHM,
+                ciphertext: uint8ArrayToBase64(ciphertext),
+            })
+
+            const decrypted = await decryptDerivedAESGCM(testKeyPhrase, encryptedData)
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptDerivedAESGCM should throw on unsupported algorithm', async () => {
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: 'unsupported-algorithm',
+                ciphertext: 'dummy-data',
+            })
+
+            await expect(decryptDerivedAESGCM(testKeyPhrase, encryptedData)).rejects.toThrow(
+                'algorithm not implemented',
+            )
+        })
+    })
+
+    describe('End-to-End Encryption Flow', () => {
+        test('full encryption/decryption cycle should preserve data', async () => {
+            const originalData = new TextEncoder().encode(
+                'This is a comprehensive test message with various characters: !@#$%^&*()_+{}[]|:;<>?,./`~',
+            )
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(originalData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(originalData)
+            expect(new TextDecoder().decode(decrypted)).toBe(new TextDecoder().decode(originalData))
+        })
+
+        test('derived key encryption/decryption cycle should preserve data', async () => {
+            const originalData = new TextEncoder().encode('Test message for derived key encryption')
+            const keyPhrase = 'my-secret-passphrase-12345'
+
+            const { key, iv } = await deriveKeyAndIV(keyPhrase)
+            const { ciphertext } = await encryptAESGCM(originalData, key, iv)
+
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: AES_GCM_DERIVED_ALGORITHM,
+                ciphertext: uint8ArrayToBase64(ciphertext),
+            })
+
+            const decrypted = await decryptDerivedAESGCM(keyPhrase, encryptedData)
+            expect(decrypted).toEqual(originalData)
+        })
+    })
+
+    describe('Edge Cases', () => {
+        test('should handle large data', async () => {
+            const largeData = new Uint8Array(1024 * 100) // 100KB
+            largeData.fill(42)
+
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(largeData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(largeData)
+        })
+
+        test('should handle binary data with all byte values', async () => {
+            const binaryData = new Uint8Array(256)
+            for (let i = 0; i < 256; i++) {
+                binaryData[i] = i
+            }
+
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(binaryData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(binaryData)
+        })
+
+        test('should handle unicode strings in key phrases', async () => {
+            const unicodeKeyPhrase = '测试密码🔐🚀'
+            const { key, iv } = await deriveKeyAndIV(unicodeKeyPhrase)
+
+            expect(key.length).toBe(32)
+            expect(iv.length).toBe(12)
+
+            // Should be deterministic
+            const { key: key2, iv: iv2 } = await deriveKeyAndIV(unicodeKeyPhrase)
+            expect(key).toEqual(key2)
+            expect(iv).toEqual(iv2)
+        })
+    })
+})

--- a/packages/sdk-crypto/src/node/crypto.test.ts
+++ b/packages/sdk-crypto/src/node/crypto.test.ts
@@ -17,6 +17,10 @@ const testBase64 = 'SGVsbG8sIFdvcmxkIQ=='
 const testKeyPhrase = 'test-passphrase-123'
 
 describe('Crypto Functions', () => {
+    test('should be running in a Node environment', () => {
+        expect(typeof window === 'undefined').toBe(true)
+    })
+
     describe('Base64 Conversion', () => {
         test('uint8ArrayToBase64 should convert Uint8Array to base64', () => {
             const uint8Array = new TextEncoder().encode(testString)

--- a/packages/sdk-crypto/src/node/index.ts
+++ b/packages/sdk-crypto/src/node/index.ts
@@ -1,11 +1,7 @@
-// This function is a helper for encrypting and decrypting public content.
-// The same IV and key are generated from the key phrase each time.
-// Not intended for protecting sensitive data, but rather for obfuscating content.
-
 import { throwWithCode } from '@towns-protocol/dlog'
 import { EncryptedData, Err } from '@towns-protocol/proto'
 import { AES_GCM_DERIVED_ALGORITHM } from '@towns-protocol/encryption'
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 
 export function uint8ArrayToBase64(uint8Array: Uint8Array): string {
     return Buffer.from(uint8Array).toString('base64')

--- a/packages/sdk-crypto/src/web/crypto.test.ts
+++ b/packages/sdk-crypto/src/web/crypto.test.ts
@@ -18,6 +18,10 @@ const testBase64 = 'SGVsbG8sIFdvcmxkIQ=='
 const testKeyPhrase = 'test-passphrase-123'
 
 describe('Crypto Functions', () => {
+    test('should be running in a Web environment', () => {
+        expect(typeof window === 'undefined').toBe(false)
+    })
+
     describe('Base64 Conversion', () => {
         test('uint8ArrayToBase64 should convert Uint8Array to base64', () => {
             const uint8Array = new TextEncoder().encode(testString)

--- a/packages/sdk-crypto/src/web/crypto.test.ts
+++ b/packages/sdk-crypto/src/web/crypto.test.ts
@@ -1,0 +1,252 @@
+import { describe, test, expect } from 'vitest'
+import { EncryptedDataSchema } from '@towns-protocol/proto'
+import { AES_GCM_DERIVED_ALGORITHM } from '@towns-protocol/encryption'
+import {
+    uint8ArrayToBase64,
+    base64ToUint8Array,
+    deriveKeyAndIV,
+    encryptAESGCM,
+    decryptAESGCM,
+    decryptDerivedAESGCM,
+} from './index'
+import { create } from '@bufbuild/protobuf'
+
+// Test data
+const testData = new TextEncoder().encode('Hello, World! This is a test message.')
+const testString = 'Hello, World!'
+const testBase64 = 'SGVsbG8sIFdvcmxkIQ=='
+const testKeyPhrase = 'test-passphrase-123'
+
+describe('Crypto Functions', () => {
+    describe('Base64 Conversion', () => {
+        test('uint8ArrayToBase64 should convert Uint8Array to base64', () => {
+            const uint8Array = new TextEncoder().encode(testString)
+            const result = uint8ArrayToBase64(uint8Array)
+            expect(result).toBe(testBase64)
+        })
+
+        test('base64ToUint8Array should convert base64 to Uint8Array', () => {
+            const result = base64ToUint8Array(testBase64)
+            const decoded = new TextDecoder().decode(result)
+            expect(decoded).toBe(testString)
+        })
+
+        test('round-trip conversion should preserve data', () => {
+            const original = new Uint8Array([1, 2, 3, 4, 5, 255, 0, 128])
+            const base64 = uint8ArrayToBase64(original)
+            const restored = base64ToUint8Array(base64)
+            expect(restored).toEqual(original)
+        })
+
+        test('should handle empty arrays', () => {
+            const empty = new Uint8Array(0)
+            const base64 = uint8ArrayToBase64(empty)
+            const restored = base64ToUint8Array(base64)
+            expect(restored).toEqual(empty)
+        })
+    })
+
+    describe('Key Derivation', () => {
+        test('deriveKeyAndIV should derive consistent key and IV from string', async () => {
+            const result1 = await deriveKeyAndIV(testKeyPhrase)
+            const result2 = await deriveKeyAndIV(testKeyPhrase)
+
+            expect(result1.key).toEqual(result2.key)
+            expect(result1.iv).toEqual(result2.iv)
+            expect(result1.key.length).toBe(32) // AES-256 key
+            expect(result1.iv.length).toBe(12) // AES-GCM IV
+        })
+
+        test('deriveKeyAndIV should derive from Uint8Array', async () => {
+            const keyBuffer = new TextEncoder().encode(testKeyPhrase)
+            const result1 = await deriveKeyAndIV(keyBuffer)
+            const result2 = await deriveKeyAndIV(testKeyPhrase)
+
+            expect(result1.key).toEqual(result2.key)
+            expect(result1.iv).toEqual(result2.iv)
+        })
+
+        test('different key phrases should produce different keys', async () => {
+            const result1 = await deriveKeyAndIV('password1')
+            const result2 = await deriveKeyAndIV('password2')
+
+            expect(result1.key).not.toEqual(result2.key)
+            expect(result1.iv).not.toEqual(result2.iv)
+        })
+    })
+
+    describe('AES-GCM Encryption', () => {
+        test('encryptAESGCM should encrypt data with generated key and IV', async () => {
+            const result = await encryptAESGCM(testData)
+
+            expect(result.ciphertext).toBeDefined()
+            expect(result.iv).toBeDefined()
+            expect(result.secretKey).toBeDefined()
+            expect(result.secretKey.length).toBe(32)
+            expect(result.iv.length).toBe(12)
+            expect(result.ciphertext).not.toEqual(testData)
+        })
+
+        test('encryptAESGCM should use provided key and IV', async () => {
+            const key = new Uint8Array(32).fill(1)
+            const iv = new Uint8Array(12).fill(2)
+
+            const result = await encryptAESGCM(testData, key, iv)
+
+            expect(result.secretKey).toEqual(key)
+            expect(result.iv).toEqual(iv)
+        })
+
+        test('encryptAESGCM should throw on empty data', async () => {
+            await expect(encryptAESGCM(new Uint8Array(0))).rejects.toThrow(
+                'Cannot encrypt undefined or empty data',
+            )
+        })
+
+        test('encryptAESGCM should throw on invalid key length', async () => {
+            const shortKey = new Uint8Array(16) // Too short
+            await expect(encryptAESGCM(testData, shortKey)).rejects.toThrow('Invalid key length')
+        })
+
+        test('encryptAESGCM should throw on invalid IV length', async () => {
+            const key = new Uint8Array(32)
+            const shortIV = new Uint8Array(8) // Too short
+            await expect(encryptAESGCM(testData, key, shortIV)).rejects.toThrow('Invalid IV length')
+        })
+    })
+
+    describe('AES-GCM Decryption', () => {
+        test('decryptAESGCM should decrypt encrypted data', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptAESGCM should decrypt base64 encoded data', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const base64Ciphertext = uint8ArrayToBase64(ciphertext)
+            const decrypted = await decryptAESGCM(base64Ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptAESGCM should throw on invalid key length', async () => {
+            const { ciphertext, iv } = await encryptAESGCM(testData)
+            const shortKey = new Uint8Array(16)
+
+            await expect(decryptAESGCM(ciphertext, shortKey, iv)).rejects.toThrow(
+                'Invalid key length',
+            )
+        })
+
+        test('decryptAESGCM should throw on invalid IV length', async () => {
+            const { ciphertext, secretKey } = await encryptAESGCM(testData)
+            const shortIV = new Uint8Array(8)
+
+            await expect(decryptAESGCM(ciphertext, secretKey, shortIV)).rejects.toThrow(
+                'Invalid IV length',
+            )
+        })
+
+        test('decryptAESGCM should throw on tampered ciphertext', async () => {
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(testData)
+            const tamperedCiphertext = new Uint8Array(ciphertext)
+            tamperedCiphertext[0] = tamperedCiphertext[0] ^ 1 // Flip a bit
+
+            await expect(decryptAESGCM(tamperedCiphertext, secretKey, iv)).rejects.toThrow()
+        })
+    })
+
+    describe('Derived Key Decryption', () => {
+        test('decryptDerivedAESGCM should decrypt with key phrase', async () => {
+            const { key, iv } = await deriveKeyAndIV(testKeyPhrase)
+            const { ciphertext } = await encryptAESGCM(testData, key, iv)
+
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: AES_GCM_DERIVED_ALGORITHM,
+                ciphertext: uint8ArrayToBase64(ciphertext),
+            })
+
+            const decrypted = await decryptDerivedAESGCM(testKeyPhrase, encryptedData)
+            expect(decrypted).toEqual(testData)
+        })
+
+        test('decryptDerivedAESGCM should throw on unsupported algorithm', async () => {
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: 'unsupported-algorithm',
+                ciphertext: 'dummy-data',
+            })
+
+            await expect(decryptDerivedAESGCM(testKeyPhrase, encryptedData)).rejects.toThrow(
+                'algorithm not implemented',
+            )
+        })
+    })
+
+    describe('End-to-End Encryption Flow', () => {
+        test('full encryption/decryption cycle should preserve data', async () => {
+            const originalData = new TextEncoder().encode(
+                'This is a comprehensive test message with various characters: !@#$%^&*()_+{}[]|:;<>?,./`~',
+            )
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(originalData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(originalData)
+            expect(new TextDecoder().decode(decrypted)).toBe(new TextDecoder().decode(originalData))
+        })
+
+        test('derived key encryption/decryption cycle should preserve data', async () => {
+            const originalData = new TextEncoder().encode('Test message for derived key encryption')
+            const keyPhrase = 'my-secret-passphrase-12345'
+
+            const { key, iv } = await deriveKeyAndIV(keyPhrase)
+            const { ciphertext } = await encryptAESGCM(originalData, key, iv)
+
+            const encryptedData = create(EncryptedDataSchema, {
+                algorithm: AES_GCM_DERIVED_ALGORITHM,
+                ciphertext: uint8ArrayToBase64(ciphertext),
+            })
+
+            const decrypted = await decryptDerivedAESGCM(keyPhrase, encryptedData)
+            expect(decrypted).toEqual(originalData)
+        })
+    })
+
+    describe('Edge Cases', () => {
+        test('should handle large data', async () => {
+            const largeData = new Uint8Array(1024 * 100) // 100KB
+            largeData.fill(42)
+
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(largeData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(largeData)
+        })
+
+        test('should handle binary data with all byte values', async () => {
+            const binaryData = new Uint8Array(256)
+            for (let i = 0; i < 256; i++) {
+                binaryData[i] = i
+            }
+
+            const { ciphertext, iv, secretKey } = await encryptAESGCM(binaryData)
+            const decrypted = await decryptAESGCM(ciphertext, secretKey, iv)
+
+            expect(decrypted).toEqual(binaryData)
+        })
+
+        test('should handle unicode strings in key phrases', async () => {
+            const unicodeKeyPhrase = '测试密码🔐🚀'
+            const { key, iv } = await deriveKeyAndIV(unicodeKeyPhrase)
+
+            expect(key.length).toBe(32)
+            expect(iv.length).toBe(12)
+
+            // Should be deterministic
+            const { key: key2, iv: iv2 } = await deriveKeyAndIV(unicodeKeyPhrase)
+            expect(key).toEqual(key2)
+            expect(iv).toEqual(iv2)
+        })
+    })
+})

--- a/packages/sdk-crypto/src/web/index.ts
+++ b/packages/sdk-crypto/src/web/index.ts
@@ -1,0 +1,136 @@
+import { throwWithCode } from '@towns-protocol/dlog'
+import { EncryptedData, Err } from '@towns-protocol/proto'
+import { AES_GCM_DERIVED_ALGORITHM } from '@towns-protocol/encryption'
+
+export function uint8ArrayToBase64(uint8Array: Uint8Array): string {
+    const binary = Array.from(uint8Array, (byte) => String.fromCharCode(byte)).join('')
+    return btoa(binary)
+}
+
+export function base64ToUint8Array(base64: string): Uint8Array {
+    const binary = atob(base64)
+    return new Uint8Array(Array.from(binary, (char) => char.charCodeAt(0)))
+}
+
+async function getExtendedKeyMaterial(seedBuffer: Uint8Array, length: number): Promise<Uint8Array> {
+    let keyMaterial = new Uint8Array(await crypto.subtle.digest('SHA-256', seedBuffer))
+
+    while (keyMaterial.length < length) {
+        const newHash = new Uint8Array(await crypto.subtle.digest('SHA-256', keyMaterial))
+        const combined = new Uint8Array(keyMaterial.length + newHash.length)
+        combined.set(keyMaterial)
+        combined.set(newHash, keyMaterial.length)
+        keyMaterial = combined
+    }
+
+    return keyMaterial.slice(0, length)
+}
+
+export async function deriveKeyAndIV(
+    keyPhrase: string | Uint8Array,
+): Promise<{ key: Uint8Array; iv: Uint8Array }> {
+    let keyBuffer: Uint8Array
+
+    if (typeof keyPhrase === 'string') {
+        const encoder = new TextEncoder()
+        keyBuffer = encoder.encode(keyPhrase)
+    } else {
+        keyBuffer = keyPhrase
+    }
+
+    const keyMaterial = await getExtendedKeyMaterial(keyBuffer, 32 + 12) // 32 bytes for key, 12 bytes for IV
+
+    const key = keyMaterial.slice(0, 32) // AES-256 key
+    const iv = keyMaterial.slice(32, 32 + 12) // AES-GCM IV
+
+    return { key, iv }
+}
+
+export async function encryptAESGCM(
+    data: Uint8Array,
+    key?: Uint8Array,
+    iv?: Uint8Array,
+): Promise<{ ciphertext: Uint8Array; iv: Uint8Array; secretKey: Uint8Array }> {
+    if (!data || data.length === 0) {
+        throw new Error('Cannot encrypt undefined or empty data')
+    }
+
+    if (!key) {
+        key = new Uint8Array(32)
+        crypto.getRandomValues(key)
+    } else if (key.length !== 32) {
+        throw new Error('Invalid key length. AES-256-GCM requires a 32-byte key.')
+    }
+
+    if (!iv) {
+        iv = new Uint8Array(12)
+        crypto.getRandomValues(iv)
+    } else if (iv.length !== 12) {
+        throw new Error('Invalid IV length. AES-256-GCM requires a 12-byte IV.')
+    }
+
+    const cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'AES-GCM' }, false, [
+        'encrypt',
+    ])
+
+    const encryptedBuffer = await crypto.subtle.encrypt(
+        {
+            name: 'AES-GCM',
+            iv: iv,
+        },
+        cryptoKey,
+        data,
+    )
+
+    const ciphertext = new Uint8Array(encryptedBuffer)
+
+    return { ciphertext, iv, secretKey: key }
+}
+
+export async function decryptAESGCM(
+    data: Uint8Array | string,
+    key: Uint8Array,
+    iv: Uint8Array,
+): Promise<Uint8Array> {
+    if (key.length !== 32) {
+        throw new Error('Invalid key length. AES-256-GCM requires a 32-byte key.')
+    }
+
+    if (iv.length !== 12) {
+        throw new Error('Invalid IV length. AES-256-GCM requires a 12-byte IV.')
+    }
+
+    let dataBuffer: Uint8Array
+    if (typeof data === 'string') {
+        dataBuffer = base64ToUint8Array(data)
+    } else {
+        dataBuffer = data
+    }
+
+    const cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'AES-GCM' }, false, [
+        'decrypt',
+    ])
+
+    const decryptedBuffer = await crypto.subtle.decrypt(
+        {
+            name: 'AES-GCM',
+            iv: iv,
+        },
+        cryptoKey,
+        dataBuffer,
+    )
+
+    return new Uint8Array(decryptedBuffer)
+}
+
+export async function decryptDerivedAESGCM(
+    keyPhrase: string,
+    encryptedData: EncryptedData,
+): Promise<Uint8Array> {
+    if (encryptedData.algorithm !== AES_GCM_DERIVED_ALGORITHM) {
+        throwWithCode(`${encryptedData.algorithm}" algorithm not implemented`, Err.UNIMPLEMENTED)
+    }
+    const { key, iv } = await deriveKeyAndIV(keyPhrase)
+    const ciphertext = base64ToUint8Array(encryptedData.ciphertext)
+    return decryptAESGCM(ciphertext, key, iv)
+}

--- a/packages/sdk-crypto/tsconfig.json
+++ b/packages/sdk-crypto/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        // Why??
+        "incremental": false,
+        "composite": false,
+        "moduleResolution": "bundler",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "experimentalDecorators": true,
+        "types": ["vitest/globals"]
+    },
+    "include": ["./src/**/*"]
+}

--- a/packages/sdk-crypto/tsdown.config.ts
+++ b/packages/sdk-crypto/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/node/index.ts', 'src/web/index.ts', 'src/common/index.ts'],
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    format: ['cjs', 'esm'],
+    dts: true,
+})

--- a/packages/sdk-crypto/vitest.config.ts
+++ b/packages/sdk-crypto/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        projects: [
+            {
+                test: {
+                    include: ['src/web/**/*.test.ts'],
+                    name: 'web',
+                    environment: 'happy-dom',
+                },
+            },
+            {
+                test: {
+                    include: ['src/node/**/*.test.ts'],
+                    name: 'node',
+                    environment: 'node',
+                },
+            },
+        ],
+    },
+})

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,7 @@
         "@towns-protocol/encryption": "workspace:^",
         "@towns-protocol/generated": "workspace:^",
         "@towns-protocol/proto": "workspace:^",
+        "@towns-protocol/sdk-crypto": "workspace:^",
         "@towns-protocol/web3": "workspace:^",
         "browser-or-node": "^3.0.0",
         "debug": "^4.3.4",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -174,7 +174,12 @@ import { SyncState } from './syncedStreamsLoop'
 import { SyncedStream } from './syncedStream'
 import { SyncedStreamsExtension } from './syncedStreamsExtension'
 import { SignerContext } from './signerContext'
-import { decryptAESGCM, deriveKeyAndIV, encryptAESGCM, uint8ArrayToBase64 } from './crypto_utils'
+import {
+    decryptAESGCM,
+    deriveKeyAndIV,
+    encryptAESGCM,
+    uint8ArrayToBase64,
+} from '@towns-protocol/sdk-crypto'
 import { makeTags, makeTipTags, makeTransferTags } from './tags'
 import { TipEventObject } from '@towns-protocol/generated/dev/typings/ITipping'
 import { StreamsView } from './streams-view/streamsView'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,7 +4,6 @@
 export * from './check'
 export * from './client'
 export * from './clientDecryptionExtensions'
-export * from './crypto_utils'
 export * from './encryptedContentTypes'
 export * from './id'
 export * from './makeAuthenticationRpcClient'

--- a/packages/sdk/src/notificationService.ts
+++ b/packages/sdk/src/notificationService.ts
@@ -13,7 +13,7 @@ export class NotificationService {
         userId: Uint8Array,
         serviceUrl: string,
         opts: RpcOptions | undefined,
-        getSignature: (hash: Buffer) => Promise<Uint8Array>,
+        getSignature: (hash: Uint8Array) => Promise<Uint8Array>,
         extraFinishAuthParams: Record<string, any>,
     ) {
         const authenticationRpcClient = makeAuthenticationRpcClient(serviceUrl, opts)

--- a/packages/sdk/src/streamStateView_Space.ts
+++ b/packages/sdk/src/streamStateView_Space.ts
@@ -21,7 +21,7 @@ import { check, throwWithCode } from '@towns-protocol/dlog'
 import { logNever } from './check'
 import { contractAddressFromSpaceId, isDefaultChannelId, streamIdAsString } from './id'
 import { fromBinary } from '@bufbuild/protobuf'
-import { decryptDerivedAESGCM } from './crypto_utils'
+import { decryptDerivedAESGCM } from '@towns-protocol/sdk-crypto'
 import { bytesToHex } from 'ethereum-cryptography/utils'
 
 export type ParsedChannelProperties = {

--- a/packages/sdk/src/streamStateView_UserMetadata.ts
+++ b/packages/sdk/src/streamStateView_UserMetadata.ts
@@ -17,7 +17,7 @@ import { logNever } from './check'
 import { UserDevice } from '@towns-protocol/encryption'
 import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 import { getUserIdFromStreamId } from './id'
-import { decryptDerivedAESGCM } from './crypto_utils'
+import { decryptDerivedAESGCM } from '@towns-protocol/sdk-crypto'
 import { fromBinary } from '@bufbuild/protobuf'
 
 export class StreamStateView_UserMetadata extends StreamStateView_AbstractContent {

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -53,7 +53,7 @@ import {
     make_MemberPayload_KeyFulfillment,
     make_MemberPayload_KeySolicitation,
 } from '../../types'
-import { deriveKeyAndIV } from '../../crypto_utils'
+import { deriveKeyAndIV } from '@towns-protocol/sdk-crypto'
 import { nanoid } from 'nanoid'
 import { RiverTimelineEvent, TimelineEvent } from '../../sync-agent/timeline/models/timeline-types'
 

--- a/packages/sdk/src/tests/multi_ne/media.test.ts
+++ b/packages/sdk/src/tests/multi_ne/media.test.ts
@@ -6,7 +6,7 @@ import { makeTestClient, makeUniqueSpaceStreamId } from '../testUtils'
 import { Client } from '../../client'
 import { makeUniqueChannelStreamId, makeDMStreamId, streamIdAsString } from '../../id'
 import { CreationCookie, CreationCookieSchema, InfoRequestSchema } from '@towns-protocol/proto'
-import { deriveKeyAndIV, encryptAESGCM } from '../../crypto_utils'
+import { deriveKeyAndIV, encryptAESGCM } from '@towns-protocol/sdk-crypto'
 import { create } from '@bufbuild/protobuf'
 
 describe('mediaTests', () => {

--- a/packages/sdk/src/tests/multi_ne/space.test.ts
+++ b/packages/sdk/src/tests/multi_ne/space.test.ts
@@ -14,7 +14,7 @@ import {
     MembershipOp,
     PlainMessage,
 } from '@towns-protocol/proto'
-import { deriveKeyAndIV } from '../../crypto_utils'
+import { deriveKeyAndIV } from '@towns-protocol/sdk-crypto'
 import { nanoid } from 'nanoid'
 import { create } from '@bufbuild/protobuf'
 import { unpackStream } from '../../sign'

--- a/packages/sdk/src/tests/unit/crypto_utils.test.ts
+++ b/packages/sdk/src/tests/unit/crypto_utils.test.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from 'crypto'
-import { deriveKeyAndIV, encryptAESGCM } from '../../crypto_utils'
+import { deriveKeyAndIV, encryptAESGCM } from '@towns-protocol/sdk-crypto'
 
 describe('crypto_utils', () => {
     test('derivedKeyAndIV', async () => {

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -32,6 +32,7 @@
 		"@towns-protocol/generated": "workspace:^",
 		"@towns-protocol/proto": "workspace:^",
 		"@towns-protocol/sdk": "workspace:^",
+		"@towns-protocol/sdk-crypto": "workspace:^",
 		"@towns-protocol/web3": "workspace:^",
 		"dd-trace": "^5.19.0",
 		"dotenv": "^16.4.5",

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -3,12 +3,12 @@ import {
 	StreamRpcClient,
 	StreamStateView,
 	UnpackEnvelopeOpts,
-	decryptAESGCM,
 	makeStreamRpcClient,
 	streamIdAsBytes,
 	streamIdAsString,
 	unpackStream,
 } from '@towns-protocol/sdk'
+import { decryptAESGCM } from '@towns-protocol/sdk-crypto'
 import { filetypemime } from 'magic-bytes.js'
 import { FastifyBaseLogger } from 'fastify'
 import { LRUCache } from 'lru-cache'

--- a/packages/stream-metadata/tests/testUtils.ts
+++ b/packages/stream-metadata/tests/testUtils.ts
@@ -9,7 +9,8 @@ import {
 	MediaInfo,
 	MediaInfoSchema,
 } from '@towns-protocol/proto'
-import { Client, encryptAESGCM, streamIdAsString } from '@towns-protocol/sdk'
+import { Client, streamIdAsString } from '@towns-protocol/sdk'
+import { encryptAESGCM } from '@towns-protocol/sdk-crypto'
 import {
 	CreateLegacySpaceParams,
 	ETH_ADDRESS,

--- a/packages/stream-metadata/tsconfig.json
+++ b/packages/stream-metadata/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"module": "ESNext",
 		"target": "ES2022",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -26,7 +26,7 @@
 
         /* Modules */
         "module": "esnext" /* Specify what module code is generated. */,
-        "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+        "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.27.5":
+  version: 7.27.5
+  resolution: "@babel/generator@npm:7.27.5"
+  dependencies:
+    "@babel/parser": ^7.27.5
+    "@babel/types": ^7.27.3
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.25
+    jsesc: ^3.0.2
+  checksum: f6d3bf70f6bfbc5df263a023200728c53161d7f3ee3607bd8b2222c8568b6dd604ee490e305f0492a8225dac059ad75b4cc772b5cfd7d967e70360499d4d3701
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-compilation-targets@npm:7.24.7"
@@ -754,6 +767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 0a8464adc4b39b138aedcb443b09f4005d86207d7126e5e079177e05c3116107d856ec08282b365e9a79a9872f40f4092a6127f8d74c8a01c1ef789dacfc25d6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
@@ -765,6 +785,13 @@ __metadata:
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
   checksum: 5b85918cb1a92a7f3f508ea02699e8d2422fe17ea8e82acd445006c0ef7520fbf48e3dbcdaf7b0a1d571fc3a2715a29719e5226636cb6042e15fe6ed2a590944
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-identifier@npm:7.27.1"
+  checksum: 3c7e8391e59d6c85baeefe9afb86432f2ab821c6232b00ea9082a51d3e7e95a2f3fb083d74dc1f49ac82cf238e1d2295dafcb001f7b0fab479f3f56af5eaaa47
   languageName: node
   linkType: hard
 
@@ -821,6 +848,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: fc9d2c4c8712f89672edc55c0dc5cf640dcec715b56480f111f85c2bc1d507e251596e4110d65796690a96ac37a4b60432af90b3e97bb47e69d4ef83872dbbd6
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.27.3, @babel/parser@npm:^7.27.5":
+  version: 7.27.5
+  resolution: "@babel/parser@npm:7.27.5"
+  dependencies:
+    "@babel/types": ^7.27.3
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 16f00a12895522c1682f1f047332010e129ba517add3a2db347a658e02f60434fc38f9105a9d6ec3fd6bfb5d1b0b70d88585c1f10e06e2b58fba29004a42d648
   languageName: node
   linkType: hard
 
@@ -923,6 +961,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.24.7
     to-fast-properties: ^2.0.0
   checksum: 3e4437fced97e02982972ce5bebd318c47d42c9be2152c0fd28c6f786cc74086cc0a8fb83b602b846e41df37f22c36254338eada1a47ef9d8a1ec92332ca3ea8
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.27.3, @babel/types@npm:^7.27.6":
+  version: 7.27.6
+  resolution: "@babel/types@npm:7.27.6"
+  dependencies:
+    "@babel/helper-string-parser": ^7.27.1
+    "@babel/helper-validator-identifier": ^7.27.1
+  checksum: c3bd0984d892b0edec38fd12cf63f620bb52fba8187ec7cbe2d1aff5bee5e185e0fd86a3fb90b4d8f18b072113d07901476d0e39f58d5c988db14b231a6ea735
   languageName: node
   linkType: hard
 
@@ -1792,6 +1840,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "@emnapi/core@npm:1.4.3"
+  dependencies:
+    "@emnapi/wasi-threads": 1.0.2
+    tslib: ^2.4.0
+  checksum: 1c757d380b3cecec637a2eccfb31b770b995060f695d1e15b29a86e2038909a24152947ef6e4b6586759e6716148ff17f40e51367d1b79c9a3e1b6812537bdf4
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:^1.2.0":
   version: 1.3.1
   resolution: "@emnapi/runtime@npm:1.3.1"
@@ -1810,12 +1868,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "@emnapi/runtime@npm:1.4.3"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: ff2074809638ed878e476ece370c6eae7e6257bf029a581bb7a290488d8f2a08c420a65988c7f03bfc6bb689218f0cd995d2f935bd182150b357fc2341142f4f
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.0.1":
   version: 1.0.1
   resolution: "@emnapi/wasi-threads@npm:1.0.1"
   dependencies:
     tslib: ^2.4.0
   checksum: e154880440ff9bfe67b417f30134f0ff6fee28913dbf4a22de2e67dda5bf5b51055647c5d1565281df17ef5dfcc89256546bdf9b8ccfd07e07566617e7ce1498
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@emnapi/wasi-threads@npm:1.0.2"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: c289cd3d0e26f11de23429a4abc7f99927917c0871d5a22637cbb75170f2b58d3a42e80d76dea89d054e529f79e35cdc953324819a7f990305d0db2897fa5fab
   languageName: node
   linkType: hard
 
@@ -4367,7 +4443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
@@ -5148,6 +5224,17 @@ __metadata:
   version: 3.0.2
   resolution: "@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^0.2.10":
+  version: 0.2.11
+  resolution: "@napi-rs/wasm-runtime@npm:0.2.11"
+  dependencies:
+    "@emnapi/core": ^1.4.3
+    "@emnapi/runtime": ^1.4.3
+    "@tybys/wasm-util": ^0.9.0
+  checksum: 7c614625784ab467cc7b36b4d7384854891469d0ddce8ca831d28b2abdf8cb3f014d8e8a181c98000719effb46950ab9134b245ab9a8044ad7a7da725b40f858
   languageName: node
   linkType: hard
 
@@ -6042,6 +6129,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/runtime@npm:=0.72.2":
+  version: 0.72.2
+  resolution: "@oxc-project/runtime@npm:0.72.2"
+  checksum: e761527ca87986709c828a50734ec4f8b25b8e7539857c0cc049c7a939d33f6c73a38d52a412d6e2ef14575061940409537d4beadce819ad49173ae05699a7e4
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.72.2":
+  version: 0.72.2
+  resolution: "@oxc-project/types@npm:0.72.2"
+  checksum: 34ced21a1d4acbd7a372e7e66ad7bcb87b561427666c0fbe0c937516b347ad584f685e4ed3480da124083ee099020fdaaecf0ce33e50442030690c69d6086764
+  languageName: node
+  linkType: hard
+
 "@parcel/watcher-android-arm64@npm:2.4.1":
   version: 2.4.1
   resolution: "@parcel/watcher-android-arm64@npm:2.4.1"
@@ -6350,6 +6451,15 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: dbfae1f0a3cb5ee07711eb0247d5f61039989094858989cede3f86bfef59224c72df17a1b898266e5ba7c6a7032ab647c59ad3df8f76771ef65d8974a3f93f19
+  languageName: node
+  linkType: hard
+
+"@quansync/fs@npm:^0.1.1":
+  version: 0.1.3
+  resolution: "@quansync/fs@npm:0.1.3"
+  dependencies:
+    quansync: ^0.2.10
+  checksum: 049f410f3834ea79b2ab748d9486fa52c238df9ca3170320d9d5a81f64c78f9612b8e78df4c0922bd2a38d4a65a42cf732f4e52b5ec4679b5a1d422aaa998158
   languageName: node
   linkType: hard
 
@@ -7154,6 +7264,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-arm64@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.11-commit.f051675"
+  dependencies:
+    "@napi-rs/wasm-runtime": ^0.2.10
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.11-commit.f051675"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.11-commit.f051675"
+  checksum: b9ddade88cba133c64d9c860336e128147ac5f5e3b1c87527092878b996a4ca1e98c670c44a9c1d6ce2599723891836727c9b5920bf8b5f8cedda4262118dbe3
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-inject@npm:^5.0.5":
   version: 5.0.5
   resolution: "@rollup/plugin-inject@npm:5.0.5"
@@ -7171,18 +7374,18 @@ __metadata:
   linkType: hard
 
 "@rollup/pluginutils@npm:^5.0.1":
-  version: 5.1.0
-  resolution: "@rollup/pluginutils@npm:5.1.0"
+  version: 5.1.4
+  resolution: "@rollup/pluginutils@npm:5.1.4"
   dependencies:
     "@types/estree": ^1.0.0
     estree-walker: ^2.0.2
-    picomatch: ^2.3.1
+    picomatch: ^4.0.2
   peerDependencies:
     rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
   peerDependenciesMeta:
     rollup:
       optional: true
-  checksum: 3cc5a6d91452a6eabbfd1ae79b4dd1f1e809d2eecda6e175deb784e75b0911f47e9ecce73f8dd315d6a8b3f362582c91d3c0f66908b6ced69345b3cbe28f8ce8
+  checksum: dc0294580effbf68965ed7939c9e469b8c8847b59842e4691fd10d0a8d0b178600bd912694c409ae33600c9059efce72e96f25917cff983afd57f092a7aeb8d2
   languageName: node
   linkType: hard
 
@@ -9021,6 +9224,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@towns-protocol/sdk-crypto@workspace:^, @towns-protocol/sdk-crypto@workspace:packages/sdk-crypto":
+  version: 0.0.0-use.local
+  resolution: "@towns-protocol/sdk-crypto@workspace:packages/sdk-crypto"
+  dependencies:
+    "@bufbuild/protobuf": ^2.2.2
+    "@towns-protocol/dlog": "workspace:^"
+    "@towns-protocol/encryption": "workspace:^"
+    "@towns-protocol/proto": "workspace:^"
+    "@types/node": ^20.14.8
+    "@typescript-eslint/eslint-plugin": ^8.29.0
+    "@typescript-eslint/parser": ^8.29.0
+    eslint: ^8.57.1
+    eslint-import-resolver-typescript: ^4.3.2
+    eslint-plugin-import-x: ^4.10.2
+    eslint-plugin-tsdoc: ^0.3.0
+    happy-dom: ^15.11.7
+    tsdown: ^0.12.3
+    typescript: ^5.8.2
+    vitest: 3.2.3
+  languageName: unknown
+  linkType: soft
+
 "@towns-protocol/sdk@workspace:^, @towns-protocol/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local
   resolution: "@towns-protocol/sdk@workspace:packages/sdk"
@@ -9036,6 +9261,7 @@ __metadata:
     "@towns-protocol/encryption": "workspace:^"
     "@towns-protocol/generated": "workspace:^"
     "@towns-protocol/proto": "workspace:^"
+    "@towns-protocol/sdk-crypto": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
     "@types/debug": ^4.1.8
     "@types/lodash": ^4.14.186
@@ -9083,6 +9309,7 @@ __metadata:
     "@towns-protocol/prettier-config": "workspace:^"
     "@towns-protocol/proto": "workspace:^"
     "@towns-protocol/sdk": "workspace:^"
+    "@towns-protocol/sdk-crypto": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
     "@types/node": ^20.14.8
     "@types/uuid": ^10.0.0
@@ -11329,6 +11556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansis@npm:^4.0.0, ansis@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ansis@npm:4.1.0"
+  checksum: ef795cb9d33348cab1344e02701ab9f492e9bf6b2f0b49e7a6ec2ea2cf8b80bf6c8def4e741a77a1e6a8422dda9ebd1a823d9cee6eca07edc70c49d77b752e7a
+  languageName: node
+  linkType: hard
+
 "antlr4@npm:^4.13.1-patch-1":
   version: 4.13.1
   resolution: "antlr4@npm:4.13.1"
@@ -11625,6 +11859,16 @@ __metadata:
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
   checksum: a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
+  languageName: node
+  linkType: hard
+
+"ast-kit@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "ast-kit@npm:2.1.0"
+  dependencies:
+    "@babel/parser": ^7.27.3
+    pathe: ^2.0.3
+  checksum: b48e905ea64dcb8a5f2c79f993ab4b3c4bd43acb75c662f51548dffdf9b0a9ae7d55d994b9c9e9515024bcd30c885dbf0506ab1df99f849f102d3629204afbcc
   languageName: node
   linkType: hard
 
@@ -11962,6 +12206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"birpc@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "birpc@npm:2.3.0"
+  checksum: a8e28ba8a2aa6b8723e5449a89ce7b36eab31c8ca6c9fde5cc683942fa2a4397a2580ed4fd9c322f04b4b8ab7ff55364ac1fcbef38d674dfd3df3233ac328b5c
+  languageName: node
+  linkType: hard
+
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -11998,10 +12249,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
-  version: 4.12.0
-  resolution: "bn.js@npm:4.12.0"
-  checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0":
+  version: 4.12.2
+  resolution: "bn.js@npm:4.12.2"
+  checksum: dd224afda6f5a7d15f2fe5154e1a1c245576a725584ea1852c8c42f9748dfe847bc63a48b2885360023389a24cfebb3653ca97f4c69742f3c22bc63da6565030
   languageName: node
   linkType: hard
 
@@ -12012,7 +12263,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.0.0, bn.js@npm:^5.1.2, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+"bn.js@npm:^4.11.9":
+  version: 4.12.0
+  resolution: "bn.js@npm:4.12.0"
+  checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.1.2, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3
@@ -12143,7 +12401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-cipher@npm:^1.0.0":
+"browserify-cipher@npm:^1.0.1":
   version: 1.0.1
   resolution: "browserify-cipher@npm:1.0.1"
   dependencies:
@@ -12167,16 +12425,17 @@ __metadata:
   linkType: hard
 
 "browserify-rsa@npm:^4.0.0, browserify-rsa@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "browserify-rsa@npm:4.1.0"
+  version: 4.1.1
+  resolution: "browserify-rsa@npm:4.1.1"
   dependencies:
-    bn.js: ^5.0.0
-    randombytes: ^2.0.1
-  checksum: 155f0c135873efc85620571a33d884aa8810e40176125ad424ec9d85016ff105a07f6231650914a760cca66f29af0494087947b7be34880dd4599a0cd3c38e54
+    bn.js: ^5.2.1
+    randombytes: ^2.1.0
+    safe-buffer: ^5.2.1
+  checksum: 2628508646331791c29312bbf274c076a237437a17178ea9bdc75c577fb4164a0da0b137deaadf6ade623701332377c5c2ceb0ff6f991c744a576e790ec95852
   languageName: node
   linkType: hard
 
-"browserify-sign@npm:^4.0.0":
+"browserify-sign@npm:^4.2.3":
   version: 4.2.3
   resolution: "browserify-sign@npm:4.2.3"
   dependencies:
@@ -12474,7 +12733,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+  checksum: b2863d74fcf2a6948221f65d95b91b4b2d90cfe8927650b506141e669f7d5de65cea191bf788838bc40d13846b7886c5bc5c84ab96c3adbcf88ad69a72fcdc6b
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.0
+    es-define-property: ^1.0.0
+    get-intrinsic: ^1.2.4
+    set-function-length: ^1.2.2
+  checksum: aa2899bce917a5392fd73bd32e71799c37c0b7ab454e0ed13af7f6727549091182aade8bbb7b55f304a5bc436d543241c14090fb8a3137e9875e23f444f4f5a9
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
   version: 1.0.7
   resolution: "call-bind@npm:1.0.7"
   dependencies:
@@ -12484,6 +12765,16 @@ __metadata:
     get-intrinsic: ^1.2.4
     set-function-length: ^1.2.1
   checksum: 295c0c62b90dd6522e6db3b0ab1ce26bdf9e7404215bda13cfee25b626b5ff1a7761324d58d38b1ef1607fc65aca2d06e44d2e18d0dfc6c14b465b00d8660029
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.2
+    get-intrinsic: ^1.3.0
+  checksum: 2f6399488d1c272f56306ca60ff696575e2b7f31daf23bc11574798c84d9f2759dceb0cb1f471a85b77f28962a7ac6411f51d283ea2e45319009a19b6ccab3b2
   languageName: node
   linkType: hard
 
@@ -12753,6 +13044,15 @@ __metadata:
     fsevents:
       optional: true
   checksum: d2f29f499705dcd4f6f3bbed79a9ce2388cf530460122eed3b9c48efeab7a4e28739c6551fd15bec9245c6b9eeca7a32baa64694d64d9b6faeb74ddb8c4a413d
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: ^4.0.1
+  checksum: a8765e452bbafd04f3f2fad79f04222dd65f43161488bb6014a41099e6ca18d166af613d59a90771908c1c823efa3f46ba36b86ac50b701c20c1b9908c5fe36e
   languageName: node
   linkType: hard
 
@@ -13558,7 +13858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-ecdh@npm:^4.0.0":
+"create-ecdh@npm:^4.0.4":
   version: 4.0.4
   resolution: "create-ecdh@npm:4.0.4"
   dependencies:
@@ -13581,7 +13881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-hmac@npm:^1.1.0, create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
+"create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
   version: 1.1.7
   resolution: "create-hmac@npm:1.1.7"
   dependencies:
@@ -13682,22 +13982,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0":
-  version: 3.12.0
-  resolution: "crypto-browserify@npm:3.12.0"
+"crypto-browserify@npm:^3.12.1":
+  version: 3.12.1
+  resolution: "crypto-browserify@npm:3.12.1"
   dependencies:
-    browserify-cipher: ^1.0.0
-    browserify-sign: ^4.0.0
-    create-ecdh: ^4.0.0
-    create-hash: ^1.1.0
-    create-hmac: ^1.1.0
-    diffie-hellman: ^5.0.0
-    inherits: ^2.0.1
-    pbkdf2: ^3.0.3
-    public-encrypt: ^4.0.0
-    randombytes: ^2.0.0
-    randomfill: ^1.0.3
-  checksum: c1609af82605474262f3eaa07daa0b2140026bd264ab316d4bf1170272570dbe02f0c49e29407fe0d3634f96c507c27a19a6765fb856fed854a625f9d15618e2
+    browserify-cipher: ^1.0.1
+    browserify-sign: ^4.2.3
+    create-ecdh: ^4.0.4
+    create-hash: ^1.2.0
+    create-hmac: ^1.1.7
+    diffie-hellman: ^5.0.3
+    hash-base: ~3.0.4
+    inherits: ^2.0.4
+    pbkdf2: ^3.1.2
+    public-encrypt: ^4.0.3
+    randombytes: ^2.1.0
+    randomfill: ^1.0.4
+  checksum: 4e643dd5acfff80fbe2cc567feb75a22d726cc4df34772c988f326976c3c1ee1f8a611a33498dab11568cff3e134f0bd44a0e1f4c216585e5877ab5327cdb6fc
   languageName: node
   linkType: hard
 
@@ -14430,7 +14731,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diffie-hellman@npm:^5.0.0":
+"diff@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "diff@npm:8.0.2"
+  checksum: 0d5556beff9aa688117ef79b1c88eb663df9959bc59946122330932c01e8db5529f914dcc87bf00fd1fecbca75731e6be7c8fabe1e34e10d6557e0536b7c856c
+  languageName: node
+  linkType: hard
+
+"diffie-hellman@npm:^5.0.3":
   version: 5.0.3
   resolution: "diffie-hellman@npm:5.0.3"
   dependencies:
@@ -14509,10 +14817,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domain-browser@npm:^4.22.0":
-  version: 4.23.0
-  resolution: "domain-browser@npm:4.23.0"
-  checksum: 95b772f5fa88300240694380e06e03868573acdf86ca392a58c78602d6536dca2097ad2469a1500bd23a1329b09992de846e0b66c364cbf5711a7fee3ee5dac9
+"domain-browser@npm:4.22.0":
+  version: 4.22.0
+  resolution: "domain-browser@npm:4.22.0"
+  checksum: e7ce1c19073e17dec35cfde050a3ddaac437d3ba8b870adabf9d5682e665eab3084df05de432dedf25b34303f0a2c71ac30f1cdba61b1aea018047b10de3d988
   languageName: node
   linkType: hard
 
@@ -14667,6 +14975,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dts-resolver@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "dts-resolver@npm:2.1.1"
+  peerDependencies:
+    oxc-resolver: ">=11.0.0"
+  peerDependenciesMeta:
+    oxc-resolver:
+      optional: true
+  checksum: 3e41479ebc8b845cba87eb14df2b52bcccb9e5b384a522a2ff3f922e6f042911928db43b13db505386fa312a787862e1c53e51ed5e2602c28ed6b145bb43eb19
+  languageName: node
+  linkType: hard
+
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.1
+    es-errors: ^1.3.0
+    gopd: ^1.2.0
+  checksum: 149207e36f07bd4941921b0ca929e3a28f1da7bd6b6ff8ff7f4e2f2e460675af4576eeba359c635723dc189b64cdd4787e0255897d5b135ccc5d15cb8685fc90
+  languageName: node
+  linkType: hard
+
 "duplexer@npm:^0.1.1":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
@@ -14752,7 +15083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.6.1, elliptic@npm:^6.5.2":
+"elliptic@npm:6.6.1, elliptic@npm:^6.5.2, elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -14764,21 +15095,6 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: 27b14a52f68bbbc0720da259f712cb73e953f6d2047958cd02fb0d0ade2e83849dc39fb4af630889c67df8817e24237428cf59c4f4c07700f755b401149a7375
-  languageName: node
-  linkType: hard
-
-"elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
-  version: 6.5.6
-  resolution: "elliptic@npm:6.5.6"
-  dependencies:
-    bn.js: ^4.11.9
-    brorand: ^1.1.0
-    hash.js: ^1.0.0
-    hmac-drbg: ^1.0.1
-    inherits: ^2.0.4
-    minimalistic-assert: ^1.0.1
-    minimalistic-crypto-utils: ^1.0.1
-  checksum: 213d778ccfe99ec8f0f871b1cc96a10ac3763d9175215d0a9dc026f291e5f50fea6f635e4e47b4506f9ada25aeb703bd807d8737b880dbb24d092a3001c6d97d
   languageName: node
   linkType: hard
 
@@ -14815,6 +15131,13 @@ __metadata:
   version: 2.4.0
   resolution: "emojilib@npm:2.4.0"
   checksum: ea241c342abda5a86ffd3a15d8f4871a616d485f700e03daea38c6ce38205847cea9f6ff8d5e962c00516b004949cc96c6e37b05559ea71a0a496faba53b56da
+  languageName: node
+  linkType: hard
+
+"empathic@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "empathic@npm:1.1.0"
+  checksum: 1e41763802f14e5fa2522063f8f93e161c64916698f39e493a3e274356e39aa6f60d60f33063c92f9d5c5426fd33d9cb33baed2885a194648254181ce5495a9c
   languageName: node
   linkType: hard
 
@@ -15037,6 +15360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 0512f4e5d564021c9e3a644437b0155af2679d10d80f21adaf868e64d30efdfbd321631956f20f42d655fedb2e3a027da479fad3fa6048f768eb453a80a5f80a
+  languageName: node
+  linkType: hard
+
 "es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
@@ -15079,6 +15409,15 @@ __metadata:
   dependencies:
     es-errors: ^1.3.0
   checksum: 26f0ff78ab93b63394e8403c353842b2272836968de4eafe97656adfb8a7c84b9099bf0fe96ed58f4a4cddc860f6e34c77f91649a58a5daa4a9c40b902744e3c
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: ^1.3.0
+  checksum: 214d3767287b12f36d3d7267ef342bbbe1e89f899cfd67040309fc65032372a8e60201410a99a1645f2f90c1912c8c49c8668066f6bdd954bcd614dda2e3da97
   languageName: node
   linkType: hard
 
@@ -17500,6 +17839,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.2
+    es-define-property: ^1.0.1
+    es-errors: ^1.3.0
+    es-object-atoms: ^1.1.1
+    function-bind: ^1.1.2
+    get-proto: ^1.0.1
+    gopd: ^1.2.0
+    has-symbols: ^1.1.0
+    hasown: ^2.0.2
+    math-intrinsics: ^1.1.0
+  checksum: 301008e4482bb9a9cb49e132b88fee093bff373b4e6def8ba219b1e96b60158a6084f273ef5cafe832e42cd93462f4accb46a618d35fe59a2b507f2388c5b79d
+  languageName: node
+  linkType: hard
+
 "get-nonce@npm:^1.0.0":
   version: 1.0.1
   resolution: "get-nonce@npm:1.0.1"
@@ -17532,6 +17889,16 @@ __metadata:
   version: 5.1.1
   resolution: "get-port@npm:5.1.1"
   checksum: 0162663ffe5c09e748cd79d97b74cd70e5a5c84b760a475ce5767b357fb2a57cb821cee412d646aa8a156ed39b78aab88974eddaa9e5ee926173c036c0713787
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: ^1.0.1
+    es-object-atoms: ^1.0.0
+  checksum: 4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -17589,6 +17956,15 @@ __metadata:
   dependencies:
     resolve-pkg-maps: ^1.0.0
   checksum: cebf14d38ecaa9a1af25fc3f56317402a4457e7e20f30f52a0ab98b4c85962a259f75065e483824f73a1ce4a8e4926c149ead60f0619842b8cd13b94e15fbdec
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.10.1":
+  version: 4.10.1
+  resolution: "get-tsconfig@npm:4.10.1"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: 22925debda6bd0992171a44ee79a22c32642063ba79534372c4d744e0c9154abe2c031659da0fb86bc9e73fc56a3b76b053ea5d24ca3ac3da43d2e6f7d1c3c33
   languageName: node
   linkType: hard
 
@@ -17899,6 +18275,13 @@ __metadata:
   dependencies:
     get-intrinsic: ^1.1.3
   checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
+  languageName: node
+  linkType: hard
+
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: cc6d8e655e360955bdccaca51a12a474268f95bb793fc3e1f2bdadb075f28bfd1fd988dab872daf77a61d78cbaf13744bc8727a17cfb1d150d76047d805375f3
   languageName: node
   linkType: hard
 
@@ -18218,6 +18601,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: b2316c7302a0e8ba3aaba215f834e96c22c86f192e7310bdf689dd0e6999510c89b00fbc5742571507cebf25764d68c988b3a0da217369a73596191ac0ce694b
+  languageName: node
+  linkType: hard
+
 "has-tostringtag@npm:^1.0.0, has-tostringtag@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-tostringtag@npm:1.0.2"
@@ -18245,13 +18635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash-base@npm:~3.0":
-  version: 3.0.4
-  resolution: "hash-base@npm:3.0.4"
+"hash-base@npm:~3.0, hash-base@npm:~3.0.4":
+  version: 3.0.5
+  resolution: "hash-base@npm:3.0.5"
   dependencies:
-    inherits: ^2.0.1
-    safe-buffer: ^5.0.1
-  checksum: 878465a0dfcc33cce195c2804135352c590d6d10980adc91a9005fd377e77f2011256c2b7cfce472e3f2e92d561d1bf3228d2da06348a9017ce9a258b3b49764
+    inherits: ^2.0.4
+    safe-buffer: ^5.2.1
+  checksum: 6a82675a5de2ea9347501bbe655a2334950c7ec972fd9810ae9529e06aeab8f7e8ef68fc2112e5e6f0745561a7e05326efca42ad59bb5fd116537f5f8b0a216d
   languageName: node
   linkType: hard
 
@@ -18713,6 +19103,13 @@ __metadata:
   version: 4.7.4
   resolution: "hono@npm:4.7.4"
   checksum: fcc4b48eaa51572f6db6b102a2ce9c69ead6c47cba9c4e9e816c5741894dc210913f29379967005591d43884ea8ad56a66859c4126bf0eeddc275d64fcb9af1c
+  languageName: node
+  linkType: hard
+
+"hookable@npm:^5.5.3":
+  version: 5.5.3
+  resolution: "hookable@npm:5.5.3"
+  checksum: df659977888398649b6ef8c4470719e7e8384a1d939a6587e332e86fd55b3881806e2f8aaebaabdb4f218f74b83b98f2110e143df225e16d62a39dc271e7e288
   languageName: node
   linkType: hard
 
@@ -19983,6 +20380,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jiti@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "jiti@npm:2.4.2"
+  bin:
+    jiti: lib/jiti-cli.mjs
+  checksum: c6c30c7b6b293e9f26addfb332b63d964a9f143cdd2cf5e946dbe5143db89f7c1b50ad9223b77fb1f6ddb0b9c5ecef995fea024ecf7d2861d285d779cde66e1e
+  languageName: node
+  linkType: hard
+
 "jju@npm:~1.4.0":
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
@@ -20067,6 +20473,15 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 4dc190771129e12023f729ce20e1e0bfceac84d73a85bc3119f7f938843fe25a4aeccb54b6494dce26fcf263d815f5f31acdefac7cc9329efb8422a4f4d9fa9d
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "jsesc@npm:3.1.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 19c94095ea026725540c0d29da33ab03144f6bcf2d4159e4833d534976e99e0c09c38cefa9a575279a51fc36b31166f8d6d05c9fe2645d5f15851d690b41f17f
   languageName: node
   linkType: hard
 
@@ -20912,21 +21327,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.3":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
   dependencies:
     "@jridgewell/sourcemap-codec": ^1.5.0
   checksum: f4b4ed17c5ada64f77fc98491847302ebad64894a905c417c943840c0384662118c9b37f9f68bb86add159fa4749ff6f118c4627d69a470121b46731f8debc6d
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.3":
-  version: 0.30.10
-  resolution: "magic-string@npm:0.30.10"
-  dependencies:
-    "@jridgewell/sourcemap-codec": ^1.4.15
-  checksum: 456fd47c39b296c47dff967e1965121ace35417eab7f45a99e681e725b8661b48e1573c366ee67a27715025b3740773c46b088f115421c7365ea4ea6fa10d399
   languageName: node
   linkType: hard
 
@@ -21080,6 +21486,13 @@ __metadata:
   version: 1.2.6
   resolution: "match-all@npm:1.2.6"
   checksum: 3d4f16b8fd082f2fd10e362f4a8b71c62f8a767591b3db831ca2bdcf726337e9a64e4abc30e2ef053dc2bcfb875a9ed80bd78e006ad5ef11380a7158d0cb00e1
+  languageName: node
+  linkType: hard
+
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 0e513b29d120f478c85a70f49da0b8b19bc638975eca466f2eeae0071f3ad00454c621bf66e16dd435896c208e719fc91ad79bbfba4e400fe0b372e7c1c9c9a2
   languageName: node
   linkType: hard
 
@@ -23506,8 +23919,8 @@ __metadata:
   linkType: hard
 
 "node-stdlib-browser@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "node-stdlib-browser@npm:1.2.0"
+  version: 1.3.1
+  resolution: "node-stdlib-browser@npm:1.3.1"
   dependencies:
     assert: ^2.0.0
     browser-resolve: ^2.0.0
@@ -23516,8 +23929,8 @@ __metadata:
     console-browserify: ^1.1.0
     constants-browserify: ^1.0.0
     create-require: ^1.1.1
-    crypto-browserify: ^3.11.0
-    domain-browser: ^4.22.0
+    crypto-browserify: ^3.12.1
+    domain-browser: 4.22.0
     events: ^3.0.0
     https-browserify: ^1.0.0
     isomorphic-timers-promises: ^1.0.1
@@ -23533,10 +23946,10 @@ __metadata:
     string_decoder: ^1.0.0
     timers-browserify: ^2.0.4
     tty-browserify: 0.0.1
-    url: ^0.11.0
+    url: ^0.11.4
     util: ^0.12.4
     vm-browserify: ^1.0.1
-  checksum: fe491f0839319fd9bb95964c6f7da81fc7fde4c3ac9062aa367f19bc5a6060d0d9e423d3de4196cb51f8259d6aaf6cf380048c48a86eb3721c6223dd0dcc5bfd
+  checksum: 2012dbd84de654c60414c7d88817c1c8214324fa4e77f09395aa2a9d3722f49fafc0abf1643dc5998a96ebcee2409ee0d957ec4c4fd50d3ff5b40e031d1feb90
   languageName: node
   linkType: hard
 
@@ -23974,6 +24387,13 @@ __metadata:
   version: 1.13.1
   resolution: "object-inspect@npm:1.13.1"
   checksum: 7d9fa9221de3311dcb5c7c307ee5dc011cdd31dc43624b7c184b3840514e118e05ef0002be5388304c416c0eb592feb46e983db12577fc47e47d5752fbbfb61f
+  languageName: node
+  linkType: hard
+
+"object-inspect@npm:^1.13.3":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 582810c6a8d2ef988ea0a39e69e115a138dad8f42dd445383b394877e5816eb4268489f316a6f74ee9c4e0a984b3eab1028e3e79d62b1ed67c726661d55c7a8b
   languageName: node
   linkType: hard
 
@@ -24838,7 +25258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.17, pbkdf2@npm:^3.0.3, pbkdf2@npm:^3.1.2":
+"pbkdf2@npm:^3.0.17, pbkdf2@npm:^3.1.2":
   version: 3.1.2
   resolution: "pbkdf2@npm:3.1.2"
   dependencies:
@@ -25807,7 +26227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"public-encrypt@npm:^4.0.0":
+"public-encrypt@npm:^4.0.3":
   version: 4.0.3
   resolution: "public-encrypt@npm:4.0.3"
   dependencies:
@@ -25926,12 +26346,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.11.2":
-  version: 6.12.3
-  resolution: "qs@npm:6.12.3"
+"qs@npm:^6.12.3":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
   dependencies:
-    side-channel: ^1.0.6
-  checksum: 9a9228a623bc36d41648237667d7342fb8d64d1cfeb29e474b0c44591ba06ac507e2d726f60eca5af8dc420e5dd23370af408ef8c28e0405675c7187b736a693
+    side-channel: ^1.1.0
+  checksum: 189b52ad4e9a0da1a16aff4c58b2a554a8dad9bd7e287c7da7446059b49ca2e33a49e570480e8be406b87fccebf134f51c373cbce36c8c83859efa0c9b71d635
   languageName: node
   linkType: hard
 
@@ -25941,6 +26361,13 @@ __metadata:
   dependencies:
     side-channel: ^1.0.6
   checksum: aa761d99e65b6936ba2dd2187f2d9976afbcda38deb3ff1b3fe331d09b0c578ed79ca2abdde1271164b5be619c521ec7db9b34c23f49a074e5921372d16242d5
+  languageName: node
+  linkType: hard
+
+"quansync@npm:^0.2.10, quansync@npm:^0.2.8":
+  version: 0.2.10
+  resolution: "quansync@npm:0.2.10"
+  checksum: 0328dd30fc864722e1ebd9cc779ca2c36005ac7552f52f1b318eb6cc225382c0ee337d021a086daa113efcfeec8d9a5891e3fd26d8081425eaf33cbc108f68f4
   languageName: node
   linkType: hard
 
@@ -26014,7 +26441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randomfill@npm:^1.0.3":
+"randomfill@npm:^1.0.4":
   version: 1.0.4
   resolution: "randomfill@npm:1.0.4"
   dependencies:
@@ -26776,7 +27203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.17.0, resolve@npm:^1.22.2, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.22.2, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -26789,7 +27216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.4":
+"resolve@npm:^1.17.0, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -26831,7 +27258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@~1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@~1.22.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@~1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@~1.22.2#~builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -26844,7 +27271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#~builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -27039,6 +27466,85 @@ __metadata:
     safe-stable-stringify: ^2.4.3
     semver-compare: ^1.0.0
   checksum: 6999031e9bf7d04178335603b78467b99397180135515826cf7ad37c83a6b4b944abe929c3b494d1c76eb455039abab4bcfafe93fb5613d3c1b4772548baf0d3
+  languageName: node
+  linkType: hard
+
+"rolldown-plugin-dts@npm:^0.13.8":
+  version: 0.13.9
+  resolution: "rolldown-plugin-dts@npm:0.13.9"
+  dependencies:
+    "@babel/generator": ^7.27.5
+    "@babel/parser": ^7.27.5
+    "@babel/types": ^7.27.6
+    ast-kit: ^2.1.0
+    birpc: ^2.3.0
+    debug: ^4.4.1
+    dts-resolver: ^2.1.1
+    get-tsconfig: ^4.10.1
+  peerDependencies:
+    "@typescript/native-preview": ">=7.0.0-dev.20250601.1"
+    rolldown: ^1.0.0-beta.9
+    typescript: ^5.0.0
+    vue-tsc: ~2.2.0
+  peerDependenciesMeta:
+    "@typescript/native-preview":
+      optional: true
+    typescript:
+      optional: true
+    vue-tsc:
+      optional: true
+  checksum: a541b414db042dcbf45d4dc73172bacec469e68c90da44e168b4d0488da68add6317c8ce35ee55f47e8573ddefcc07caa858523c8b39e7a04c12dcb3c193a0e2
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:1.0.0-beta.11-commit.f051675":
+  version: 1.0.0-beta.11-commit.f051675
+  resolution: "rolldown@npm:1.0.0-beta.11-commit.f051675"
+  dependencies:
+    "@oxc-project/runtime": =0.72.2
+    "@oxc-project/types": =0.72.2
+    "@rolldown/binding-darwin-arm64": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-darwin-x64": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-freebsd-x64": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-linux-arm64-gnu": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-linux-arm64-musl": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-linux-x64-gnu": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-linux-x64-musl": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-wasm32-wasi": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-win32-arm64-msvc": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-win32-ia32-msvc": 1.0.0-beta.11-commit.f051675
+    "@rolldown/binding-win32-x64-msvc": 1.0.0-beta.11-commit.f051675
+    "@rolldown/pluginutils": 1.0.0-beta.11-commit.f051675
+    ansis: ^4.0.0
+  dependenciesMeta:
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-ia32-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 2580b43148f4c8f01408cad6860ab8d1a112f32c60a5996a66b34deca7ddcb55ea84ea1dbeaba8aa5e62f258fb49e89c9dddd29dabe031e3f8ffe70e8423172c
   languageName: node
   linkType: hard
 
@@ -27604,6 +28110,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.2":
+  version: 7.7.2
+  resolution: "semver@npm:7.7.2"
+  bin:
+    semver: bin/semver.js
+  checksum: dd94ba8f1cbc903d8eeb4dd8bf19f46b3deb14262b6717d0de3c804b594058ae785ef2e4b46c5c3b58733c99c83339068203002f9e37cfe44f7e2cc5e3d2f621
+  languageName: node
+  linkType: hard
+
 "semver@npm:~7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
@@ -27691,6 +28206,20 @@ __metadata:
     gopd: ^1.0.1
     has-property-descriptors: ^1.0.1
   checksum: 23742476d695f2eae86348c069bd164d4f25fa7c26546a46a2b5f370f1f84b98ec64366d2cd17785d5b41bbf16b95855da4b7eb188e7056fe3b0248d61f6afda
+  languageName: node
+  linkType: hard
+
+"set-function-length@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: ^1.1.4
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    get-intrinsic: ^1.2.4
+    gopd: ^1.0.1
+    has-property-descriptors: ^1.0.2
+  checksum: a8248bdacdf84cb0fab4637774d9fb3c7a8e6089866d04c817583ff48e14149c87044ce683d7f50759a8c50fb87c7a7e173535b06169c87ef76f5fb276dfff72
   languageName: node
   linkType: hard
 
@@ -27846,6 +28375,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "side-channel-list@npm:1.0.0"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.3
+  checksum: 603b928997abd21c5a5f02ae6b9cc36b72e3176ad6827fab0417ead74580cc4fb4d5c7d0a8a2ff4ead34d0f9e35701ed7a41853dac8a6d1a664fcce1a044f86f
+  languageName: node
+  linkType: hard
+
+"side-channel-map@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-map@npm:1.0.1"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+  checksum: 42501371cdf71f4ccbbc9c9e2eb00aaaab80a4c1c429d5e8da713fd4d39ef3b8d4a4b37ed4f275798a65260a551a7131fd87fe67e922dba4ac18586d6aab8b06
+  languageName: node
+  linkType: hard
+
+"side-channel-weakmap@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "side-channel-weakmap@npm:1.0.2"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+    side-channel-map: ^1.0.1
+  checksum: a815c89bc78c5723c714ea1a77c938377ea710af20d4fb886d362b0d1f8ac73a17816a5f6640f354017d7e292a43da9c5e876c22145bac00b76cfb3468001736
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4, side-channel@npm:^1.0.6":
   version: 1.0.6
   resolution: "side-channel@npm:1.0.6"
@@ -27855,6 +28419,19 @@ __metadata:
     get-intrinsic: ^1.2.4
     object-inspect: ^1.13.1
   checksum: bfc1afc1827d712271453e91b7cd3878ac0efd767495fd4e594c4c2afaa7963b7b510e249572bfd54b0527e66e4a12b61b80c061389e129755f34c493aad9b97
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "side-channel@npm:1.1.0"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.3
+    side-channel-list: ^1.0.0
+    side-channel-map: ^1.0.1
+    side-channel-weakmap: ^1.0.2
+  checksum: bf73d6d6682034603eb8e99c63b50155017ed78a522d27c2acec0388a792c3ede3238b878b953a08157093b85d05797217d270b7666ba1f111345fbe933380ff
   languageName: node
   linkType: hard
 
@@ -29189,6 +29766,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyexec@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tinyexec@npm:1.0.1"
+  checksum: 40f5219abf891884863b085ebe5e8c8bf95bde802f6480f279588b355835ad1604fa01eada2afe90063b48b53cd4b0be5c37393980e23f06fd10689d92fb9586
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.10, tinyglobby@npm:^0.2.9":
   version: 0.2.10
   resolution: "tinyglobby@npm:0.2.10"
@@ -29530,6 +30114,46 @@ __metadata:
     minimist: ^1.2.6
     strip-bom: ^3.0.0
   checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
+  languageName: node
+  linkType: hard
+
+"tsdown@npm:^0.12.3":
+  version: 0.12.7
+  resolution: "tsdown@npm:0.12.7"
+  dependencies:
+    ansis: ^4.1.0
+    cac: ^6.7.14
+    chokidar: ^4.0.3
+    debug: ^4.4.1
+    diff: ^8.0.2
+    empathic: ^1.1.0
+    hookable: ^5.5.3
+    rolldown: 1.0.0-beta.11-commit.f051675
+    rolldown-plugin-dts: ^0.13.8
+    semver: ^7.7.2
+    tinyexec: ^1.0.1
+    tinyglobby: ^0.2.14
+    unconfig: ^7.3.2
+  peerDependencies:
+    "@arethetypeswrong/core": ^0.18.1
+    publint: ^0.3.0
+    typescript: ^5.0.0
+    unplugin-lightningcss: ^0.4.0
+    unplugin-unused: ^0.5.0
+  peerDependenciesMeta:
+    "@arethetypeswrong/core":
+      optional: true
+    publint:
+      optional: true
+    typescript:
+      optional: true
+    unplugin-lightningcss:
+      optional: true
+    unplugin-unused:
+      optional: true
+  bin:
+    tsdown: dist/run.mjs
+  checksum: ea589feb00446353503349f16c5331908da4e3fd4111e44c73d6c48ba2ee0bdd15a872af5259c4dbd26aed1d27eb73f6eb174578d8e7f3618893ac1b4a29734e
   languageName: node
   linkType: hard
 
@@ -30150,6 +30774,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unconfig@npm:^7.3.2":
+  version: 7.3.2
+  resolution: "unconfig@npm:7.3.2"
+  dependencies:
+    "@quansync/fs": ^0.1.1
+    defu: ^6.1.4
+    jiti: ^2.4.2
+    quansync: ^0.2.8
+  checksum: eb975b0b4a099895759001e14cdc6b63d45dd99a915c1b2ed7e91cf4acaa45d84696edc873f31211f489f3cf5d97966767dbaaecc0e3cfbf476ec7507c5a2607
+  languageName: node
+  linkType: hard
+
 "uncrypto@npm:^0.1.3":
   version: 0.1.3
   resolution: "uncrypto@npm:0.1.3"
@@ -30685,13 +31321,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url@npm:^0.11.0":
-  version: 0.11.3
-  resolution: "url@npm:0.11.3"
+"url@npm:^0.11.4":
+  version: 0.11.4
+  resolution: "url@npm:0.11.4"
   dependencies:
     punycode: ^1.4.1
-    qs: ^6.11.2
-  checksum: f9e7886f46a16f96d2e42fbcc5d682c231c55ef5442c1ff66150c0f6556f6e3a97d094a84f51be15ec2432711d212eb60426659ce418f5fcadeaa3f601532c4e
+    qs: ^6.12.3
+  checksum: c25e587723d343d5d4248892393bfa5039ded9c2c07095a9d005bc64b7cb8956d623c0d8da8d1a28f71986a7a8d80fc2e9f9cf84235e48fa435a5cb4451062c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This allow us to bundle correctly sdk to both browser and web, since we we're using node-only APIs instead of solving if it was node / browser.

Also allow us to be a step closer to remove the `vite-plugin-node-polyfills` from clients. (https://github.com/towns-protocol/towns/pull/3265 is the missing piece)

✅ Requires vitest update to 3.2.1 https://github.com/towns-protocol/towns/pull/3237