### PR TITLE
go: add test-all-report to run go tests and print a report at the end

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -44,6 +44,7 @@ There are just commands to run go tests, `go test` works too:
 
     just test ./...  # Run go test
     just test-all # Run all go tests from module root
+    just test-all-report # Run all go tests from module root and print report at the end
     just t # Run all tests from current dir
 
     just t-debug -run TestMyName  # Run TestMyName with info logging and test printing

--- a/core/justfile
+++ b/core/justfile
@@ -578,11 +578,23 @@ _test-from-dir $DIR *args:
         go test {{args}} | yarn exec pino-pretty
     fi
 
+_test-print-report-from-dir $DIR *args:
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    cd $DIR
+    echo "Running go test from $(git rev-parse --show-prefix)"
+    if ! command -v gotestsum >/dev/null 2>&1; then
+        go install gotest.tools/gotestsum@latest
+    fi
+    gotestsum --hide-summary=skipped {{args}}
+
 # Run go tests from current directory
 test *args: (_test-from-dir invocation_directory() args)
 
 # Run all go tests from module root
 test-all *args: (_test-from-dir justfile_directory() "-v" args "./...")
+
+# Run all go tests from module root and print a report at the end
+test-all-report *args: (_test-print-report-from-dir justfile_directory() args "./...")
 
 # Run all go tests from current directory
 t *args: (_test-from-dir invocation_directory() "-v" args "./...")


### PR DESCRIPTION
When the go tests are run only failed is printed at the end if 1 or more tests fail. Its up to the developer to scroll back and find the failed tests in a big amount of output of all tests. The default go test command doesn't provide any kind of filtering.

This change adds the `test-all-report` just command that runs the go tests and prints a report at the end that contains the tests that fail.

Example output:

```
=== Failed
=== FAIL: node/rpc TestBotConversationNoRace/Large_bot_chat_test (16.23s)
    tester_test.go:809:
        	Error Trace:	/Users/bas/dev/towns/towns/core/node/rpc/tester_test.go:809
        	            				/Users/bas/dev/towns/towns/core/node/rpc/tester_test.go:800
        	            				/Users/bas/dev/towns/towns/core/node/rpc/tester_test.go:1618
        	            				/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Condition never satisfied
        	Test:       	TestBotConversationNoRace/Large_bot_chat_test
    tester_test.go:1624: client 0-17ee9e failed

=== FAIL: node/rpc TestBotConversationNoRace (0.00s)

=== FAIL: node/rpc TestReplMcConversationNoRace/10x1000 (unknown)

=== FAIL: node/rpc TestSyncWithManyStreams (unknown)

=== FAIL: node/rpc TestReplMcConversationNoRace (unknown)
--- PASS: TestReplMcConversationNoRace/5x100 (23.59s)
    skip.go:10: Skipping flaky test TestReplMcConversationNoRace/30x1000 (RIVER_TEST_ENABLE_FLAKY to enable) TODO: REPLICATION: FIX: flaky
--- SKIP: TestReplMcConversationNoRace/30x1000 (0.00s)
    skip.go:10: Skipping flaky test TestReplMcConversationNoRace/100x100 (RIVER_TEST_ENABLE_FLAKY to enable) TODO: REPLICATION: FIX: flaky
--- SKIP: TestReplMcConversationNoRace/100x100 (0.00s)
```