### PR TITLE
Return error when failing to get membership expires at on node

### DIFF
--- a/core/node/auth/space_contract_v3.go
+++ b/core/node/auth/space_contract_v3.go
@@ -230,7 +230,7 @@ func (sc *SpaceContractV3) GetMembershipStatus(
 		expiresAt, err := membership.ExpiresAt(&bind.CallOpts{Context: ctx}, tokenId)
 		if err != nil {
 			log.Warnw("Failed to get expiration for token", "tokenId", tokenId, "error", err)
-			continue
+			return nil, err
 		}
 
 		// Token never expires


### PR DESCRIPTION
otherwise the scrubber will think you’re expired and kick you out!