### PR TITLE
feat: add ERC1271 signature validation to spaces

### DIFF
--- a/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySpace.s.sol
@@ -29,6 +29,7 @@ import {DeploySwapFacet} from "../facets/DeploySwapFacet.s.sol";
 import {DeployTipping} from "../facets/DeployTipping.s.sol";
 import {DeployTreasury} from "../facets/DeployTreasury.s.sol";
 import {DeployAppAccount} from "../facets/DeployAppAccount.s.sol";
+import {DeployERC1271} from "../facets/DeployERC1271.s.sol";
 
 // contracts
 import {Diamond} from "@towns-protocol/diamond/src/Diamond.sol";
@@ -119,6 +120,7 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
         facetHelper.add("TippingFacet");
         facetHelper.add("Treasury");
         facetHelper.add("AppAccount");
+        facetHelper.add("ERC1271Facet");
 
         if (isAnvil()) {
             facetHelper.add("MockLegacyMembership");
@@ -181,6 +183,9 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
 
         facet = facetHelper.getDeployedAddress("AppAccount");
         addCut(makeCut(facet, FacetCutAction.Add, DeployAppAccount.selectors()));
+
+        facet = facetHelper.getDeployedAddress("ERC1271Facet");
+        addCut(makeCut(facet, FacetCutAction.Add, DeployERC1271.selectors()));
 
         if (isAnvil()) {
             facet = facetHelper.getDeployedAddress("MockLegacyMembership");
@@ -254,6 +259,8 @@ contract DeploySpace is IDiamondInitHelper, DiamondHelper, Deployer {
                 addCut(makeCut(facet, FacetCutAction.Add, DeployTreasury.selectors()));
             } else if (facetName.eq("AppAccount")) {
                 addCut(makeCut(facet, FacetCutAction.Add, DeployAppAccount.selectors()));
+            } else if (facetName.eq("ERC1271Facet")) {
+                addCut(makeCut(facet, FacetCutAction.Add, DeployERC1271.selectors()));
             }
         }
     }

--- a/packages/contracts/scripts/deployments/facets/DeployERC1271.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployERC1271.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
+
+// libraries
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
+
+// contracts
+import {ERC1271Facet} from "src/spaces/facets/account/ERC1271Facet.sol";
+import {ERC1271} from "solady/accounts/ERC1271.sol";
+import {EIP712} from "solady/utils/EIP712.sol";
+import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
+
+library DeployERC1271 {
+    using DynamicArrayLib for DynamicArrayLib.DynamicArray;
+
+    function selectors() internal pure returns (bytes4[] memory res) {
+        DynamicArrayLib.DynamicArray memory arr = DynamicArrayLib.p().reserve(3);
+        arr.p(ERC1271.isValidSignature.selector);
+        arr.p(EIP712.eip712Domain.selector);
+        arr.p(ERC1271Facet.DOMAIN_SEPARATOR.selector);
+        bytes32[] memory selectors_ = arr.asBytes32Array();
+        assembly ("memory-safe") {
+            res := selectors_
+        }
+    }
+
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    ) internal pure returns (IDiamond.FacetCut memory) {
+        return
+            IDiamond.FacetCut({
+                action: action,
+                facetAddress: facetAddress,
+                functionSelectors: selectors()
+            });
+    }
+
+    function deploy() internal returns (address) {
+        return LibDeploy.deployCode("ERC1271Facet.sol", "");
+    }
+}

--- a/packages/contracts/src/spaces/facets/account/ERC1271Facet.sol
+++ b/packages/contracts/src/spaces/facets/account/ERC1271Facet.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+import {ERC1271} from "solady/accounts/ERC1271.sol";
+import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
+import {Entitled} from "../Entitled.sol";
+
+contract ERC1271Facet is ERC1271, Entitled, Facet {
+    function _domainNameAndVersion()
+        internal
+        pure
+        override
+        returns (string memory name, string memory version)
+    {
+        return ("Space", "1");
+    }
+
+    function _erc1271Signer() internal view override returns (address) {
+        return _owner();
+    }
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparator();
+    }
+}

--- a/packages/contracts/test/mocks/MockApp.sol
+++ b/packages/contracts/test/mocks/MockApp.sol
@@ -2,10 +2,14 @@
 pragma solidity ^0.8.23;
 
 import {EIP712} from "solady/utils/EIP712.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 contract MockApp is EIP712 {
     // EIP-712 type hash for Mail struct
     bytes32 public constant MAIL_TYPEHASH = keccak256("Mail(address to,string contents)");
+
+    // ERC1271 magic value
+    bytes4 private constant MAGICVALUE = 0x1626ba7e;
 
     constructor() {}
 
