### PR TITLE
feat: implement token-based entitlement for role access control

### DIFF
--- a/packages/contracts/CLAUDE.md
+++ b/packages/contracts/CLAUDE.md
@@ -126,6 +126,7 @@ contract FeatureFacet is FeatureBase, IFeature {
 
 - **Visibility**: Always use explicit visibility modifiers
 - **Access Control**: Use modifiers for permission checks
+- **Events**: Emit events for state changes
 - **Gas Optimization**:
   - Pack storage variables
   - Use `calldata` for external function arrays/strings
@@ -299,4 +300,4 @@ Key environment variables needed:
 - [Diamond Standard (EIP-2535)](https://eips.ethereum.org/EIPS/eip-2535)
 - [Foundry Documentation](https://book.getfoundry.sh/)
 - [OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts)
-- Internal docs in `/docs` directory (if available)
+- [Solady Contracts](https://vectorized.github.io/solady)

--- a/packages/contracts/CLAUDE.md
+++ b/packages/contracts/CLAUDE.md
@@ -1,0 +1,302 @@
+# CLAUDE.md - Towns Protocol Contracts
+
+## Overview
+
+You are working with the Towns Protocol smart contracts - a complex blockchain-based space/channel management system with role-based access control, entitlements, and cross-chain delegation mechanisms. This codebase implements a sophisticated permission system that allows for cross-chain rule validation, user management, and token distribution.
+
+## Core Functionality
+
+The system provides:
+
+- Creation and management of spaces (communities) and channels
+- Role-based access control with granular permissions
+- Cross-chain entitlement validation between Ethereum L1 and Base L2
+- User membership management with NFT-based membership tokens
+- Rule-based entitlements with logical operations (AND/OR)
+- Staking and rewards distribution for DAO participants and node operators
+- Cross-chain delegation and governance mechanisms
+- Token airdrops and points-based reward systems
+
+## Technology Stack
+
+- **Language**: Solidity ^0.8.23
+- **Framework**: Foundry for development and testing
+- **Architecture**: Diamond Pattern (EIP-2535) for upgradeability
+- **Dependencies**: OpenZeppelin Contracts, Solady, PRB Math
+- **Testing**: Forge test with fuzz testing
+- **Networks**: Ethereum mainnet, Base, River (custom chain), and testnets
+
+## Project Structure
+
+```
+src/
+├── airdrop/           # Token distribution (drops, points, streaks, rules)
+├── base/registry/     # Core registry, delegation, rewards, entitlement checking
+│   └── facets/
+│       ├── distribution/  # Staking and rewards for DAO participants
+│       ├── mainnet/      # Cross-chain delegation handling
+│       ├── delegation/   # Space-to-operator delegation
+│       └── operator/     # Node operator registration
+├── spaces/            # Space management, entitlements, permissions
+│   └── facets/       # Diamond pattern facets for spaces
+├── factory/          # Factory contracts for space creation
+├── utils/            # Utility libraries
+├── diamond/          # Diamond pattern implementation
+├── tokens/           # Token management, NFTs, bridging
+└── crosschain/       # Cross-chain functionality
+
+scripts/
+├── deployments/      # Deployment scripts
+│   ├── diamonds/     # Diamond deployment scripts
+│   └── facets/       # Facet deployment scripts
+└── interactions/     # Interaction scripts
+
+test/                 # Comprehensive test suite
+```
+
+## Key Contracts
+
+### Core Infrastructure
+
+- `Diamond.sol` - Main diamond proxy implementation
+- `Architect.sol` - Factory for space creation/initialization
+- `CreateSpace.sol` - Space instance creation/initialization
+- `BaseRegistry.sol` - Central registry for base chain operations
+
+### Permissions & Access Control
+
+- `Roles.sol` - Role-based permissions and hierarchies
+- `EntitlementsManager.sol` - Entitlement validation and access control
+- `RuleEntitlement.sol` - Rule-based entitlements with cross-chain validation
+- `EntitlementChecker.sol` - Cross-chain entitlement validation
+
+### Token Management
+
+- `Towns.sol` - Main ERC20 token with inflation mechanism
+- `MembershipToken.sol` - NFT-based membership tokens
+- `DropFacet.sol` - Token airdrops with claiming conditions
+- `TownsPoints.sol` - Points-based rewards, check-ins, streaks
+
+### Cross-chain & Delegation
+
+- `RewardsDistribution.sol` - Token staking, delegation proxies, reward calculations
+- `MainnetDelegation.sol` - Cross-chain delegation via cross-domain messengers
+- `SpaceDelegationFacet.sol` - Space delegation to node operators
+
+## Development Guidelines
+
+### 1. Architecture Pattern - Diamond (EIP-2535)
+
+All contracts follow the Diamond Pattern for upgradeability. When implementing features:
+
+```solidity
+// Storage Library - ALWAYS use diamond storage pattern
+library FeatureStorage {
+    bytes32 internal constant STORAGE_SLOT =
+        keccak256("diamond.facets.feature.storage");
+
+    struct Layout {
+        // state variables here
+    }
+
+    function getLayout() internal pure returns (Layout storage ds) {
+        assembly { ds.slot := STORAGE_SLOT }
+    }
+}
+
+// Base Contract - internal logic
+abstract contract FeatureBase {
+    using FeatureStorage for FeatureStorage.Layout;
+
+    function _internalLogic() internal {
+        FeatureStorage.Layout storage $ = FeatureStorage.getLayout();
+        // implementation
+    }
+}
+
+// Facet Contract - external interface
+contract FeatureFacet is FeatureBase, IFeature {
+    function externalFunction() external {
+        _internalLogic();
+    }
+}
+```
+
+### 2. Coding Standards
+
+- **Visibility**: Always use explicit visibility modifiers
+- **Access Control**: Use modifiers for permission checks
+- **Gas Optimization**:
+  - Pack storage variables
+  - Use `calldata` for external function arrays/strings
+  - Cache storage reads
+  - Use `unchecked` blocks where safe
+  - Prefer `++i` over `i++` in loops
+- **Security**:
+  - Follow Checks-Effects-Interactions pattern
+  - Use reentrancy guards where needed
+  - Validate all inputs
+  - Use safe math operations
+- **Documentation**: NatSpec for all public/external functions
+
+### 3. Testing Requirements
+
+- Write comprehensive unit tests for all functionality
+- Use fuzz testing for numeric inputs (default 4096 runs)
+- Test permission and access control logic thoroughly
+- Test cross-chain functionality with fork tests
+- Test upgrade paths for diamond facets
+
+### 4. Common Patterns
+
+**Permission Checks**:
+
+```solidity
+modifier onlyOwner() {
+    if (!_isOwner(msg.sender)) revert Unauthorized();
+    _;
+}
+
+modifier hasPermission(string memory permission) {
+    if (!_hasPermission(msg.sender, permission)) revert Unauthorized();
+    _;
+}
+```
+
+**Storage Access**:
+
+```solidity
+function _getData() internal view returns (uint256) {
+  return FeatureStorage.getLayout().data;
+}
+```
+
+**Event Emission**:
+
+```solidity
+event DataUpdated(address indexed user, uint256 newValue);
+
+function updateData(uint256 value) external {
+  // checks
+  // effects
+  emit DataUpdated(msg.sender, value);
+  // interactions
+}
+```
+
+## Build and Test Commands
+
+```bash
+# Install dependencies
+yarn
+
+# Build contracts
+forge build
+# or
+yarn build
+
+# Run tests
+forge test --ffi --nmc Fork --fuzz-runs 4096
+# or
+yarn test
+
+# Run specific test
+forge test --match-test testFunctionName -vvvv
+
+# Gas snapshot
+forge snapshot --isolate
+
+# Format code
+yarn format
+
+# Lint
+yarn lint
+
+# Generate TypeScript types
+yarn typings
+```
+
+## Deployment
+
+The project uses a sophisticated deployment system with support for multiple networks and deployment contexts (alpha, omega, etc.).
+
+### Local Deployment
+
+```bash
+# Start local blockchain
+anvil
+
+# Deploy to local
+make deploy-base-anvil contract=DeploySpace type=diamonds
+
+# Deploy facet
+make deploy-facet-local rpc=base_anvil contract=MembershipFacet
+```
+
+### Remote Deployment
+
+```bash
+# Deploy to testnet
+make deploy-base-sepolia contract=DeploySpace type=diamonds context=alpha
+
+# Deploy with hardware wallet
+make deploy-ledger-base-sepolia contract=DeploySpace type=diamonds context=gamma
+```
+
+## Environment Variables
+
+Key environment variables needed:
+
+- `LOCAL_PRIVATE_KEY` - For local deployments
+- `TESTNET_PRIVATE_KEY` - For testnet deployments
+- `BASE_RPC_URL`, `BASE_ANVIL_RPC_URL`, etc. - RPC endpoints
+- `BASESCAN_API_KEY` - For contract verification
+- `HD_PATH`, `SENDER_ADDRESS` - For hardware wallet deployments
+
+## Common Workflows
+
+### 1. Adding a New Facet
+
+1. Create storage library in `src/[module]/facets/[feature]/[Feature]Storage.sol`
+2. Create base contract with internal logic in `[Feature]Base.sol`
+3. Create facet contract with external functions in `[Feature]Facet.sol`
+4. Create interface in `I[Feature].sol`
+5. Add deployment script in `scripts/deployments/facets/Deploy[Feature].s.sol`
+6. Write comprehensive tests in `test/[module]/[feature]/[Feature].t.sol`
+
+### 2. Modifying Existing Facets
+
+1. Make changes following the existing pattern
+2. If adding storage, ensure no collision with existing slots
+3. Update tests to cover new functionality
+4. Deploy new facet version and use diamond cut to upgrade
+
+### 3. Cross-chain Integration
+
+1. Use `EntitlementChecker` for cross-chain permission validation
+2. Implement `ICrossChainEntitlement` for custom cross-chain rules
+3. Use proper chain IDs and cross-domain messenger contracts
+4. Test with fork tests against actual deployed contracts
+
+## Security Considerations
+
+1. **Reentrancy**: Always use reentrancy guards for external calls
+2. **Access Control**: Verify permissions at every entry point
+3. **Input Validation**: Validate all external inputs
+4. **Upgrades**: Follow diamond upgrade best practices
+5. **Cross-chain**: Validate message authenticity and handle failures
+
+## Debugging Tips
+
+1. Use `-vvvv` flag with forge test for detailed traces
+2. Check storage slot collisions if unexpected behavior
+3. Verify facet selectors are correctly mapped in diamond
+4. Use `forge debug` for step-by-step execution
+5. Check events for state changes
+
+## Resources
+
+- [Diamond Standard (EIP-2535)](https://eips.ethereum.org/EIPS/eip-2535)
+- [Foundry Documentation](https://book.getfoundry.sh/)
+- [OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts)
+- Internal docs in `/docs` directory (if available)

--- a/packages/contracts/src/spaces/entitlements/token/ITokenEntitlement.sol
+++ b/packages/contracts/src/spaces/entitlements/token/ITokenEntitlement.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IEntitlement} from "src/spaces/entitlements/IEntitlement.sol";
+
+interface ITokenEntitlement is IEntitlement {
+    enum TokenType {
+        ERC20,
+        ERC721,
+        ERC1155,
+        NATIVE
+    }
+
+    struct TokenData {
+        TokenType tokenType;
+        address contractAddress;
+        uint256 threshold; // For ERC20/ERC1155/NATIVE: minimum balance, For ERC721: minimum number of tokens
+        uint256 tokenId; // Only used for ERC1155
+    }
+
+    error TokenEntitlement__NotAllowed();
+    error TokenEntitlement__InvalidTokenData();
+    error TokenEntitlement__InvalidTokenType();
+
+    function getTokenData(uint256 roleId) external view returns (TokenData memory);
+    function encodeTokenData(TokenData calldata data) external pure returns (bytes memory);
+}

--- a/packages/contracts/src/spaces/entitlements/token/TokenEntitlement.sol
+++ b/packages/contracts/src/spaces/entitlements/token/TokenEntitlement.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+
+import {ITokenEntitlement} from "./ITokenEntitlement.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IRoles} from "src/spaces/facets/roles/IRoles.sol";
+import {IEntitlement} from "../IEntitlement.sol";
+
+contract TokenEntitlement is
+    Initializable,
+    ERC165Upgradeable,
+    ContextUpgradeable,
+    UUPSUpgradeable,
+    ITokenEntitlement
+{
+    // keccak256(abi.encode(uint256(keccak256("spaces.entitlements.token.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant STORAGE_SLOT =
+        0x66667ff88546bbe8cd8a256e24a6dc28862d3e12e7bd3d829a51bb68df7b2800;
+
+    // @custom:storage-location erc7201:spaces.entitlements.token.storage
+    struct Layout {
+        mapping(uint256 => TokenData) tokenDataByRoleId;
+        mapping(uint256 => address) grantedBy;
+        mapping(uint256 => uint256) grantedTime;
+    }
+
+    address public SPACE_ADDRESS;
+
+    string public constant name = "Token Entitlement";
+    string public constant description = "Entitlement for same-chain token balance checks";
+    string public constant moduleType = "TokenEntitlement";
+    bool public constant isCrosschain = false;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _space) public initializer {
+        __UUPSUpgradeable_init();
+        __ERC165_init();
+        __Context_init();
+        SPACE_ADDRESS = _space;
+    }
+
+    modifier onlySpace() {
+        if (_msgSender() != SPACE_ADDRESS) {
+            revert TokenEntitlement__NotAllowed();
+        }
+        _;
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlySpace {}
+
+    function getLayout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+        return
+            interfaceId == type(IEntitlement).interfaceId ||
+            interfaceId == type(ITokenEntitlement).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function isEntitled(bytes32, address[] memory users, bytes32) external view returns (bool) {
+        uint256 usersLength = users.length;
+
+        // Get all role IDs that have token data configured
+        Layout storage $ = getLayout();
+
+        IRoles.Role[] memory roles = IRoles(SPACE_ADDRESS).getRoles();
+
+        for (uint256 i; i < roles.length; ++i) {
+            uint256 roleId = roles[i].id;
+            TokenData storage tokenData = $.tokenDataByRoleId[roleId];
+
+            // Skip if no token data for this role
+            if (
+                tokenData.contractAddress == address(0) && tokenData.tokenType != TokenType.NATIVE
+            ) {
+                continue;
+            }
+
+            // Check if any user meets the token requirements
+            for (uint256 j; j < usersLength; ++j) {
+                if (_checkTokenBalance(users[i], tokenData)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    function setEntitlement(uint256 roleId, bytes calldata entitlementData) external onlySpace {
+        if (entitlementData.length == 0) {
+            revert TokenEntitlement__InvalidTokenData();
+        }
+
+        TokenData memory tokenData = abi.decode(entitlementData, (TokenData));
+
+        // Validate token data
+        if (tokenData.tokenType > TokenType.NATIVE) {
+            revert TokenEntitlement__InvalidTokenType();
+        }
+
+        if (tokenData.tokenType != TokenType.NATIVE && tokenData.contractAddress == address(0)) {
+            revert TokenEntitlement__InvalidTokenData();
+        }
+
+        if (tokenData.threshold == 0) {
+            revert TokenEntitlement__InvalidTokenData();
+        }
+
+        Layout storage $ = getLayout();
+        $.tokenDataByRoleId[roleId] = tokenData;
+        $.grantedBy[roleId] = _msgSender();
+        $.grantedTime[roleId] = block.timestamp;
+    }
+
+    function removeEntitlement(uint256 roleId) external onlySpace {
+        Layout storage $ = getLayout();
+
+        if ($.grantedBy[roleId] == address(0)) {
+            revert TokenEntitlement__InvalidTokenData();
+        }
+
+        delete $.tokenDataByRoleId[roleId];
+        delete $.grantedBy[roleId];
+        delete $.grantedTime[roleId];
+    }
+
+    function getEntitlementDataByRoleId(uint256 roleId) external view returns (bytes memory) {
+        Layout storage $ = getLayout();
+        TokenData storage tokenData = $.tokenDataByRoleId[roleId];
+
+        if ($.grantedBy[roleId] == address(0)) {
+            return "";
+        }
+
+        return abi.encode(tokenData);
+    }
+
+    function getTokenData(uint256 roleId) external view returns (TokenData memory) {
+        return getLayout().tokenDataByRoleId[roleId];
+    }
+
+    function encodeTokenData(TokenData calldata data) external pure returns (bytes memory) {
+        return abi.encode(data);
+    }
+
+    function _checkTokenBalance(
+        address user,
+        TokenData storage tokenData
+    ) internal view returns (bool) {
+        if (tokenData.tokenType == TokenType.ERC20) {
+            return IERC20(tokenData.contractAddress).balanceOf(user) >= tokenData.threshold;
+        } else if (tokenData.tokenType == TokenType.ERC721) {
+            return IERC721(tokenData.contractAddress).balanceOf(user) >= tokenData.threshold;
+        } else if (tokenData.tokenType == TokenType.ERC1155) {
+            return
+                IERC1155(tokenData.contractAddress).balanceOf(user, tokenData.tokenId) >=
+                tokenData.threshold;
+        } else if (tokenData.tokenType == TokenType.NATIVE) {
+            return user.balance >= tokenData.threshold;
+        }
+
+        return false;
+    }
+}

--- a/packages/contracts/test/spaces/entitlements/token/TokenEntitlement.t.sol
+++ b/packages/contracts/test/spaces/entitlements/token/TokenEntitlement.t.sol
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {TokenEntitlement} from "src/spaces/entitlements/token/TokenEntitlement.sol";
+import {ITokenEntitlement} from "src/spaces/entitlements/token/ITokenEntitlement.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {MockERC721} from "test/mocks/MockERC721.sol";
+import {MockERC1155} from "test/mocks/MockERC1155.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract TokenEntitlementTest is Test {
+    TokenEntitlement public implementation;
+    TokenEntitlement public tokenEntitlement;
+
+    MockERC20 public mockERC20;
+    MockERC721 public mockERC721;
+    MockERC1155 public mockERC1155;
+
+    address public space = address(0x1234);
+    address public alice = address(0xABCD);
+    address public bob = address(0xDEAD);
+
+    uint256 public constant ROLE_ID = 1;
+    uint256 public constant ERC1155_TOKEN_ID = 42;
+
+    event EntitlementSet(uint256 indexed roleId, address indexed grantedBy);
+    event EntitlementRemoved(uint256 indexed roleId);
+
+    function setUp() public {
+        // Deploy mock tokens
+        mockERC20 = new MockERC20("Test Token", "TEST");
+        mockERC721 = new MockERC721();
+        mockERC1155 = new MockERC1155();
+
+        // Deploy implementation
+        implementation = new TokenEntitlement();
+
+        // Deploy proxy
+        bytes memory initData = abi.encodeCall(TokenEntitlement.initialize, (space));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
+        tokenEntitlement = TokenEntitlement(address(proxy));
+    }
+
+    function testInitialize() public {
+        assertEq(tokenEntitlement.SPACE_ADDRESS(), space);
+        assertEq(tokenEntitlement.name(), "Token Entitlement");
+        assertEq(tokenEntitlement.description(), "Entitlement for same-chain token balance checks");
+        assertEq(tokenEntitlement.moduleType(), "TokenEntitlement");
+        assertFalse(tokenEntitlement.isCrosschain());
+    }
+
+    function testSetEntitlementERC20() public {
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC20,
+            contractAddress: address(mockERC20),
+            threshold: 100 ether,
+            tokenId: 0
+        });
+
+        bytes memory encodedData = abi.encode(tokenData);
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, encodedData);
+
+        ITokenEntitlement.TokenData memory storedData = tokenEntitlement.getTokenData(ROLE_ID);
+        assertEq(uint8(storedData.tokenType), uint8(ITokenEntitlement.TokenType.ERC20));
+        assertEq(storedData.contractAddress, address(mockERC20));
+        assertEq(storedData.threshold, 100 ether);
+        assertEq(storedData.tokenId, 0);
+    }
+
+    function testSetEntitlementERC721() public {
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC721,
+            contractAddress: address(mockERC721),
+            threshold: 2, // Must own at least 2 NFTs
+            tokenId: 0
+        });
+
+        bytes memory encodedData = abi.encode(tokenData);
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, encodedData);
+
+        ITokenEntitlement.TokenData memory storedData = tokenEntitlement.getTokenData(ROLE_ID);
+        assertEq(uint8(storedData.tokenType), uint8(ITokenEntitlement.TokenType.ERC721));
+        assertEq(storedData.contractAddress, address(mockERC721));
+        assertEq(storedData.threshold, 2);
+    }
+
+    function testSetEntitlementERC1155() public {
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC1155,
+            contractAddress: address(mockERC1155),
+            threshold: 5,
+            tokenId: ERC1155_TOKEN_ID
+        });
+
+        bytes memory encodedData = abi.encode(tokenData);
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, encodedData);
+
+        ITokenEntitlement.TokenData memory storedData = tokenEntitlement.getTokenData(ROLE_ID);
+        assertEq(uint8(storedData.tokenType), uint8(ITokenEntitlement.TokenType.ERC1155));
+        assertEq(storedData.contractAddress, address(mockERC1155));
+        assertEq(storedData.threshold, 5);
+        assertEq(storedData.tokenId, ERC1155_TOKEN_ID);
+    }
+
+    function testSetEntitlementNative() public {
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.NATIVE,
+            contractAddress: address(0),
+            threshold: 1 ether,
+            tokenId: 0
+        });
+
+        bytes memory encodedData = abi.encode(tokenData);
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, encodedData);
+
+        ITokenEntitlement.TokenData memory storedData = tokenEntitlement.getTokenData(ROLE_ID);
+        assertEq(uint8(storedData.tokenType), uint8(ITokenEntitlement.TokenType.NATIVE));
+        assertEq(storedData.contractAddress, address(0));
+        assertEq(storedData.threshold, 1 ether);
+    }
+
+    function testIsEntitledERC20() public {
+        // Setup ERC20 entitlement
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC20,
+            contractAddress: address(mockERC20),
+            threshold: 100 ether,
+            tokenId: 0
+        });
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        // Alice has no tokens - should not be entitled
+        address[] memory users = new address[](1);
+        users[0] = alice;
+        assertFalse(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Give Alice tokens
+        mockERC20.mint(alice, 100 ether);
+
+        // Now Alice should be entitled
+        assertTrue(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Test with multiple users where one is entitled
+        address[] memory multiUsers = new address[](2);
+        multiUsers[0] = bob; // Bob has no tokens
+        multiUsers[1] = alice; // Alice has tokens
+        assertTrue(tokenEntitlement.isEntitled(bytes32(0), multiUsers, bytes32(0)));
+    }
+
+    function testIsEntitledERC721() public {
+        // Setup ERC721 entitlement
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC721,
+            contractAddress: address(mockERC721),
+            threshold: 2,
+            tokenId: 0
+        });
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        address[] memory users = new address[](1);
+        users[0] = alice;
+
+        // Alice has no NFTs - should not be entitled
+        assertFalse(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Give Alice 1 NFT - still not enough
+        mockERC721.mintTo(alice);
+        assertFalse(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Give Alice another NFT - now she has 2
+        mockERC721.mintTo(alice);
+        assertTrue(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+    }
+
+    function testIsEntitledERC1155() public {
+        // Setup ERC1155 entitlement
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC1155,
+            contractAddress: address(mockERC1155),
+            threshold: 5,
+            tokenId: ERC1155_TOKEN_ID
+        });
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        address[] memory users = new address[](1);
+        users[0] = alice;
+
+        // Alice has no tokens - should not be entitled
+        assertFalse(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Give Alice tokens
+        mockERC1155.safeMint(alice, ERC1155_TOKEN_ID, 5);
+
+        // Now Alice should be entitled
+        assertTrue(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+    }
+
+    function testIsEntitledNative() public {
+        // Setup native token entitlement
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.NATIVE,
+            contractAddress: address(0),
+            threshold: 1 ether,
+            tokenId: 0
+        });
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        address[] memory users = new address[](1);
+        users[0] = alice;
+
+        // Alice has no ETH - should not be entitled
+        assertFalse(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+
+        // Give Alice ETH
+        vm.deal(alice, 1 ether);
+
+        // Now Alice should be entitled
+        assertTrue(tokenEntitlement.isEntitled(bytes32(0), users, bytes32(0)));
+    }
+
+    function testRemoveEntitlement() public {
+        // First set an entitlement
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC20,
+            contractAddress: address(mockERC20),
+            threshold: 100 ether,
+            tokenId: 0
+        });
+
+        vm.prank(space);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        // Verify it was set
+        bytes memory data = tokenEntitlement.getEntitlementDataByRoleId(ROLE_ID);
+        assertTrue(data.length > 0);
+
+        // Remove it
+        vm.prank(space);
+        tokenEntitlement.removeEntitlement(ROLE_ID);
+
+        // Verify it was removed
+        data = tokenEntitlement.getEntitlementDataByRoleId(ROLE_ID);
+        assertEq(data.length, 0);
+    }
+
+    function testOnlySpaceCanSetEntitlement() public {
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC20,
+            contractAddress: address(mockERC20),
+            threshold: 100 ether,
+            tokenId: 0
+        });
+
+        bytes memory encodedData = abi.encode(tokenData);
+
+        vm.prank(alice);
+        vm.expectRevert(ITokenEntitlement.TokenEntitlement__NotAllowed.selector);
+        tokenEntitlement.setEntitlement(ROLE_ID, encodedData);
+    }
+
+    function testInvalidTokenData() public {
+        // Test empty data
+        vm.prank(space);
+        vm.expectRevert(ITokenEntitlement.TokenEntitlement__InvalidTokenData.selector);
+        tokenEntitlement.setEntitlement(ROLE_ID, "");
+
+        // Test zero threshold
+        ITokenEntitlement.TokenData memory tokenData = ITokenEntitlement.TokenData({
+            tokenType: ITokenEntitlement.TokenType.ERC20,
+            contractAddress: address(mockERC20),
+            threshold: 0,
+            tokenId: 0
+        });
+
+        vm.prank(space);
+        vm.expectRevert(ITokenEntitlement.TokenEntitlement__InvalidTokenData.selector);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+
+        // Test zero address for non-native token
+        tokenData.contractAddress = address(0);
+        tokenData.threshold = 100;
+
+        vm.prank(space);
+        vm.expectRevert(ITokenEntitlement.TokenEntitlement__InvalidTokenData.selector);
+        tokenEntitlement.setEntitlement(ROLE_ID, abi.encode(tokenData));
+    }
+
+    function testRemoveNonExistentEntitlement() public {
+        vm.prank(space);
+        vm.expectRevert(ITokenEntitlement.TokenEntitlement__InvalidTokenData.selector);
+        tokenEntitlement.removeEntitlement(999);
+    }
+}


### PR DESCRIPTION
### Description

Implemented a new TokenEntitlement contract that enables role-based access control based on token ownership. This entitlement allows spaces to grant roles to users who hold specific amounts of ERC20, ERC721, ERC1155, or native tokens.

### Changes

- Created `ITokenEntitlement.sol` interface defining the token entitlement contract structure
- Implemented `TokenEntitlement.sol` with support for four token types:
  - ERC20: Checks minimum token balance
  - ERC721: Checks minimum number of NFTs owned
  - ERC1155: Checks minimum balance of a specific token ID
  - Native: Checks minimum ETH/native token balance
- Added comprehensive test suite in `TokenEntitlement.t.sol` covering all token types and edge cases
- Implemented proper storage layout using ERC-7201 namespaced storage pattern

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines