### PR TITLE
Jt/net 261 staking subgraph

### DIFF
--- a/packages/subgraph/ponder.config.alpha.ts
+++ b/packages/subgraph/ponder.config.alpha.ts
@@ -10,7 +10,7 @@ import {
     entitlementCheckerAbi,
     nodeOperatorFacetAbi,
     spaceDelegationFacetAbi,
-    rewardsDistributionAbi,
+    rewardsDistributionV2Abi,
     xChainAbi,
 } from '@towns-protocol/contracts/typings'
 
@@ -39,6 +39,11 @@ if (!baseRegistry) {
     throw new Error('Base registry address not found')
 }
 
+const riverAirdrop = getContractAddress('riverAirdrop')
+if (!riverAirdrop) {
+    throw new Error('River airdrop address not found')
+}
+
 export default createConfig({
     networks: {
         anvil: {
@@ -59,10 +64,16 @@ export default createConfig({
                 entitlementCheckerAbi,
                 nodeOperatorFacetAbi,
                 spaceDelegationFacetAbi,
-                rewardsDistributionAbi,
+                rewardsDistributionV2Abi,
                 xChainAbi,
             ]),
             address: baseRegistry,
+            startBlock,
+            network: 'alpha',
+        },
+        RiverAirdrop: {
+            abi: mergeAbis([rewardsDistributionV2Abi]),
+            address: riverAirdrop,
             startBlock,
             network: 'alpha',
         },

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -46,6 +46,11 @@ if (!swapRouter) {
     throw new Error('Swap router address not found')
 }
 
+const riverAirdrop = getContractAddress('riverAirdrop')
+if (!riverAirdrop) {
+    throw new Error('River airdrop address not found')
+}
+
 export default createConfig({
     networks: {
         anvil: {
@@ -100,6 +105,12 @@ export default createConfig({
         SwapRouter: {
             abi: swapRouterAbi,
             address: swapRouter,
+            startBlock,
+            network: 'gamma',
+        },
+        RiverAirdrop: {
+            abi: mergeAbis([rewardsDistributionV2Abi]),
+            address: riverAirdrop,
             startBlock,
             network: 'gamma',
         },

--- a/packages/subgraph/ponder.config.omega.ts
+++ b/packages/subgraph/ponder.config.omega.ts
@@ -46,6 +46,11 @@ if (!baseRegistry) {
     throw new Error('Base registry address not found')
 }
 
+const riverAirdrop = getContractAddress('riverAirdrop')
+if (!riverAirdrop) {
+    throw new Error('River airdrop address not found')
+}
+
 export default createConfig({
     networks: {
         anvil: {
@@ -100,6 +105,12 @@ export default createConfig({
         SwapRouter: {
             abi: swapRouterAbi,
             address: swapRouter,
+            startBlock,
+            network: 'omega',
+        },
+        RiverAirdrop: {
+            abi: mergeAbis([rewardsDistributionV2Abi]),
+            address: riverAirdrop,
             startBlock,
             network: 'omega',
         },

--- a/packages/subgraph/ponder.config.ts
+++ b/packages/subgraph/ponder.config.ts
@@ -45,6 +45,11 @@ if (!swapRouter) {
     throw new Error('Swap router address not found')
 }
 
+const riverAirdrop = getContractAddress('riverAirdrop')
+if (!riverAirdrop) {
+    throw new Error('River airdrop address not found')
+}
+
 export default createConfig({
     networks: {
         anvil: {
@@ -69,6 +74,12 @@ export default createConfig({
                 xChainAbi,
             ]),
             address: baseRegistry,
+            startBlock,
+            network: 'anvil',
+        },
+        RiverAirdrop: {
+            abi: mergeAbis([rewardsDistributionV2Abi]),
+            address: riverAirdrop,
             startBlock,
             network: 'anvil',
         },

--- a/packages/subgraph/ponder.schema.ts
+++ b/packages/subgraph/ponder.schema.ts
@@ -96,3 +96,46 @@ export const feeDistributionToSwapRouterSwap = relations(feeDistribution, ({ one
         references: [swapRouterSwap.txHash],
     }),
 }))
+
+// stakers
+export const stakers = onchainTable('stakers', (t) => ({
+    depositId: t.bigint().primaryKey(),
+    owner: t.hex(),
+    delegatee: t.hex(),
+    beneficiary: t.hex(),
+    amount: t.bigint(),
+    createdAt: t.bigint(),
+}))
+
+// each staker can optionally belong to a space
+export const stakingToSpace = relations(stakers, ({ one }) => ({
+    space: one(space, {
+        fields: [stakers.delegatee],
+        references: [space.id],
+    }),
+}))
+
+// each space can have many stakers
+export const spaceToStakers = relations(space, ({ many }) => ({
+    stakers: many(stakers),
+}))
+
+// operators
+export const operator = onchainTable('operators', (t) => ({
+    address: t.hex().primaryKey(),
+    status: t.integer(),
+    createdAt: t.bigint(),
+}))
+
+// each staker can optionally belong to an operator
+export const stakingToOperator = relations(stakers, ({ one }) => ({
+    operator: one(operator, {
+        fields: [stakers.delegatee],
+        references: [operator.address],
+    }),
+}))
+
+// each operator can have many stakings
+export const operatorToStakings = relations(operator, ({ many }) => ({
+    stakings: many(stakers),
+}))


### PR DESCRIPTION
Updates subgraph with staking related events from RewardsDistribution interface. Staking events are produced from the RiverAirdrop and BaseRegistry diamond. Each event can be associated with an operator or space. I've also added an operator index to track operators and their current status so that we can aggregate stake by operator (as well as space).