@@ -28,5 +32,39 @@ contract MockApp is EIP712 {
     /// @dev Returns the domain separator for this contract
     function getDomainSeparator() external view returns (bytes32) {
         return _domainSeparator();
+    }
+
+    /// @dev Validates a mail signature through an ERC1271 contract
+    /// This simulates a real-world use case where an app validates user signatures
+    function validateMailSignature(
+        address erc1271Contract,
+        address to,
+        string memory contents,
+        bytes calldata signature
+    ) external view returns (bool) {
+        // Create the EIP-712 hash that this app would create
+        bytes32 mailHash = this.createMailHash(to, contents);
+
+        // Call isValidSignature on the ERC1271 contract
+        // Handle potential reverts for invalid signatures
+        try IERC1271(erc1271Contract).isValidSignature(mailHash, signature) returns (
+            bytes4 result
+        ) {
+            return result == MAGICVALUE;
+        } catch {
+            // If the call reverts, the signature is invalid
+            return false;
+        }
+    }
+
+    /// @dev Helper function to get the signature data needed for ERC1271
+    /// Returns the hash and signature components for testing
+    function getSignatureData(
+        address to,
+        string memory contents
+    ) external view returns (bytes32 mailHash, bytes32 structHash, bytes32 domainSeparator) {
+        structHash = this.getMailStructHash(to, contents);
+        domainSeparator = this.getDomainSeparator();
+        mailHash = this.createMailHash(to, contents);
     }
 }

--- a/packages/contracts/test/mocks/MockApp.sol
+++ b/packages/contracts/test/mocks/MockApp.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {EIP712} from "solady/utils/EIP712.sol";
+
+contract MockApp is EIP712 {
+    // EIP-712 type hash for Mail struct
+    bytes32 public constant MAIL_TYPEHASH = keccak256("Mail(address to,string contents)");
+
+    constructor() {}
+
+    /// @dev Returns the EIP-712 domain name.
+    function _domainNameAndVersion() internal pure override returns (string memory, string memory) {
+        return ("MockApp", "1");
+    }
+
+    /// @dev Creates an EIP-712 hash for a Mail struct
+    function createMailHash(address to, string memory contents) external view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(MAIL_TYPEHASH, to, keccak256(bytes(contents))));
+        return _hashTypedData(structHash);
+    }
+
+    /// @dev Returns the struct hash for a Mail struct (without domain separator)
+    function getMailStructHash(address to, string memory contents) external pure returns (bytes32) {
+        return keccak256(abi.encode(MAIL_TYPEHASH, to, keccak256(bytes(contents))));
+    }
+
+    /// @dev Returns the domain separator for this contract
+    function getDomainSeparator() external view returns (bytes32) {
+        return _domainSeparator();
+    }
+}

--- a/packages/contracts/test/spaces/BaseSetup.sol
+++ b/packages/contracts/test/spaces/BaseSetup.sol
@@ -60,6 +60,7 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
 
     address internal deployer;
     address internal founder;
+    uint256 internal founderPrivateKey;
     address internal space;
     address internal everyoneSpace;
     address internal spaceFactory;
