### PR TITLE
Unread tweak - count encrypted non-ref messages as unread

### DIFF
--- a/packages/sdk/src/views/streams/unreadMarkersTransform.ts
+++ b/packages/sdk/src/views/streams/unreadMarkersTransform.ts
@@ -274,6 +274,10 @@ function isCountedAsUnread(event: TimelineEvent, myUserId: string): boolean {
     switch (event.content?.kind) {
         case RiverTimelineEvent.ChannelMessage:
             return event.sender.id !== myUserId
+        case RiverTimelineEvent.ChannelMessageEncrypted:
+            return event.sender.id !== myUserId
+        case RiverTimelineEvent.ChannelMessageEncryptedWithRef:
+            return false
         default:
             return false
     }


### PR DESCRIPTION
I was seeing really odd behavior in my app with unread, it was not displaying unreads properly if decryption was behind.
We originally did it this way before we had the WithRef version of the encrypted channel message
Testing locally this seems much better.