### PR TITLE
Subgraph enable cache across envs

### DIFF
--- a/packages/subgraph/ponder.config.alpha.ts
+++ b/packages/subgraph/ponder.config.alpha.ts
@@ -10,7 +10,7 @@ import {
     entitlementCheckerAbi,
     nodeOperatorFacetAbi,
     spaceDelegationFacetAbi,
-    rewardsDistributionAbi,
+    rewardsDistributionV2Abi,
     xChainAbi,
 } from '@towns-protocol/contracts/typings'
 
@@ -44,12 +44,12 @@ export default createConfig({
         anvil: {
             chainId: 31337,
             transport: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
         alpha: {
             chainId: 84532,
             transport: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
     },
     contracts: {
@@ -59,7 +59,7 @@ export default createConfig({
                 entitlementCheckerAbi,
                 nodeOperatorFacetAbi,
                 spaceDelegationFacetAbi,
-                rewardsDistributionAbi,
+                rewardsDistributionV2Abi,
                 xChainAbi,
             ]),
             address: baseRegistry,

--- a/packages/subgraph/ponder.config.gamma.ts
+++ b/packages/subgraph/ponder.config.gamma.ts
@@ -51,12 +51,12 @@ export default createConfig({
         anvil: {
             id: 31337,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
         gamma: {
             id: 84532,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
     },
     contracts: {

--- a/packages/subgraph/ponder.config.omega.ts
+++ b/packages/subgraph/ponder.config.omega.ts
@@ -51,12 +51,12 @@ export default createConfig({
         anvil: {
             id: 31337,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
         omega: {
             id: 8453,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
     },
     contracts: {

--- a/packages/subgraph/ponder.config.ts
+++ b/packages/subgraph/ponder.config.ts
@@ -50,12 +50,12 @@ export default createConfig({
         anvil: {
             id: 31337,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
         gamma: {
             id: 84532,
             rpc: http(process.env.PONDER_RPC_URL_1),
-            disableCache: true,
+            disableCache: false,
         },
     },
     contracts: {


### PR DESCRIPTION
Enables cache such that if subgraph pod restarts (happens often), subgraph will quickly attempt to rebuild instance on new pid from cache versus re-indexing from start block, which takes >12 hours in omega. 