@@ -177,7 +178,8 @@ contract BaseSetup is TestUtils, EIP712Utils, SpaceHelper {
         vm.stopPrank();
 
         // create a new space
-        founder = _randomAddress();
+        founderPrivateKey = _randomUint256();
+        founder = vm.addr(founderPrivateKey);
 
         // Create the arguments necessary for creating a space
         IArchitectBase.SpaceInfo memory spaceInfo = _createSpaceInfo("BaseSetupSpace");

--- a/packages/contracts/test/spaces/account/ERC1271.t.sol
+++ b/packages/contracts/test/spaces/account/ERC1271.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+// utils
+import {BaseSetup} from "test/spaces/BaseSetup.sol";
+import {console} from "forge-std/console.sol";
+
+//interfaces
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IArchitect} from "src/factory/facets/architect/IArchitect.sol";
+
+//libraries
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+//contracts
+import {ERC1271Facet} from "src/spaces/facets/account/ERC1271Facet.sol";
+import {EIP712} from "solady/utils/EIP712.sol";
+import {MockApp} from "test/mocks/MockApp.sol";
+
+contract ERC1271Test is BaseSetup {
+    ERC1271Facet internal erc1271Facet;
+    EIP712 internal eip712;
+    MockApp internal mockApp;
+
+    // ERC1271 magic values
+    bytes4 internal constant MAGICVALUE = 0x1626ba7e; // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+    bytes4 internal constant INVALID_SIGNATURE = 0xffffffff;
+
+    // Test data
+    bytes32 internal constant TEST_HASH = keccak256("test message");
+    string internal constant TEST_MESSAGE = "Hello, ERC1271!";
+
+    function setUp() public override {
+        super.setUp();
+
+        erc1271Facet = ERC1271Facet(everyoneSpace);
+        eip712 = EIP712(everyoneSpace);
+        mockApp = new MockApp();
+    }
+
+    function test_isValidSignature_validSignature() external view {
+        bytes32 messageHash = MessageHashUtils.toEthSignedMessageHash(bytes(TEST_MESSAGE));
+        bytes memory signature = _signPersonalSign(founderPrivateKey, messageHash);
+        bytes4 result = erc1271Facet.isValidSignature(messageHash, signature);
+        assertEq(result, MAGICVALUE, "Should return magic value for valid signature");
+    }
+
+    function test_isValidSignature_validTypedDataSign() external view {
+        string memory contentsDescription = "Mail(address to,string contents)";
+        string memory contents = "Hello, Towns!";
+
+        // Use MockApp to get the struct hash and domain separator
+        bytes32 structHash = mockApp.getMailStructHash(founder, contents);
+        bytes32 appDomainSeparator = mockApp.getDomainSeparator();
+
+        // The hash that the app would create and pass to isValidSignature
+        bytes32 appHash = mockApp.createMailHash(founder, contents);
+
+        bytes memory signature = _signTypedDataSign(
+            founderPrivateKey,
+            appDomainSeparator,
+            structHash,
+            contentsDescription
+        );
+
+        // Pass the app hash to isValidSignature (this is what the app would pass)
+        bytes4 result = erc1271Facet.isValidSignature(appHash, signature);
+        assertEq(result, MAGICVALUE, "Should return magic value for valid EIP-712 signature");
+    }
+
+    function _signPersonalSign(
+        uint256 privateKey,
+        bytes32 messageHash
+    ) internal view returns (bytes memory) {
+        bytes32 personalSignTypehash = keccak256("PersonalSign(bytes prefixed)");
+        bytes32 personalSignStructHash = keccak256(abi.encode(personalSignTypehash, messageHash));
+        bytes32 domainSeparator = erc1271Facet.DOMAIN_SEPARATOR();
+        bytes32 finalHash = keccak256(
+            abi.encodePacked("\x19\x01", domainSeparator, personalSignStructHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, finalHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signTypedDataSign(
+        uint256 privateKey,
+        bytes32 appDomainSeparator,
+        bytes32 structHash,
+        string memory contentsDescription
+    ) internal view returns (bytes memory) {
+        // Get the account's EIP-712 domain information and build TypedDataSign struct hash
+        bytes32 typedDataSignStructHash = _buildTypedDataSignStructHash(structHash);
+
+        // Build the final EIP-712 hash using APP_DOMAIN_SEPARATOR
+        bytes32 eip712Hash = keccak256(
+            abi.encodePacked("\x19\x01", appDomainSeparator, typedDataSignStructHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, eip712Hash);
+
+        // Append domain separator, struct hash, contents description, and its length
+        return
+            abi.encodePacked(
+                r,
+                s,
+                v,
+                appDomainSeparator,
+                structHash,
+                bytes(contentsDescription),
+                uint16(bytes(contentsDescription).length)
+            );
+    }
+
+    function _buildTypedDataSignStructHash(bytes32 structHash) internal view returns (bytes32) {
+        (
+            ,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+
+        ) = erc1271Facet.eip712Domain();
+
+        // The TypedDataSign struct has the format:
+        // TypedDataSign(Mail contents,string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)Mail(address to,string contents)
+        // We construct this dynamically using the MockApp's MAIL_TYPEHASH
+        string memory mailTypeString = "Mail(address to,string contents)";
+        string memory typedDataSignTypeString = string(
+            abi.encodePacked(
+                "TypedDataSign(Mail contents,string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)",
+                mailTypeString
+            )
+        );
+
+        bytes32 typedDataSignTypehash = keccak256(bytes(typedDataSignTypeString));
+
+        return
+            keccak256(
+                abi.encode(
+                    typedDataSignTypehash,
+                    structHash, // contents (the Mail struct hash)
+                    keccak256(bytes(name)),
+                    keccak256(bytes(version)),
+                    chainId,
+                    verifyingContract,
+                    salt
+                )
+            );
+    }
+}


### PR DESCRIPTION
### Description

Added ERC1271 support to Space contracts, enabling signature verification for smart contract wallets. This implementation allows Spaces to validate both personal signatures and EIP-712 typed data signatures, making them compatible with external applications that require signature verification.

### Changes

- Added new `ERC1271Facet` contract that implements the ERC1271 standard
- Integrated the facet into the Space diamond deployment process
- Created `MockApp` contract for testing EIP-712 signature verification
- Added comprehensive tests for signature validation including both personal signatures and typed data signatures
- Implemented domain separator exposure for EIP-712 compatibility

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines