### PR TITLE
fix stream-metadata dockerbuild

### DIFF
--- a/packages/rpc-connector/tsdown.config.ts
+++ b/packages/rpc-connector/tsdown.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig } from 'tsup'
+import { defineConfig } from 'tsdown'
 
 export default defineConfig({
     entry: ['src/node/index.ts', 'src/web/index.ts', 'src/common/index.ts'],
-    splitting: false,
     sourcemap: true,
     clean: true,
     format: ['cjs', 'esm'],

--- a/packages/sdk-crypto/tsdown.config.ts
+++ b/packages/sdk-crypto/tsdown.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig } from 'tsup'
+import { defineConfig } from 'tsdown'
 
 export default defineConfig({
     entry: ['src/node/index.ts', 'src/web/index.ts', 'src/common/index.ts'],
-    splitting: false,
     sourcemap: true,
     clean: true,
     format: ['cjs', 'esm'],

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.20 as builder
+FROM node:lts-alpine3.20 AS builder
 
 WORKDIR /river
 
@@ -28,6 +28,8 @@ COPY ./packages/dlog /river/packages/dlog
 COPY ./packages/proto /river/packages/proto
 COPY ./packages/sdk /river/packages/sdk
 COPY ./packages/encryption /river/packages/encryption
+COPY ./packages/sdk-crypto /river/packages/sdk-crypto
+COPY ./packages/rpc-connector /river/packages/rpc-connector
 COPY ./packages/stream-metadata /river/packages/stream-metadata
 
 # install dependencies and build
@@ -37,7 +39,7 @@ RUN yarn install
 RUN yarn run turbo build --filter @towns-protocol/stream-metadata
 
 # create runner image with only the necessary files
-FROM node:lts-alpine3.20 as runner
+FROM node:lts-alpine3.20 AS runner
 COPY --from=builder /river/packages/stream-metadata/dist /river/packages/stream-metadata/dist
 
 # install external dependencies that were excluded from the bundle


### PR DESCRIPTION
I made the mistake of calling `tsdown` but imporing `tsup` in rpc-connector and sdk-crypto

It was working fine since we had tsup installed in other packages and tsdown is compatible, but on docker, tsup wasn't  installed (since the package that was tsup installed isnt copied in the dockerfile)

Also, I forgot to include the new packages dirs. This PR fixes it