### PR TITLE
Scrubber updates to membership reason

### DIFF
--- a/core/node/events/events.go
+++ b/core/node/events/events.go
@@ -174,7 +174,12 @@ func Make_MemberPayload_Membership(
 	userAddress []byte,
 	initiatorAddress []byte,
 	streamParentId []byte,
+	inReason *MembershipReason,
 ) *StreamEvent_MemberPayload {
+	reason := MembershipReason_MR_NONE
+	if inReason != nil {
+		reason = *inReason
+	}
 	return &StreamEvent_MemberPayload{
 		MemberPayload: &MemberPayload{
 			Content: &MemberPayload_Membership_{
@@ -183,6 +188,7 @@ func Make_MemberPayload_Membership(
 					UserAddress:      userAddress,
 					InitiatorAddress: initiatorAddress,
 					StreamParentId:   streamParentId,
+					Reason:           reason,
 				},
 			},
 		},
@@ -323,7 +329,7 @@ func Make_ChannelPayload_Membership(
 	} else {
 		spaceIdBytes = nil
 	}
-	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, spaceIdBytes)
+	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, spaceIdBytes, nil)
 }
 
 func Make_DMChannelPayload_Message(content string) *StreamEvent_DmChannelPayload {
@@ -393,7 +399,7 @@ func Make_DmChannelPayload_Membership(op MembershipOp, userId string, initiatorI
 			panic(err) // todo convert everything to common.Address
 		}
 	}
-	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil)
+	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil, nil)
 }
 
 // todo delete and replace with Make_MemberPayload_Membership
@@ -409,7 +415,7 @@ func Make_GdmChannelPayload_Membership(op MembershipOp, userId string, initiator
 			panic(err) // todo convert everything to common.Address
 		}
 	}
-	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil)
+	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil, nil)
 }
 
 func Make_SpacePayload_Inception(streamId StreamId, settings *StreamSettings) *StreamEvent_SpacePayload {
@@ -438,7 +444,7 @@ func Make_SpacePayload_Membership(op MembershipOp, userId string, initiatorId st
 			panic(err) // todo convert everything to common.Address
 		}
 	}
