### PR TITLE
Refactor: Change userId to common.Address across codebase 

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -78,11 +79,11 @@ func (r *isEntitledResult) Reason() EntitlementResultReason {
 
 var everyone = common.HexToAddress("0x1") // This represents an Ethereum address of "0x1"
 
-func NewChainAuthArgsForSpace(spaceId shared.StreamId, userId string, permission Permission) *ChainAuthArgs {
+func NewChainAuthArgsForSpace(spaceId shared.StreamId, userId common.Address, permission Permission) *ChainAuthArgs {
 	return &ChainAuthArgs{
 		kind:       chainAuthKindSpace,
 		spaceId:    spaceId,
-		principal:  common.HexToAddress(userId),
+		principal:  userId,
 		permission: permission,
 	}
 }
@@ -90,34 +91,34 @@ func NewChainAuthArgsForSpace(spaceId shared.StreamId, userId string, permission
 func NewChainAuthArgsForChannel(
 	spaceId shared.StreamId,
 	channelId shared.StreamId,
-	userId string,
+	userId common.Address,
 	permission Permission,
 ) *ChainAuthArgs {
 	return &ChainAuthArgs{
 		kind:       chainAuthKindChannel,
 		spaceId:    spaceId,
 		channelId:  channelId,
-		principal:  common.HexToAddress(userId),
+		principal:  userId,
 		permission: permission,
 	}
 }
 
-func NewChainAuthArgsForIsSpaceMember(spaceId shared.StreamId, userId string) *ChainAuthArgs {
+func NewChainAuthArgsForIsSpaceMember(spaceId shared.StreamId, userId common.Address) *ChainAuthArgs {
 	return &ChainAuthArgs{
 		kind:      chainAuthKindIsSpaceMember,
 		spaceId:   spaceId,
-		principal: common.HexToAddress(userId),
+		principal: userId,
 	}
 }
 
 func NewChainAuthArgsForIsWalletLinked(
-	userAddress []byte,
-	walletAddress []byte,
+	userAddress common.Address,
+	walletAddress common.Address,
 ) *ChainAuthArgs {
 	return &ChainAuthArgs{
 		kind:          chainAuthKindIsWalletLinked,
-		principal:     common.BytesToAddress(userAddress),
-		walletAddress: common.BytesToAddress(walletAddress),
+		principal:     userAddress,
+		walletAddress: walletAddress,
 	}
 }
 

--- a/core/node/auth/auth_impl_cache_test.go
+++ b/core/node/auth/auth_impl_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/towns-protocol/towns/core/config"
 	"github.com/towns-protocol/towns/core/node/base/test"
 	"github.com/towns-protocol/towns/core/node/shared"
@@ -67,7 +68,7 @@ func TestCache(t *testing.T) {
 	result, cacheHit, err := c.executeUsingCache(
 		ctx,
 		cfg,
-		NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite),
+		NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite),
 		func(context.Context, *config.Config, *ChainAuthArgs) (CacheResult, error) {
 			cacheMissForReal = true
 			return &simpleCacheResult{allowed: true}, nil
@@ -82,7 +83,7 @@ func TestCache(t *testing.T) {
 	result, cacheHit, err = c.executeUsingCache(
 		ctx,
 		cfg,
-		NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite),
+		NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite),
 		func(context.Context, *config.Config, *ChainAuthArgs) (CacheResult, error) {
 			cacheMissForReal = true
 			return &simpleCacheResult{allowed: false}, nil
@@ -95,13 +96,13 @@ func TestCache(t *testing.T) {
 
 	// Bust negative cache, validate next computation was a cache miss with expected
 	// result
-	c.bust(NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite))
+	c.bust(NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite))
 
 	cacheMissForReal = false
 	result, cacheHit, err = c.executeUsingCache(
 		ctx,
 		cfg,
-		NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite),
+		NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite),
 		func(context.Context, *config.Config, *ChainAuthArgs) (CacheResult, error) {
 			cacheMissForReal = true
 			return &simpleCacheResult{allowed: true}, nil
@@ -117,7 +118,7 @@ func TestCache(t *testing.T) {
 	result, cacheHit, err = c.executeUsingCache(
 		ctx,
 		cfg,
-		NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite),
+		NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite),
 		func(context.Context, *config.Config, *ChainAuthArgs) (CacheResult, error) {
 			cacheMissForReal = true
 			return &simpleCacheResult{allowed: true}, nil
@@ -130,13 +131,13 @@ func TestCache(t *testing.T) {
 
 	// Bust positive cache, validate next computation was a cache miss with expected
 	// result
-	c.bust(NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite))
+	c.bust(NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite))
 
 	cacheMissForReal = false
 	result, cacheHit, err = c.executeUsingCache(
 		ctx,
 		cfg,
-		NewChainAuthArgsForChannel(spaceId, channelId, "3", PermissionWrite),
+		NewChainAuthArgsForChannel(spaceId, channelId, common.HexToAddress("0x3"), PermissionWrite),
 		func(context.Context, *config.Config, *ChainAuthArgs) (CacheResult, error) {
 			cacheMissForReal = true
 			return &simpleCacheResult{allowed: true}, nil

--- a/core/node/events/events.go
+++ b/core/node/events/events.go
@@ -557,17 +557,13 @@ func Make_UserMetadataPayload_EncryptionDevice(
 func Make_UserPayload_Membership(
 	op MembershipOp,
 	streamId StreamId,
-	inInviter *string,
+	inInviter common.Address,
 	streamParentId []byte,
 	reason *MembershipReason,
 ) *StreamEvent_UserPayload {
 	var inviter []byte
-	if inInviter != nil {
-		var err error
-		inviter, err = AddressFromUserId(*inInviter)
-		if err != nil {
-			panic(err) // todo convert everything to StreamId
-		}
+	if inInviter != (common.Address{}) {
+		inviter = inInviter.Bytes()
 	}
 
 	return &StreamEvent_UserPayload{

--- a/core/node/events/snapshot_test.go
+++ b/core/node/events/snapshot_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/towns-protocol/towns/core/node/base/test"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	. "github.com/towns-protocol/towns/core/node/protocol"
@@ -55,7 +56,7 @@ func make_User_Membership(
 		Make_UserPayload_Membership(
 			membershipOp,
 			streamId,
-			nil,
+			common.Address{},
 			nil,
 			nil,
 		),

--- a/core/node/events/stream_view_test.go
+++ b/core/node/events/stream_view_test.go
@@ -47,7 +47,7 @@ func TestLoad(t *testing.T) {
 	assert.NoError(t, err)
 	join, err := MakeEnvelopeWithPayload(
 		userWallet,
-		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, nil, nil, nil),
+		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, common.Address{}, nil, nil),
 		nil,
 	)
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestLoad(t *testing.T) {
 	// add one more event (just join again)
 	join2, err := MakeEnvelopeWithPayload(
 		userWallet,
-		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, nil, nil, nil),
+		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, common.Address{}, nil, nil),
 		view.LastBlock().Ref,
 	)
 	assert.NoError(t, err)
@@ -170,7 +170,7 @@ func TestLoad(t *testing.T) {
 	// add another join event
 	join3, err := MakeEnvelopeWithPayload(
 		userWallet,
-		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, nil, nil, nil),
+		Make_UserPayload_Membership(MembershipOp_SO_JOIN, streamId, common.Address{}, nil, nil),
 		view.LastBlock().Ref,
 	)
 	assert.NoError(t, err)
@@ -244,7 +244,7 @@ func TestLoad(t *testing.T) {
 	// add an event with an old hash
 	join4, err := MakeEnvelopeWithPayload(
 		userWallet,
-		Make_UserPayload_Membership(MembershipOp_SO_LEAVE, streamId, nil, nil, nil),
+		Make_UserPayload_Membership(MembershipOp_SO_LEAVE, streamId, common.Address{}, nil, nil),
 		newSV1.blocks[0].Ref,
 	)
 	assert.NoError(t, err)

--- a/core/node/events/stream_viewstate_joinable.go
+++ b/core/node/events/stream_viewstate_joinable.go
@@ -20,6 +20,7 @@ type JoinableStreamView interface {
 
 var _ JoinableStreamView = (*StreamView)(nil)
 
+// TODO: FIX: REFACTOR: make it to be GetChannelMembers() (map[common.Address]struct{}, error)
 func (r *StreamView) GetChannelMembers() (mapset.Set[string], error) {
 	members := mapset.NewSet[string]()
 

--- a/core/node/rpc/membership_scrub_test.go
+++ b/core/node/rpc/membership_scrub_test.go
@@ -40,7 +40,7 @@ func addUserToChannel(
 		events.Make_UserPayload_Membership(
 			MembershipOp_SO_JOIN,
 			channelId,
-			nil,
+			common.Address{},
 			spaceId[:],
 			nil,
 		),
@@ -215,29 +215,29 @@ func (o *ObservingEventAdder) ObservedEvents() []struct {
 func (o *ObservingEventAdder) ValidateMembershipLeaveEvents(t assert.TestingT, expectedReason *MembershipReason) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	
+
 	for i, e := range o.observedEvents {
 		userPayload, ok := e.payload.(*StreamEvent_UserPayload)
 		assert.True(t, ok, "Event %d is not a UserPayload", i)
 		if !ok {
 			continue
 		}
-		
+
 		membershipPayload, ok := userPayload.UserPayload.Content.(*UserPayload_UserMembership_)
 		assert.True(t, ok, "Event %d is not a MembershipPayload", i)
 		if !ok {
 			continue
 		}
-		
-		assert.Equal(t, MembershipOp_SO_LEAVE, membershipPayload.UserMembership.Op, 
+
+		assert.Equal(t, MembershipOp_SO_LEAVE, membershipPayload.UserMembership.Op,
 			"Event %d is not a LEAVE operation", i)
-		
+
 		// Check for scrubber reason
 		assert.NotNil(t, membershipPayload.UserMembership.Reason, "Event %d has no reason", i)
-		
+
 		// Verify the reason matches the expected one
-		assert.Equal(t, *expectedReason, *membershipPayload.UserMembership.Reason, 
-			"Event %d has incorrect reason code. Expected: %v, Got: %v", 
+		assert.Equal(t, *expectedReason, *membershipPayload.UserMembership.Reason,
+			"Event %d has incorrect reason code. Expected: %v, Got: %v",
 			i, *expectedReason, *membershipPayload.UserMembership.Reason)
 	}
 }
@@ -376,7 +376,7 @@ func TestScrubStreamTaskProcessor(t *testing.T) {
 						// event for one of the users is emitted twice. Why?
 						// assert.Len(eventAdder.ObservedEvents(), len(tc.expectedBootedUsers))
 						assert.GreaterOrEqual(len(eventAdder.ObservedEvents()), len(tc.expectedBootedUsers))
-						
+
 						eventAdder.ValidateMembershipLeaveEvents(t, &tc.expectedReasonCode)
 
 					}

--- a/core/node/rpc/service_norace_test.go
+++ b/core/node/rpc/service_norace_test.go
@@ -179,7 +179,7 @@ func TestSyncSubscriptionWithTooSlowClient_NoRace(t *testing.T) {
 			channelId, _ := StreamIdFromBytes(channel.GetStreamId())
 			userJoin, err := events.MakeEnvelopeWithPayload(
 				wallet,
-				events.Make_UserPayload_Membership(protocol.MembershipOp_SO_JOIN, channelId, nil, spaceID[:], nil),
+				events.Make_UserPayload_Membership(protocol.MembershipOp_SO_JOIN, channelId, common.Address{}, spaceID[:], nil),
 				MiniblockRefFromLastHash(miniBlockHashResp.Msg),
 			)
 			req.NoError(err)
@@ -400,7 +400,7 @@ func TestUnstableStreams_NoRace(t *testing.T) {
 			channelId, _ := StreamIdFromBytes(channel.GetStreamId())
 			userJoin, err := events.MakeEnvelopeWithPayload(
 				wallet,
-				events.Make_UserPayload_Membership(protocol.MembershipOp_SO_JOIN, channelId, nil, spaceID[:], nil),
+				events.Make_UserPayload_Membership(protocol.MembershipOp_SO_JOIN, channelId, common.Address{}, spaceID[:], nil),
 				&MiniblockRef{
 					Hash: common.BytesToHash(miniBlockHashResp.Msg.GetHash()),
 					Num:  miniBlockHashResp.Msg.GetMiniblockNum(),

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -285,7 +285,7 @@ func joinChannel(
 		events.Make_UserPayload_Membership(
 			protocol.MembershipOp_SO_JOIN,
 			channelId,
-			nil,
+			common.Address{},
 			spaceId[:],
 			nil,
 		),

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -897,7 +897,7 @@ func (tc *testClient) joinChannel(
 		Make_UserPayload_Membership(
 			MembershipOp_SO_JOIN,
 			channelId,
-			nil,
+			common.Address{},
 			spaceId[:],
 			nil,
 		),


### PR DESCRIPTION
Cleanup: Use correct types instead of string or []byte in bunch of APIs