### PR TITLE
node: include last error in returned error when context in backoff timer expires

### DIFF
--- a/core/node/base/backoff_tracker.go
+++ b/core/node/base/backoff_tracker.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	. "github.com/towns-protocol/towns/core/node/protocol"
@@ -34,6 +35,7 @@ type BackoffTracker struct {
 
 // Wait waits for the next attempt.
 // If the context is cancelled, the function returns the context error.
+// If the context times out, the function returns a deadline exceeded error with lastErr as the base error if given.
 // If the maximum number of attempts is reached, the function returns the last error.
 func (b *BackoffTracker) Wait(ctx context.Context, lastErr error) error {
 	b.NumAttempts++
@@ -59,6 +61,19 @@ func (b *BackoffTracker) Wait(ctx context.Context, lastErr error) error {
 
 	select {
 	case <-ctx.Done():
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.Canceled) {
+				return ctxErr
+			}
+
+			if errors.Is(context.DeadlineExceeded, ctxErr) {
+				if lastErr != nil {
+					return RiverErrorWithBases(Err_DEADLINE_EXCEEDED, "operation timed out", []error{lastErr})
+				}
+				return RiverError(Err_DEADLINE_EXCEEDED, "operation timed out")
+			}
+		}
+
 		return ctx.Err()
 	case <-time.After(b.NextDelay):
 		if b.Multiplier <= 0 {

--- a/core/node/base/backoff_tracker_test.go
+++ b/core/node/base/backoff_tracker_test.go
@@ -1,0 +1,66 @@
+package base
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/towns-protocol/towns/core/node/protocol"
+)
+
+func TestBackoffTrackerErrorTimeout(t *testing.T) {
+	tracker := &BackoffTracker{
+		NextDelay:  10 * time.Millisecond,
+		Multiplier: 2,
+		Divisor:    1,
+	}
+
+	var (
+		err                error
+		expectedErr        = errors.New("expected error content")
+		ctxTimeout, cancel = context.WithTimeout(t.Context(), 150*time.Millisecond)
+	)
+	defer cancel()
+
+	for {
+		err = tracker.Wait(ctxTimeout, expectedErr)
+		if err != nil {
+			break
+		}
+	}
+
+	assert.Equal(t, Err_DEADLINE_EXCEEDED, AsRiverError(err).Code)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestBackoffTrackerErrorCancelled(t *testing.T) {
+	tracker := &BackoffTracker{
+		NextDelay:  10 * time.Millisecond,
+		Multiplier: 2,
+		Divisor:    1,
+	}
+
+	var (
+		err                   error
+		expectedErr           = context.Canceled
+		ctxWithCancel, cancel = context.WithCancel(t.Context())
+	)
+	defer cancel()
+
+	for i := range 10 {
+		err = tracker.Wait(ctxWithCancel, expectedErr)
+		if err != nil {
+			break
+		}
+
+		if i >= 5 {
+			cancel()
+		}
+	}
+
+	assert.Equal(t, Err_CANCELED, AsRiverError(err).Code)
+	assert.ErrorIs(t, err, expectedErr)
+}


### PR DESCRIPTION
Several operations need to be retried after it failed. `base#BackoffTracker` provides functionality to retry an operator N times or with a time backoff that periodically retries the operation until a context expires/cancelled. When the context expires the returned error doesn't contain the given last error that gives context to the operation that must be tried. The result is that the caller can miss valuable information about the error.

Example:

```
Error leaving stream. AddEvent: (4:DEADLINE_EXCEEDED) 
<<base 0: deadline_exceeded: AddEvent: (4:DEADLINE_EXCEEDED) 
<<base 0: context deadline exceeded
>>base 0 end
    nodeAddress = 0xB85dd7d21Bc093DAe6f1b56a20a45ec1770D11dD
    nodeUrl = 
    handler = AddEvent
    elapsed = 5.000850173s
    streamId = a8e4a1935907fe134e5cac6de5c877b464e0f1db870000000000000000000000
>>base 0 end
    nodeAddress = 0x122Ba69B3FdcE8B6cb18C0Ed163744B17400c2CB
    nodeUrl = 
    handler = AddEvent
    elapsed = 5.016830969s
    streamId = a8e4a1935907fe134e5cac6de5c877b464e0f1db870000000000000000000000
```

This change includes error information (if available) to the river error that is returned to the caller when the context expires.