### PR TITLE
feat: add app registry addresses for alpha and gamma on base

### DIFF
--- a/packages/contracts/deployments/alpha/base/addresses/appRegistry.json
+++ b/packages/contracts/deployments/alpha/base/addresses/appRegistry.json
@@ -1,0 +1,3 @@
+{
+  "address": "0x23a9f5AbBcC82d1E2B5C0781b1F05F2B623E2c69"
+}

--- a/packages/contracts/deployments/gamma/base/addresses/appRegistry.json
+++ b/packages/contracts/deployments/gamma/base/addresses/appRegistry.json
@@ -1,0 +1,3 @@
+{
+  "address": "0xec3081A4b07678C12Fc6B56f69F894EE9e732c42"
+}


### PR DESCRIPTION
### Description

Added AppRegistry contract addresses for alpha and gamma environments on Base network.

### Changes

- Added AppRegistry contract address for alpha environment on Base Sepolia: `0x23a9f5AbBcC82d1E2B5C0781b1F05B623E2c69`
- Added AppRegistry contract address for gamma environment on Base Sepolia: `0xec3081A4b07678C12Fc6B56f69F894EE9e732c42`

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines