### PR TITLE
sdk: dont use `crypto` from node

### DIFF
--- a/packages/sdk/.eslintrc.json
+++ b/packages/sdk/.eslintrc.json
@@ -14,6 +14,21 @@
     "ignorePatterns": ["dist/**", ".turbo/**", "node_modules/**", "vitest.*"],
     "rules": {
         "no-console": "error",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "crypto",
+                        "message": "SDK should be Web compatible. Follow the convention from @towns-protocol/rpc-connector and @towns-protocol/sdk-crypto if you need specific API."
+                    },
+                    {
+                        "name": "node:crypto",
+                        "message": "SDK should be Web compatible. Follow the convention from @towns-protocol/rpc-connector and @towns-protocol/sdk-crypto if you need specific API."
+                    }
+                ]
+            }
+        ],
         "import-x/no-extraneous-dependencies": [
             "error",
             {

--- a/packages/sdk/src/tests/unit/helpers/ConversationBuilder.ts
+++ b/packages/sdk/src/tests/unit/helpers/ConversationBuilder.ts
@@ -10,7 +10,6 @@ import {
     EventStatus,
     RiverTimelineEvent,
 } from '../../../sync-agent/timeline/models/timeline-types'
-import { randomBytes } from 'crypto'
 import { ETH_ADDRESS } from '@towns-protocol/web3'
 import { BlockchainTransaction_Tip, PlainMessage } from '@towns-protocol/proto'
 import {
@@ -20,6 +19,9 @@ import {
 } from '../../../views/streams/timelinesModel'
 import { hexToBytes } from 'ethereum-cryptography/utils'
 import { getFallbackContent } from '../../../views/streams/timelineEvents'
+import { bin_toHexString } from '@towns-protocol/dlog'
+
+const randomBytes = (len: number) => window.crypto.getRandomValues(new Uint8Array(len))
 
 export class ConversationBuilder {
     events: TimelineEvent[] = []
@@ -245,7 +247,7 @@ function makeTip(params: {
             },
         },
         tip,
-        transactionHash: randomBytes(32).toString('hex'),
+        transactionHash: bin_toHexString(randomBytes(32)),
         fromUserId: params.fromUserId,
         refEventId: params.messageId,
         toUserId: params.toUserId, // I'm cheating here and not putting it into the transaction because we use readable names for ids


### PR DESCRIPTION
We want the SDK to be compatible with Web API. Let's avoid using `node:crypto` so we dont need to use `nodePolyfills` on clients.

We _can_ support both runtimes, but this would introduce multiple paths, multiple build entries, more tests and so on. One day we gonna get there.

For now, if we need to use any specific API from node, we solve the runtime import by creating a new package (e.g @towns-protocol/rpc-connector), supporting the same interface but changing the implementation, and leave to the runtime to solve the correct module by assigning the path in `package.json` `exports` field

If you find any other node specific module usage, please add to the eslint rule.