### PR TITLE
use `lodash-es`

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -34,7 +34,6 @@
         "typed-emitter": "^2.1.0"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.186",
         "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -54,26 +54,9 @@ module.exports = {
     rules: {
         'no-console': 'error',
         'no-void': ['error', { allowAsStatement: true }],
-        'no-restricted-imports': [
-            'error',
-            {
-                paths: [
-                    {
-                        name: 'lodash',
-                        message: 'Please use lodash submodules imports.',
-                    },
-                    {
-                        name: 'lodash/fp',
-                        message: 'Please use lodash submodules imports.',
-                    },
-                ],
-            },
-        ],
         'no-constant-condition': 'off',
-
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/require-await': 'off',
-
         '@typescript-eslint/no-misused-promises': [
             'error',
             {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,7 +41,7 @@
         "dexie": "^4.0.7",
         "ethereum-cryptography": "^3.2.0",
         "ethers": "^5.7.2",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "nanoid": "^4.0.0",
         "p-limit": "^6.1.0",
         "vitest": "^3.2.3"
@@ -49,7 +49,7 @@
     "devDependencies": {
         "@connectrpc/connect-web": "^2.0.0",
         "@types/debug": "^4.1.8",
-        "@types/lodash": "^4.14.186",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.14.8",
         "@types/seedrandom": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.0",

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -23,7 +23,7 @@ import { Client } from './client'
 import { EncryptedContent } from './encryptedContentTypes'
 import { Permission } from '@towns-protocol/web3'
 import { check } from '@towns-protocol/dlog'
-import chunk from 'lodash/chunk'
+import { chunk } from 'lodash-es'
 import { isDefined } from './check'
 import { isMobileSafari } from './utils'
 import {

--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -11,7 +11,7 @@ import { Err } from '@towns-protocol/proto'
 import { genShortId, streamIdAsString } from './id'
 import { isBaseUrlIncluded, isIConnectError } from './utils'
 import { dlog, dlogError, check } from '@towns-protocol/dlog'
-import cloneDeep from 'lodash/cloneDeep'
+import { cloneDeep } from 'lodash-es'
 
 export const DEFAULT_RETRY_PARAMS: RetryParams = {
     maxAttempts: 3,

--- a/packages/sdk/src/tests/multi/transactions.test.ts
+++ b/packages/sdk/src/tests/multi/transactions.test.ts
@@ -8,7 +8,7 @@ import { LocalhostWeb3Provider } from '@towns-protocol/web3'
 import { makeRiverConfig } from '../../riverConfig'
 import { SyncAgent } from '../../sync-agent/syncAgent'
 import { Bot } from '../../sync-agent/utils/bot'
-import cloneDeep from 'lodash/cloneDeep'
+import { cloneDeep } from 'lodash-es'
 import { deepCopy } from 'ethers/lib/utils'
 import { randomBytes } from '../../utils'
 

--- a/packages/sdk/src/tests/multi/transactions_Tip.test.ts
+++ b/packages/sdk/src/tests/multi/transactions_Tip.test.ts
@@ -13,7 +13,7 @@ import { makeUniqueChannelStreamId } from '../../id'
 import { randomBytes } from '../../utils'
 import { TipEventObject } from '@towns-protocol/generated/dev/typings/ITipping'
 import { deepCopy } from 'ethers/lib/utils'
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'lodash-es'
 import { RiverTimelineEvent, TimelineEvent } from '../../sync-agent/timeline/models/timeline-types'
 
 const base_log = dlog('csb:test:transactions_Tip')

--- a/packages/sdk/src/tests/multi_ne/sign.test.ts
+++ b/packages/sdk/src/tests/multi_ne/sign.test.ts
@@ -2,7 +2,7 @@
  * @group main
  */
 
-import _ from 'lodash'
+import { cloneDeep } from 'lodash-es'
 import { unpackEnvelope, makeEvent, publicKeyToAddress } from '../../sign'
 import { make_UserPayload_Inception } from '../../types'
 import { dlog, bin_fromHexString, bin_toHexString } from '@towns-protocol/dlog'
@@ -238,19 +238,19 @@ describe('sign', () => {
             expect(event2).not.toEqual(event)
 
             await expect(async () => {
-                const e = _.cloneDeep(event)
+                const e = cloneDeep(event)
                 e.hash = event2.hash
                 await unpackEnvelope(e, undefined)
             }).rejects.toThrow()
 
             await expect(async () => {
-                const e = _.cloneDeep(event)
+                const e = cloneDeep(event)
                 e.signature = event2.signature
                 await unpackEnvelope(e, undefined)
             }).rejects.toThrow()
 
             await expect(async () => {
-                const e = _.cloneDeep(event)
+                const e = cloneDeep(event)
                 e.event = event2.event
                 await unpackEnvelope(e, undefined)
             }).rejects.toThrow()

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -41,7 +41,7 @@ import { ethers, ContractTransaction } from 'ethers'
 import { RiverDbManager } from '../riverDbManager'
 import { StreamRpcClient, makeStreamRpcClient } from '../makeStreamRpcClient'
 import assert from 'assert'
-import _ from 'lodash'
+import { forEachRight } from 'lodash-es'
 import { MockEntitlementsDelegate } from '../utils'
 import { SignerContext, makeSignerContext } from '../signerContext'
 import {
@@ -462,7 +462,7 @@ export const lastEventFiltered = <T extends (a: ParsedEvent) => any>(
     f: T,
 ): ReturnType<T> | undefined => {
     let ret: ReturnType<T> | undefined = undefined
-    _.forEachRight(events, (v): boolean => {
+    forEachRight(events, (v): boolean => {
         const r = f(v)
         if (r !== undefined) {
             ret = r

--- a/packages/sdk/src/views/streams/spaceMentionsTransform.ts
+++ b/packages/sdk/src/views/streams/spaceMentionsTransform.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual'
+import { isEqual } from 'lodash-es'
 import { isChannelStreamId, spaceIdFromChannelId } from '../../id'
 import { MentionResult } from '../../sync-agent/timeline/models/timeline-types'
 import { TimelinesViewModel } from './timelinesModel'

--- a/packages/sdk/src/views/streams/timelines.ts
+++ b/packages/sdk/src/views/streams/timelines.ts
@@ -10,7 +10,7 @@ import { StreamChange } from '../../streamEvents'
 import { toDecryptedContentErrorEvent, toDecryptedEvent, toEvent } from './timelineEvents'
 import { DecryptedContent } from '../../encryptedContentTypes'
 import { DecryptionSessionError } from '../../decryptionExtensions'
-import isEqual from 'lodash/isEqual'
+import { isEqual } from 'lodash-es'
 import { isDMChannelStreamId } from '../../id'
 
 export interface TimelinesViewDelegate {

--- a/packages/sdk/src/views/streams/timelinesModel.ts
+++ b/packages/sdk/src/views/streams/timelinesModel.ts
@@ -1,4 +1,3 @@
-import reverse from 'lodash/reverse'
 import {
     MessageTipEvent,
     MessageTips,
@@ -407,7 +406,7 @@ export function makeTimelinesViewInterface(
 
     function prependEvents(events: TimelineEvent[], userId: string, streamId: string) {
         setState((state) => {
-            for (const event of reverse(events)) {
+            for (const event of [...events].reverse()) {
                 const editsEventId = getEditsId(event.content)
                 const redactsEventId = getRedactsId(event.content)
                 if (redactsEventId) {

--- a/packages/sdk/src/views/transforms/blockedUserIdsTransform.ts
+++ b/packages/sdk/src/views/transforms/blockedUserIdsTransform.ts
@@ -1,5 +1,5 @@
 import { UserSettingsPayload_Snapshot_UserBlocks } from '@towns-protocol/proto'
-import { isEqual } from 'lodash'
+import { isEqual } from 'lodash-es'
 
 type Input = Record<string, UserSettingsPayload_Snapshot_UserBlocks>
 

--- a/packages/sdk/src/views/transforms/dmsAndGdmsTransform.ts
+++ b/packages/sdk/src/views/transforms/dmsAndGdmsTransform.ts
@@ -3,7 +3,7 @@ import { Membership } from '../../sync-agent/timeline/models/timeline-types'
 import { DmStreamModel } from '../streams/dmStreams'
 import { GdmStreamModel } from '../streams/gdmStreams'
 import { isDefined } from '../../check'
-import isEqual from 'lodash/isEqual'
+import { isEqual } from 'lodash-es'
 
 export interface DmAndGdmModel {
     id: string

--- a/packages/sdk/src/views/transforms/dmsAndGdmsUnreadIdsTransform.ts
+++ b/packages/sdk/src/views/transforms/dmsAndGdmsUnreadIdsTransform.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual'
+import { isEqual } from 'lodash-es'
 import { UnreadMarkersModel } from '../streams/unreadMarkersTransform'
 import { DmAndGdmModel } from './dmsAndGdmsTransform'
 

--- a/packages/sdk/src/views/transforms/membershipsTransform.ts
+++ b/packages/sdk/src/views/transforms/membershipsTransform.ts
@@ -2,7 +2,7 @@ import { UserPayload_UserMembership } from '@towns-protocol/proto'
 import { Membership } from '../../sync-agent/timeline/models/timeline-types'
 import { UserStreamModel } from '../streams/userStreamsView'
 import { toMembership } from '../streams/timelineEvents'
-import { isEqual } from 'lodash'
+import { isEqual } from 'lodash-es'
 
 export function membershipsTransform(
     userStream?: UserStreamModel,

--- a/packages/sdk/src/views/transforms/spaceIdsTransform.ts
+++ b/packages/sdk/src/views/transforms/spaceIdsTransform.ts
@@ -1,6 +1,6 @@
 import { Membership } from '../../sync-agent/timeline/models/timeline-types'
 import { isSpaceStreamId } from '../../id'
-import isEqual from 'lodash/isEqual'
+import { isEqual } from 'lodash-es'
 
 export function spaceIdsTransform(
     memberships: Record<string, Membership>,

--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -32,7 +32,6 @@
     },
     "devDependencies": {
         "@types/debug": "^4.1.8",
-        "@types/lodash": "^4.14.186",
         "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -27,14 +27,12 @@
         "abitype": "^0.9.10",
         "debug": "^4.3.4",
         "ethers": "^5.7.2",
-        "lodash": "^4.17.21",
         "lru-cache": "^11.0.1",
         "nanoid": "^4.0.0",
         "viem": "^2.29.3",
         "zod": "^3.21.4"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.186",
         "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8535,7 +8535,6 @@ __metadata:
     "@towns-protocol/olm": 3.2.28
     "@towns-protocol/proto": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
-    "@types/lodash": ^4.14.186
     "@types/node": ^20.14.8
     "@typescript-eslint/eslint-plugin": ^8.29.0
     "@typescript-eslint/parser": ^8.29.0
@@ -8783,7 +8782,7 @@ __metadata:
     "@towns-protocol/sdk-crypto": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
     "@types/debug": ^4.1.8
-    "@types/lodash": ^4.14.186
+    "@types/lodash-es": ^4.17.12
     "@types/node": ^20.14.8
     "@types/seedrandom": ^3.0.4
     "@typescript-eslint/eslint-plugin": ^8.29.0
@@ -8798,7 +8797,7 @@ __metadata:
     ethers: ^5.7.2
     fake-indexeddb: ^4.0.1
     happy-dom: ^15.11.7
-    lodash: ^4.17.21
+    lodash-es: ^4.17.21
     nanoid: ^4.0.0
     p-limit: ^6.1.0
     seedrandom: ^3.0.5
@@ -8869,7 +8868,6 @@ __metadata:
     "@towns-protocol/sdk": "workspace:^"
     "@towns-protocol/web3": "workspace:^"
     "@types/debug": ^4.1.8
-    "@types/lodash": ^4.14.186
     "@types/node": ^20.14.8
     "@typescript-eslint/eslint-plugin": ^8.29.0
     "@typescript-eslint/parser": ^8.29.0
@@ -8917,7 +8915,6 @@ __metadata:
     "@isaacs/ttlcache": ^1.4.1
     "@towns-protocol/dlog": "workspace:^"
     "@towns-protocol/generated": "workspace:^"
-    "@types/lodash": ^4.14.186
     "@types/node": ^20.14.8
     "@typescript-eslint/eslint-plugin": ^8.29.0
     "@typescript-eslint/parser": ^8.29.0
@@ -8927,7 +8924,6 @@ __metadata:
     eslint-import-resolver-typescript: ^4.3.2
     eslint-plugin-import-x: ^4.10.2
     ethers: ^5.7.2
-    lodash: ^4.17.21
     lru-cache: ^11.0.1
     nanoid: ^4.0.0
     typed-emitter: ^2.1.0
@@ -9253,10 +9249,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.186":
-  version: 4.14.202
-  resolution: "@types/lodash@npm:4.14.202"
-  checksum: a91acf3564a568c6f199912f3eb2c76c99c5a0d7e219394294213b3f2d54f672619f0fde4da22b29dc5d4c31457cd799acc2e5cb6bd90f9af04a1578483b6ff7
+"@types/lodash-es@npm:^4.17.12":
+  version: 4.17.12
+  resolution: "@types/lodash-es@npm:4.17.12"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 990a99e2243bebe9505cb5ad19fbc172beb4a8e00f9075c99fc06c46c2801ffdb40bc2867271cf580d5f48994fc9fb076ec92cd60a20e621603bf22114e5b077
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.17.18
+  resolution: "@types/lodash@npm:4.17.18"
+  checksum: 539b2a01a83062888c36e53450b03ff2fbb4631a8226df38e1d77888c954c931b0b1abcbb26bb4f19ffc37da5b0be4db8b3002560d2acc036e8d28ebad132c47
   languageName: node
   linkType: hard
 
@@ -20225,6 +20230,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
for better tree-shakability + keeping in sync with harmony.

also removed `lodash` dependencies from encryption, stress, and web3 package, which `lodash` was unused.