### PR TITLE
chore: use `^` in vitest dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "turbo": "^2.5.4",
         "typechain": "^8.1.1",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3",
+        "vitest": "^3.2.3",
         "wait-on": "^7.0.1"
     },
     "husky": {

--- a/packages/dlog/package.json
+++ b/packages/dlog/package.json
@@ -35,7 +35,7 @@
         "eslint-plugin-import-x": "^4.10.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "/dist"

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -44,7 +44,7 @@
         "fake-indexeddb": "^4.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "dist"

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -32,7 +32,7 @@
         "lodash.debounce": "^4.0.8",
         "ts-node": "^10.9.1",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "/dist"

--- a/packages/rpc-connector/package.json
+++ b/packages/rpc-connector/package.json
@@ -52,7 +52,7 @@
         "eslint-plugin-tsdoc": "^0.3.0",
         "tsdown": "^0.12.3",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "peerDependencies": {
         "@connectrpc/connect-node": ">=2.0.0",

--- a/packages/sdk-crypto/package.json
+++ b/packages/sdk-crypto/package.json
@@ -45,7 +45,7 @@
         "happy-dom": "^15.11.7",
         "tsdown": "^0.12.3",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "/dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,7 +45,7 @@
         "lodash": "^4.17.21",
         "nanoid": "^4.0.0",
         "p-limit": "^6.1.0",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "devDependencies": {
         "@connectrpc/connect-web": "^2.0.0",

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -65,6 +65,6 @@
 		"fake-indexeddb": "^4.0.1",
 		"prettier": "^3.5.3",
 		"typescript": "^5.8.2",
-		"vitest": "3.2.3"
+		"vitest": "^3.2.3"
 	}
 }

--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -45,7 +45,7 @@
         "msgpackr": "^1.10.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "/dist"

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -44,7 +44,7 @@
         "eslint-plugin-import-x": "^4.10.2",
         "typed-emitter": "^2.1.0",
         "typescript": "^5.8.2",
-        "vitest": "3.2.3"
+        "vitest": "^3.2.3"
     },
     "files": [
         "/dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9025,7 +9025,7 @@ __metadata:
     ts-node: ^10.9.1
     typed-emitter: ^2.1.0
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   languageName: unknown
   linkType: soft
 
@@ -31446,7 +31446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:3.2.3, vitest@npm:^3.2.3":
+"vitest@npm:^3.2.3":
   version: 3.2.3
   resolution: "vitest@npm:3.2.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8987,7 +8987,7 @@ __metadata:
     ethereum-cryptography: ^3.2.0
     ts-node: ^10.9.1
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   languageName: unknown
   linkType: soft
 
@@ -9156,7 +9156,7 @@ __metadata:
     lodash.debounce: ^4.0.8
     ts-node: ^10.9.1
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   languageName: unknown
   linkType: soft
 
@@ -9205,7 +9205,7 @@ __metadata:
     eslint-plugin-tsdoc: ^0.3.0
     tsdown: ^0.12.3
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   peerDependencies:
     "@connectrpc/connect-node": ">=2.0.0"
     "@connectrpc/connect-web": ">=2.0.0"
@@ -9235,7 +9235,7 @@ __metadata:
     happy-dom: ^15.11.7
     tsdown: ^0.12.3
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   languageName: unknown
   linkType: soft
 
@@ -9282,7 +9282,7 @@ __metadata:
     typed-emitter: ^2.1.0
     typescript: ^5.8.2
     vite-plugin-wasm: ^3.4.1
-    vitest: 3.2.3
+    vitest: ^3.2.3
     vitest-fetch-mock: ^0.4.3
   languageName: unknown
   linkType: soft
@@ -9328,7 +9328,7 @@ __metadata:
     prettier: ^3.5.3
     typescript: ^5.8.2
     uuid: ^8.3.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
@@ -9364,7 +9364,7 @@ __metadata:
     pino-pretty: ^13.0.0
     typed-emitter: ^2.1.0
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
   languageName: unknown
   linkType: soft
 
@@ -9411,7 +9411,7 @@ __metadata:
     typed-emitter: ^2.1.0
     typescript: ^5.8.2
     viem: ^2.29.3
-    vitest: 3.2.3
+    vitest: ^3.2.3
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
@@ -29323,7 +29323,7 @@ __metadata:
     turbo: ^2.5.4
     typechain: ^8.1.1
     typescript: ^5.8.2
-    vitest: 3.2.3
+    vitest: ^3.2.3
     wait-on: ^7.0.1
   languageName: unknown
   linkType: soft
@@ -31446,7 +31446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:3.2.3":
+"vitest@npm:3.2.3, vitest@npm:^3.2.3":
   version: 3.2.3
   resolution: "vitest@npm:3.2.3"
   dependencies:


### PR DESCRIPTION
So it matches on harmony syncpack check.