-	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil)
+	return Make_MemberPayload_Membership(op, userAddress, initiatorAddress, nil, nil)
 }
 
 func Make_SpacePayload_SpaceImage(

--- a/core/node/events/stream_viewstate_space_test.go
+++ b/core/node/events/stream_viewstate_space_test.go
@@ -49,7 +49,7 @@ func makeTestSpaceStream(
 	join := makeEnvelopeWithPayload_T(
 		t,
 		userWallet,
-		Make_MemberPayload_Membership(protocol.MembershipOp_SO_JOIN, userAddess, userAddess, nil),
+		Make_MemberPayload_Membership(protocol.MembershipOp_SO_JOIN, userAddess, userAddess, nil, nil),
 		nil,
 	)
 

--- a/core/node/rpc/membership_scrub_test.go
+++ b/core/node/rpc/membership_scrub_test.go
@@ -201,6 +201,13 @@ func (o *ObservingEventAdder) AddEventPayload(
 	return newEvents, nil
 }
 
+func (o *ObservingEventAdder) GetWalletAddress() common.Address {
+	return o.adder.GetWalletAddress()
+}
+
+// force interface compliance, observing event adder should implemnt EventAdder interface
+var _ scrub.EventAdder = (*ObservingEventAdder)(nil)
+
 func (o *ObservingEventAdder) ObservedEvents() []struct {
 	streamId StreamId
 	payload  IsStreamEvent_Payload

--- a/core/node/rpc/service.go
+++ b/core/node/rpc/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"connectrpc.com/otelconnect"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 
@@ -142,4 +143,8 @@ func (s *Service) BaseChain() *crypto.Blockchain {
 
 func (s *Service) RiverChain() *crypto.Blockchain {
 	return s.riverChain
+}
+
+func (s *Service) GetWalletAddress() common.Address {
+	return s.wallet.Address
 }

--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -1816,7 +1816,7 @@ func (ru *aeMembershipRules) getPermissionForMembershipOp() (auth.Permission, co
 				initiatorId,
 			)
 		}
-		if userAddress != initiatorId {
+		if userAddress != initiatorId && !ru.params.isValidNode(initiatorId[:]) {
 			return auth.PermissionModifyBanning, initiatorId, nil
 		} else {
 			return auth.PermissionUndefined, userAddress, nil

--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -1470,7 +1470,13 @@ func (ru *aeMembershipRules) requireStreamParentMembership() (*DerivedEvent, err
 	}
 	// for joins and invites, require space membership
 	return &DerivedEvent{
-		Payload:  events.Make_UserPayload_Membership(MembershipOp_SO_JOIN, *streamParentId, common.BytesToAddress(ru.membership.InitiatorAddress), nil, nil),
+		Payload: events.Make_UserPayload_Membership(
+			MembershipOp_SO_JOIN,
+			*streamParentId,
+			common.BytesToAddress(ru.membership.InitiatorAddress),
+			nil,
+			nil,
+		),
 		StreamId: userStreamId,
 	}, nil
 }
@@ -1571,6 +1577,7 @@ func (ru *aeUserMembershipRules) parentEventForUserMembership() (*DerivedEvent, 
 			userAddress.Bytes(),
 			initiatorAddress,
 			userMembership.StreamParentId,
+			userMembership.Reason,
 		),
 		StreamId: toStreamId,
 	}, nil
@@ -1586,7 +1593,13 @@ func (ru *aeUserMembershipActionRules) parentEventForUserMembershipAction() (*De
 	if err != nil {
 		return nil, err
 	}
-	payload := events.Make_UserPayload_Membership(action.Op, actionStreamId, common.BytesToAddress(ru.params.parsedEvent.Event.CreatorAddress), action.StreamParentId, nil)
+	payload := events.Make_UserPayload_Membership(
+		action.Op,
+		actionStreamId,
+		common.BytesToAddress(ru.params.parsedEvent.Event.CreatorAddress),
+		action.StreamParentId,
+		nil,
+	)
 	toUserStreamId, err := shared.UserStreamIdFromBytes(action.UserId)
 	if err != nil {
 		return nil, err
@@ -1813,7 +1826,12 @@ func (ru *aeMembershipRules) getPermissionForMembershipOp() (auth.Permission, co
 		fallthrough
 
 	default:
-		return auth.PermissionUndefined, common.Address{}, RiverError(Err_BAD_EVENT, "Need valid membership op", "op", membership.Op)
+		return auth.PermissionUndefined, common.Address{}, RiverError(
+			Err_BAD_EVENT,
+			"Need valid membership op",
+			"op",
+			membership.Op,
+		)
 	}
 }
 

--- a/core/node/scrub/stream_membership_scrub_task.go
+++ b/core/node/scrub/stream_membership_scrub_task.go
@@ -28,6 +28,7 @@ type EventAdder interface {
 		payload IsStreamEvent_Payload,
 		tags *Tags,
 	) ([]*EventRef, error)
+	GetWalletAddress() common.Address
 }
 
 type streamMembershipScrubTaskProcessorImpl struct {
@@ -160,7 +161,7 @@ func (tp *streamMembershipScrubTaskProcessorImpl) processMemberImpl(
 			Make_UserPayload_Membership(
 				MembershipOp_SO_LEAVE,
 				channelId,
-				member,
+				tp.eventAdder.GetWalletAddress(),
 				spaceId[:],
 				&reason,
 			),

--- a/packages/sdk/src/sync-agent/timeline/models/timeline-types.ts
+++ b/packages/sdk/src/sync-agent/timeline/models/timeline-types.ts
@@ -19,6 +19,7 @@ import {
     ChannelMessage_Post_AttachmentSchema,
     ChannelMessage_Post_Attachment,
     ChannelMessage_PostSchema,
+    MembershipReason,
 } from '@towns-protocol/proto'
 import type { DecryptionSessionError } from '@towns-protocol/encryption'
 import { isDefined, logNever } from '../../../check'
@@ -276,6 +277,7 @@ export interface StreamMembershipEvent {
     userId: string
     initiatorId: string
     membership: Membership
+    reason?: MembershipReason
     streamId?: string // in a case of an invitation to a channel with a streamId
 }
 

--- a/packages/sdk/src/views/streams/timelineEvents.ts
+++ b/packages/sdk/src/views/streams/timelineEvents.ts
@@ -310,6 +310,7 @@ function toTownsContent_MemberPayload(
                     userId: userIdFromAddress(value.content.value.userAddress),
                     initiatorId: userIdFromAddress(value.content.value.initiatorAddress),
                     membership: toMembership(value.content.value.op),
+                    reason: value.content.value.reason,
                 } satisfies StreamMembershipEvent,
             }
         case 'keySolicitation':
@@ -1164,7 +1165,10 @@ export function getFallbackContent(
         case RiverTimelineEvent.ChannelMessageEncrypted:
             return `Decrypting...`
         case RiverTimelineEvent.StreamMembership: {
-            return `[${content.membership}] userId: ${content.userId} initiatorId: ${content.initiatorId}`
+            return `[${content.membership}] userId: ${content.userId} initiatorId: ${content.initiatorId}` +
+                content.reason
+                ? ` reason: ${content.reason}`
+                : ''
         }
         case RiverTimelineEvent.ChannelMessage:
             return `${senderDisplayName}: ${content.body}`


### PR DESCRIPTION
1. set the node address as the “inviter” which is the initiator in logs for leaves. this differentiates the request from one sent by the user
2. update logs on client to include reason
3. forward reason in to the membership payload to help with debugging