### PR TITLE
notification_service: clone node registry instead of loading it multi…

### DIFF
--- a/core/node/nodes/node_registry.go
+++ b/core/node/nodes/node_registry.go
@@ -327,3 +327,60 @@ func (n *nodeRegistryImpl) ChooseStreamNodes(
 ) ([]common.Address, error) {
 	return n.streamPicker.ChooseStreamNodes(ctx, streamId, replFactor)
 }
+
+// CloneWithClients returns a new node registry with cloned values from n and the given
+// httpClient and httpClientWithCert.
+func (n *nodeRegistryImpl) CloneWithClients(
+	httpClient *http.Client,
+	httpClientWithCert *http.Client,
+) *nodeRegistryImpl {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	clone := &nodeRegistryImpl{
+		contract:              n.contract,
+		onChainConfig:         n.onChainConfig,
+		localNodeAddress:      n.localNodeAddress,
+		httpClient:            httpClient,
+		httpClientWithCert:    httpClientWithCert,
+		streamPicker:          n.streamPicker,
+		appliedBlockNumLocked: n.appliedBlockNumLocked,
+	}
+
+	clone.connectOpts = make([]connect.ClientOption, len(n.connectOpts))
+	copy(clone.connectOpts, n.connectOpts)
+
+	clone.nodesLocked = make(map[common.Address]*NodeRecord, len(n.nodesLocked))
+	for addr, node := range n.nodesLocked {
+		clonedNode := &NodeRecord{
+			address:             node.address,
+			operator:            node.operator,
+			url:                 node.url,
+			status:              node.status,
+			local:               node.local,
+			streamServiceClient: node.streamServiceClient,
+			nodeToNodeClient:    node.nodeToNodeClient,
+		}
+		clone.nodesLocked[addr] = clonedNode
+	}
+
+	clone.allNodesLocked = make([]*NodeRecord, len(n.allNodesLocked))
+	for i, node := range n.allNodesLocked {
+		clone.allNodesLocked[i] = clone.nodesLocked[node.address]
+	}
+
+	clone.activeNodesLocked = make([]*NodeRecord, len(n.activeNodesLocked))
+	for i, node := range n.activeNodesLocked {
+		clone.activeNodesLocked[i] = clone.nodesLocked[node.address]
+	}
+
+	clone.validAddrsLocked = make([]common.Address, len(n.validAddrsLocked))
+	copy(clone.validAddrsLocked, n.validAddrsLocked)
+
+	clone.operatorsLocked = make(map[common.Address]bool, len(n.operatorsLocked))
+	for addr, val := range n.operatorsLocked {
+		clone.operatorsLocked[addr] = val
+	}
+
+	return clone
+}


### PR DESCRIPTION
Loading the node registry takes time because it needs to load data from RiverChain. The notification service instantiates multiple instances of the node registry that all add up to boot up time. This causes the kubernetes readiness probe to time out and restart the service. This causes a restart loop.

This PR doesn't load multiple node registries but instead loads one clones it. This approach doesn't add noticeable time to the boot up sequence and should finish the boot up sequence within the probe timeout.

Long term the notification service could probably use a single node registry (http client) instance when shared syncers are enabled for all. This change is currently in deployment.