### PR TITLE
docs: fix and add hyperlinks to eip-2535

### DIFF
--- a/packages/contracts/CONTRIBUTING.md
+++ b/packages/contracts/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Before opening a pull request please:
 
 All contributions must follow the standards outlined in our [contracts.mdc](.cursor/rules/contracts.mdc) file. These include:
 
-1. All contracts should follow the Diamond Pattern (EIP-2535) for upgradeability
+1. All contracts should follow the Diamond Pattern ([EIP-2535](https://github.com/ethereum/ercs/blob/master/ERCS/erc-2535.md)) for upgradeability
 2. Use explicit visibility modifiers for all functions and state variables
 3. Implement proper access control using modifiers
 4. Follow gas optimization best practices
@@ -50,7 +50,7 @@ All contributions must follow the standards outlined in our [contracts.mdc](.cur
 
 ## Diamond Pattern Implementation & Facet Development
 
-The Towns Protocol uses the Diamond Pattern (EIP-2535) for contract upgradeability. When contributing new features or modifying existing ones, follow these guidelines:
+The Towns Protocol uses the Diamond Pattern ([EIP-2535](https://github.com/ethereum/ercs/blob/master/ERCS/erc-2535.md)) for contract upgradeability. When contributing new features or modifying existing ones, follow these guidelines:
 
 ### Architecture Overview
 

--- a/packages/docs/towns-smart-contracts/contracts.mdx
+++ b/packages/docs/towns-smart-contracts/contracts.mdx
@@ -11,7 +11,7 @@ This section provides an overview of the current deployment of key Towns smart c
 
 ### Key Smart Contracts
 
-Towns smart contracts are deployed using the Diamond Pattern (see [EIP-2525](https://eips.ethereum.org/EIPS/eip-2535)), which improves upon modularity and upgradeability.
+Towns smart contracts are deployed using the Diamond Pattern (see [EIP-2535](https://eips.ethereum.org/EIPS/eip-2535)), which improves upon modularity and upgradeability.
 
 The following is the current list of deployed diamond contracts on Base and a link to their associated facet addresses.
 


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

in `packages/docs/towns-smart-contracts/contracts.mdx` changed [EIP-2525] to [EIP-2535]

in `packages/contracts/CONTRIBUTING.md` have added [hyperlink](https://github.com/ethereum/ercs/blob/master/ERCS/erc-2535.md) to eip-2545

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
