### PR TITLE
fix(contract): remove redundant token & amount fields from `Permit2Params`

### DIFF
--- a/packages/contracts/src/router/ISwapRouter.sol
+++ b/packages/contracts/src/router/ISwapRouter.sol
@@ -21,16 +21,13 @@ interface ISwapRouterBase {
     }
 
     /// @notice Parameters for Permit2 signature transfer with witness
+    /// @dev Token and amount are derived from ExactInputParams
     /// @param owner The owner of the tokens (who signed the permit)
-    /// @param token The token address
-    /// @param amount The amount to permit
     /// @param nonce The permit nonce
     /// @param deadline The permit deadline
     /// @param signature The permit signature
     struct Permit2Params {
         address owner;
-        address token;
-        uint256 amount;
         uint256 nonce;
         uint256 deadline;
         bytes signature;
@@ -61,9 +58,6 @@ interface ISwapRouterBase {
 
     /// @notice Error thrown when an invalid amount is provided
     error SwapRouter__InvalidAmount();
-
-    /// @notice Error thrown when the permit token does not match the swap input token
-    error SwapRouter__PermitTokenMismatch();
 
     /// @notice Error thrown when the output amount is less than the minimum expected
     error SwapRouter__InsufficientOutput();
@@ -150,7 +144,7 @@ interface ISwapRouter is ISwapRouterBase {
     /// 3. Frontend calls this function with signed permit
     /// @param params The exact input swap parameters that will be bound to the permit signature
     /// @param routerParams The router interaction parameters that will be bound to the permit signature
-    /// @param permit The Permit2 data containing token, amount, nonce, deadline, and signature
+    /// @param permit The Permit2 data containing owner, nonce, deadline, and signature
     /// @param poster The address that posted this swap opportunity (included in witness)
     /// @return amountOut The amount of output tokens received after fees
     /// @return protocolFee The amount of protocol fee collected

--- a/packages/contracts/src/router/SwapRouter.sol
+++ b/packages/contracts/src/router/SwapRouter.sol
@@ -118,19 +118,13 @@ contract SwapRouter is PausableBase, ReentrancyGuardTransient, ISwapRouter, Face
             SwapRouter__NativeTokenNotSupportedWithPermit.selector.revertWith();
         }
 
-        // verify permit token matches params tokenIn
-        if (permit.token != params.tokenIn) SwapRouter__PermitTokenMismatch.selector.revertWith();
-
-        // ensure permit amount is sufficient
-        if (permit.amount < params.amountIn) SwapRouter__InvalidAmount.selector.revertWith();
-
         // take balance snapshot before Permit2 transfer to handle fee-on-transfer tokens
         uint256 balanceBefore = params.tokenIn.balanceOf(address(this));
 
         // execute permit transfer from owner to this contract via Permit2
         ISignatureTransfer(PERMIT2).permitWitnessTransferFrom(
             ISignatureTransfer.PermitTransferFrom(
-                ISignatureTransfer.TokenPermissions(permit.token, permit.amount),
+                ISignatureTransfer.TokenPermissions(params.tokenIn, params.amountIn),
                 permit.nonce,
                 permit.deadline
             ),

--- a/packages/contracts/test/router/SwapRouter.t.sol
+++ b/packages/contracts/test/router/SwapRouter.t.sol
@@ -528,36 +528,6 @@ contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
         );
     }
 
-    function test_executeSwapWithPermit_revertWhen_invalidAmount(uint256 permitAmount) public {
-        // create permit with insufficient amount
-        Permit2Params memory permitParams = defaultEmptyPermit;
-        permitParams.token = address(token0);
-        permitParams.amount = bound(permitAmount, 0, DEFAULT_AMOUNT_IN - 1);
-
-        // expect revert with InvalidAmount (permit amount < amountIn)
-        vm.expectRevert(SwapRouter__InvalidAmount.selector);
-        swapRouter.executeSwapWithPermit(
-            defaultInputParams,
-            defaultRouterParams,
-            permitParams,
-            POSTER
-        );
-    }
-
-    function test_executeSwapWithPermit_revertWhen_permitTokenMismatch() public {
-        // create permit for wrong token
-        Permit2Params memory permitParams = defaultEmptyPermit;
-        permitParams.token = address(token1); // wrong token - should be token0
-
-        vm.expectRevert(SwapRouter__PermitTokenMismatch.selector);
-        swapRouter.executeSwapWithPermit(
-            defaultInputParams,
-            defaultRouterParams,
-            permitParams,
-            POSTER
-        );
-    }
-
     function test_executeSwapWithPermit_revertWhen_nativeTokenNotSupported() public {
         // create params with native token as input (not supported with permit)
         ExactInputParams memory inputParams = defaultInputParams;
@@ -673,8 +643,6 @@ contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
         Permit2Params memory originalPermit = _createPermitParams(
             params.privateKey,
             owner,
-            address(token0),
-            params.amountIn,
             address(swapRouter),
             0,
             block.timestamp + 1 hours,
@@ -757,8 +725,6 @@ contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
         Permit2Params memory permitParams = _createPermitParams(
             params.privateKey,
             owner,
-            address(token0),
-            params.amountIn,
             address(swapRouter),
             0, // nonce
             params.deadline,
@@ -838,8 +804,6 @@ contract SwapRouterTest is SwapTestBase, IOwnableBase, IPausableBase {
         Permit2Params memory permitParams = _createPermitParams(
             params.privateKey,
             owner,
-            address(token0),
-            params.amountIn,
             address(swapRouter),
             0, // nonce
             params.deadline,

--- a/packages/contracts/test/spaces/swap/SwapFacet.t.sol
+++ b/packages/contracts/test/spaces/swap/SwapFacet.t.sol
@@ -523,8 +523,6 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
         Permit2Params memory permitParams = _createPermitParams(
             privateKey,
             owner,
-            address(token0),
-            amountIn,
             address(swapRouter),
             0, // nonce
             block.timestamp + 1 hours,
@@ -603,8 +601,6 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
         Permit2Params memory permitParams = _createPermitParams(
             privateKey,
             owner,
-            address(token0),
-            amountIn,
             address(swapRouter),
             0, // nonce
             block.timestamp + 1 hours,

--- a/packages/generated/dev/abis/ISwapFacet.abi.json
+++ b/packages/generated/dev/abis/ISwapFacet.abi.json
@@ -141,16 +141,6 @@
             "internalType": "address"
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
             "name": "nonce",
             "type": "uint256",
             "internalType": "uint256"
@@ -435,11 +425,6 @@
   {
     "type": "error",
     "name": "SwapRouter__NativeTokenNotSupportedWithPermit",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/ISwapFacet.abi.ts
+++ b/packages/generated/dev/abis/ISwapFacet.abi.ts
@@ -141,16 +141,6 @@ export default [
             "internalType": "address"
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
             "name": "nonce",
             "type": "uint256",
             "internalType": "uint256"
@@ -435,11 +425,6 @@ export default [
   {
     "type": "error",
     "name": "SwapRouter__NativeTokenNotSupportedWithPermit",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/ISwapRouter.abi.json
+++ b/packages/generated/dev/abis/ISwapRouter.abi.json
@@ -146,16 +146,6 @@
             "internalType": "address"
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
             "name": "nonce",
             "type": "uint256",
             "internalType": "uint256"
@@ -465,11 +455,6 @@
   {
     "type": "error",
     "name": "SwapRouter__NativeTokenNotSupportedWithPermit",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/ISwapRouter.abi.ts
+++ b/packages/generated/dev/abis/ISwapRouter.abi.ts
@@ -146,16 +146,6 @@ export default [
             "internalType": "address"
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
             "name": "nonce",
             "type": "uint256",
             "internalType": "uint256"
@@ -465,11 +455,6 @@ export default [
   {
     "type": "error",
     "name": "SwapRouter__NativeTokenNotSupportedWithPermit",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
     "inputs": []
   },
   {

--- a/packages/generated/dev/abis/ISwapRouterBase.abi.json
+++ b/packages/generated/dev/abis/ISwapRouterBase.abi.json
@@ -125,11 +125,6 @@
   },
   {
     "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
-    "inputs": []
-  },
-  {
-    "type": "error",
     "name": "SwapRouter__RecipientRequired",
     "inputs": []
   },

--- a/packages/generated/dev/abis/ISwapRouterBase.abi.ts
+++ b/packages/generated/dev/abis/ISwapRouterBase.abi.ts
@@ -125,11 +125,6 @@ export default [
   },
   {
     "type": "error",
-    "name": "SwapRouter__PermitTokenMismatch",
-    "inputs": []
-  },
-  {
-    "type": "error",
     "name": "SwapRouter__RecipientRequired",
     "inputs": []
   },

--- a/packages/generated/dev/typings/ISwapFacet.ts
+++ b/packages/generated/dev/typings/ISwapFacet.ts
@@ -65,8 +65,6 @@ export declare namespace ISwapRouterBase {
 
   export type Permit2ParamsStruct = {
     owner: PromiseOrValue<string>;
-    token: PromiseOrValue<string>;
-    amount: PromiseOrValue<BigNumberish>;
     nonce: PromiseOrValue<BigNumberish>;
     deadline: PromiseOrValue<BigNumberish>;
     signature: PromiseOrValue<BytesLike>;
@@ -74,15 +72,11 @@ export declare namespace ISwapRouterBase {
 
   export type Permit2ParamsStructOutput = [
     string,
-    string,
-    BigNumber,
     BigNumber,
     BigNumber,
     string
   ] & {
     owner: string;
-    token: string;
-    amount: BigNumber;
     nonce: BigNumber;
     deadline: BigNumber;
     signature: string;
@@ -92,7 +86,7 @@ export declare namespace ISwapRouterBase {
 export interface ISwapFacetInterface extends utils.Interface {
   functions: {
     "executeSwap((address,address,uint256,uint256,address),(address,address,bytes),address)": FunctionFragment;
-    "executeSwapWithPermit((address,address,uint256,uint256,address),(address,address,bytes),(address,address,uint256,uint256,uint256,bytes),address)": FunctionFragment;
+    "executeSwapWithPermit((address,address,uint256,uint256,address),(address,address,bytes),(address,uint256,uint256,bytes),address)": FunctionFragment;
     "getSwapFees()": FunctionFragment;
     "getSwapRouter()": FunctionFragment;
     "setSwapFeeConfig(uint16,bool)": FunctionFragment;

--- a/packages/generated/dev/typings/ISwapRouter.ts
+++ b/packages/generated/dev/typings/ISwapRouter.ts
@@ -64,8 +64,6 @@ export declare namespace ISwapRouterBase {
 
   export type Permit2ParamsStruct = {
     owner: PromiseOrValue<string>;
-    token: PromiseOrValue<string>;
-    amount: PromiseOrValue<BigNumberish>;
     nonce: PromiseOrValue<BigNumberish>;
     deadline: PromiseOrValue<BigNumberish>;
     signature: PromiseOrValue<BytesLike>;
@@ -73,15 +71,11 @@ export declare namespace ISwapRouterBase {
 
   export type Permit2ParamsStructOutput = [
     string,
-    string,
-    BigNumber,
     BigNumber,
     BigNumber,
     string
   ] & {
     owner: string;
-    token: string;
-    amount: BigNumber;
     nonce: BigNumber;
     deadline: BigNumber;
     signature: string;
@@ -91,7 +85,7 @@ export declare namespace ISwapRouterBase {
 export interface ISwapRouterInterface extends utils.Interface {
   functions: {
     "executeSwap((address,address,uint256,uint256,address),(address,address,bytes),address)": FunctionFragment;
-    "executeSwapWithPermit((address,address,uint256,uint256,address),(address,address,bytes),(address,address,uint256,uint256,uint256,bytes),address)": FunctionFragment;
+    "executeSwapWithPermit((address,address,uint256,uint256,address),(address,address,bytes),(address,uint256,uint256,bytes),address)": FunctionFragment;
     "getETHInputFees(uint256,address,address)": FunctionFragment;
     "getNextNonce(address,uint256)": FunctionFragment;
     "getPermit2MessageHash((address,address,uint256,uint256,address),(address,address,bytes),address,uint256,uint256,uint256)": FunctionFragment;

--- a/packages/generated/dev/typings/factories/ISwapFacet__factory.ts
+++ b/packages/generated/dev/typings/factories/ISwapFacet__factory.ts
@@ -149,16 +149,6 @@ const _abi = [
             internalType: "address",
           },
           {
-            name: "token",
-            type: "address",
-            internalType: "address",
-          },
-          {
-            name: "amount",
-            type: "uint256",
-            internalType: "uint256",
-          },
-          {
             name: "nonce",
             type: "uint256",
             internalType: "uint256",
@@ -443,11 +433,6 @@ const _abi = [
   {
     type: "error",
     name: "SwapRouter__NativeTokenNotSupportedWithPermit",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "SwapRouter__PermitTokenMismatch",
     inputs: [],
   },
   {

--- a/packages/generated/dev/typings/factories/ISwapRouter__factory.ts
+++ b/packages/generated/dev/typings/factories/ISwapRouter__factory.ts
@@ -154,16 +154,6 @@ const _abi = [
             internalType: "address",
           },
           {
-            name: "token",
-            type: "address",
-            internalType: "address",
-          },
-          {
-            name: "amount",
-            type: "uint256",
-            internalType: "uint256",
-          },
-          {
             name: "nonce",
             type: "uint256",
             internalType: "uint256",
@@ -473,11 +463,6 @@ const _abi = [
   {
     type: "error",
     name: "SwapRouter__NativeTokenNotSupportedWithPermit",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "SwapRouter__PermitTokenMismatch",
     inputs: [],
   },
   {


### PR DESCRIPTION
### Description

Remove redundant token & amount fields from `Permit2Params`.

### Changes

- Removed redundant `token` and `amount` from `Permit2Params`, deriving them from `ExactInputParams`.
- Simplified `executeSwapWithPermit` logic by removing `SwapRouter__PermitTokenMismatch` and `SwapRouter__InvalidAmount` errors.
- Updated related test cases and replaced unnecessary parameter passing.
- Improved EIP-712 signature handling by consolidating witness hash utility logic.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
