### PR TITLE
improve go test TestReplMcConversationNoRace failure logging

### DIFF
--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -1796,6 +1796,10 @@ func (tcs testClients) compareNowImpl(
 					cmp.Equal(x.GetTargetSyncIds(), y.GetTargetSyncIds())
 			})
 
+			if diff := cmp.Diff(firstUpdates, clientUpdates, opt); diff != "" {
+				fmt.Printf("firstUpdates != clientUpdates: %s\n", diff)
+			}
+
 			diff := cmp.Diff(firstUpdates, clientUpdates, opt)
 			success = success && assert.Empty(diff)
 


### PR DESCRIPTION
Print difference when 2 compared sync sessions differ in go `TestReplMcConversationNoRace` subtests.