### PR TITLE
Basvk/stream forked cmd

### DIFF
--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/towns-protocol/towns/core/config"
 	"github.com/towns-protocol/towns/core/contracts/river"
 	"github.com/towns-protocol/towns/core/node/rpc"
-	"github.com/towns-protocol/towns/core/node/shared"
 
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
@@ -818,7 +817,7 @@ func runStreamCompareMiniblockChainCmd(cfg *config.Config, args []string) error 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	streamId, err := shared.StreamIdFromString(args[0])
+	streamId, err := StreamIdFromString(args[0])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add the `compare-miniblock-chain` command to the `streams` command. This accepts a stream id and prints miniblock chains from nodes from where they forked.

```
Node 0xB85dd7d21Bc093DAe6f1b56a20a45ec1770D11dD:
  15400: 0xbbef8a29bc9bb755f395511086fc53cf5a44720062a35df3c7fab0e16c4ca24b
  15401: 0x01d46ba2762f4174b5bb238e2acf3352c33adda06d71dd9370516bdc0c1b01e7
  15402: 0xd5c35217c582dc395f19af75dc9216bbb1ab59ff359b803296fbed4093324d68
  15403: 0x08f7fffb9cad51adab4f4595e0c50c34fc9654fd7c1f4bd13a02211f646029a3
Node 0xC5FB45BDb448766135ce634bD1Da34D483ADd382:
  15400: 0xbbef8a29bc9bb755f395511086fc53cf5a44720062a35df3c7fab0e16c4ca24b
  15401: 0xedb4d97a069ba8fd0849feb1007a9796490bc61bc1d1ea27ee2291c97796e105
  15402: 0x76a0fb10574b85d7a93763fd49677380cce937878c3d95906647930201b75c74
  15403: 0x464b2bba92f489d89560b927d94d312c32b8a0606020850e886bafb8b3b6fccc
Node 0xc69ceBB1e84Ca8dda9a9Ad68D345Fbe4Ac21Fd54:
  15400: 0xbbef8a29bc9bb755f395511086fc53cf5a44720062a35df3c7fab0e16c4ca24b
  15401: 0xedb4d97a069ba8fd0849feb1007a9796490bc61bc1d1ea27ee2291c97796e105
  15402: 0x76a0fb10574b85d7a93763fd49677380cce937878c3d95906647930201b75c74
  15403: 0x464b2bba92f489d89560b927d94d312c32b8a0606020850e886bafb8b3b6fccc

Forked at 15401
```