### PR TITLE
node: move to page size context timeout from global timeout in stream…

### DIFF
--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -303,9 +303,6 @@ func (s *StreamCache) syncStreamFromSinglePeer(
 	fromInclusive int64,
 	toExclusive int64,
 ) (int64, error) {
-	ctx, cancel := context.WithTimeout(s.params.ServerCtx, 120*time.Second)
-	defer cancel()
-
 	pageSize := s.params.Config.StreamReconciliation.GetMiniblocksPageSize
 	if pageSize <= 0 {
 		pageSize = 128
@@ -317,6 +314,8 @@ func (s *StreamCache) syncStreamFromSinglePeer(
 			return currentFromInclusive, nil
 		}
 
+		ctx, cancel := context.WithTimeout(s.params.ServerCtx, time.Minute)
+
 		currentToExclusive := min(currentFromInclusive+pageSize, toExclusive)
 
 		mbs, err := s.params.RemoteMiniblockProvider.GetMbs(
@@ -327,14 +326,17 @@ func (s *StreamCache) syncStreamFromSinglePeer(
 			currentToExclusive,
 		)
 		if err != nil {
+			cancel()
 			return currentFromInclusive, err
 		}
 
 		if len(mbs) == 0 {
+			cancel()
 			return currentFromInclusive, nil
 		}
 
 		err = stream.importMiniblocks(ctx, mbs)
+		cancel()
 		if err != nil {
 			return currentFromInclusive, err
 		}


### PR DESCRIPTION
Stream reconciliation imports miniblocks from remotes in `StreamCache#syncStreamFromSinglePeer`. This creates a context with a 2 minute timeout. This is too short for streams with many miniblocks.

Importing happens in pages. Time PR replaces the global context with a timeout per page. This ensures that importing miniblocks from remotes don't timeout once the streams gets too big.