### PR TITLE
Upgrade vite to rolldown-vite@^7.0.0

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -63,7 +63,7 @@
         "prettier-plugin-tailwindcss": "^0.4.1",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.8.2",
-        "vite": "npm:rolldown-vite@6.3.21",
+        "vite": "npm:rolldown-vite@^7.0.0",
         "vite-plugin-checker": "^0.8.0",
         "vite-plugin-wasm": "^3.4.1",
         "vite-tsconfig-paths": "^5.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,10 +5715,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/runtime@npm:0.73.0, @oxc-project/runtime@npm:=0.73.0":
-  version: 0.73.0
-  resolution: "@oxc-project/runtime@npm:0.73.0"
-  checksum: f65564802974291dba684a2aee14a5a29d061fe48692cd834eec9ba8b361c7e8782e86baac95fa394634b3f34c95c52f1b66ca25c3df257aa005631e2093e0dc
+"@oxc-project/runtime@npm:0.73.2, @oxc-project/runtime@npm:=0.73.2":
+  version: 0.73.2
+  resolution: "@oxc-project/runtime@npm:0.73.2"
+  checksum: 31e568b1ef0b703af2dd2c96cb01b559e67f4b905f584b417b3bed07515c37671bfe72d20f8a2131368c08f5e8c248d0564df2d41da9a23f40be0c11dd75c46f
   languageName: node
   linkType: hard
 
@@ -5736,10 +5736,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.73.0":
-  version: 0.73.0
-  resolution: "@oxc-project/types@npm:0.73.0"
-  checksum: ecbd091fca847bf7113b3116a986e70085cafcb565e4f123899c7b7bb47fb71271706eee6fe93fdb8d04c8e9c3cba5b4eca22ddd7728589b0dc4228a41533efe
+"@oxc-project/types@npm:=0.73.2":
+  version: 0.73.2
+  resolution: "@oxc-project/types@npm:0.73.2"
+  checksum: 3619befcade730358df58bc5e2c9c037692f87fb6e4fc845246f528cbfd624a5aad8bee1f1ef5b6699453e6ffa274b5a01f9f1018f010772fad7e43b143a5a18
   languageName: node
   linkType: hard
 
@@ -6871,9 +6871,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-beta.16"
+"@rolldown/binding-darwin-arm64@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-beta.18"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -6885,9 +6885,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-beta.16"
+"@rolldown/binding-darwin-x64@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-beta.18"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6899,9 +6899,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-beta.16"
+"@rolldown/binding-freebsd-x64@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-beta.18"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6913,9 +6913,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.16"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.18"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -6927,9 +6927,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.16"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.18"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -6941,9 +6941,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.16"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.18"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -6955,9 +6955,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.16"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.18"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -6969,9 +6969,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.16"
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.18"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -6985,9 +6985,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.16"
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.18"
   dependencies:
     "@napi-rs/wasm-runtime": ^0.2.10
   conditions: cpu=wasm32
@@ -7001,9 +7001,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.16"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.18"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -7015,9 +7015,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.16"
+"@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-win32-ia32-msvc@npm:1.0.0-beta.18"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -7029,9 +7029,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.16"
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.18"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7050,10 +7050,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.16"
-  checksum: 4b39f4991a2ff59c84ee1caba68ebf299b2b113f491f0d6f201d96a6ea9e303d70830ccfedaa8d487557921746d8d2c4de4bf63b61bfccea93cb497d06fc6bec
+"@rolldown/pluginutils@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.18"
+  checksum: e2ecdf00127bbfafc92c474c159391ab0a0e6282828c1437d507aff8582b10f75879f5e82273129f50d187c488125f047ee5f4d44f7bc4039da3de3c2a261296
   languageName: node
   linkType: hard
 
@@ -8687,7 +8687,7 @@ __metadata:
     typescript: ^5.8.2
     use-stick-to-bottom: ^1.1.0
     viem: ^2.29.3
-    vite: "npm:rolldown-vite@6.3.21"
+    vite: "npm:rolldown-vite@^7.0.0"
     vite-plugin-checker: ^0.8.0
     vite-plugin-wasm: ^3.4.1
     vite-tsconfig-paths: ^5.1.3
@@ -16444,6 +16444,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.4.6":
+  version: 6.4.6
+  resolution: "fdir@npm:6.4.6"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: fe9f3014901d023cf631831dcb9eae5447f4d7f69218001dd01ecf007eccc40f6c129a04411b5cc273a5f93c14e02e971e17270afc9022041c80be924091eb6f
+  languageName: node
+  linkType: hard
+
 "fflate@npm:^0.8.2":
   version: 0.8.2
   resolution: "fflate@npm:0.8.2"
@@ -20033,7 +20045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss@npm:^1.30.0":
+"lightningcss@npm:^1.30.1":
   version: 1.30.1
   resolution: "lightningcss@npm:1.30.1"
   dependencies:
@@ -24899,6 +24911,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.5.6":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
+  dependencies:
+    nanoid: ^3.3.11
+    picocolors: ^1.1.1
+    source-map-js: ^1.2.1
+  checksum: 20f3b5d673ffeec2b28d65436756d31ee33f65b0a8bedb3d32f556fbd5973be38c3a7fb5b959a5236c60a5db7b91b0a6b14ffaac0d717dce1b903b964ee1c1bb
+  languageName: node
+  linkType: hard
+
 "postgres-array@npm:~2.0.0":
   version: 2.0.0
   resolution: "postgres-array@npm:2.0.0"
@@ -26534,25 +26557,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-beta.16":
-  version: 1.0.0-beta.16
-  resolution: "rolldown@npm:1.0.0-beta.16"
+"rolldown@npm:1.0.0-beta.18":
+  version: 1.0.0-beta.18
+  resolution: "rolldown@npm:1.0.0-beta.18"
   dependencies:
-    "@oxc-project/runtime": =0.73.0
-    "@oxc-project/types": =0.73.0
-    "@rolldown/binding-darwin-arm64": 1.0.0-beta.16
-    "@rolldown/binding-darwin-x64": 1.0.0-beta.16
-    "@rolldown/binding-freebsd-x64": 1.0.0-beta.16
-    "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-beta.16
-    "@rolldown/binding-linux-arm64-gnu": 1.0.0-beta.16
-    "@rolldown/binding-linux-arm64-musl": 1.0.0-beta.16
-    "@rolldown/binding-linux-x64-gnu": 1.0.0-beta.16
-    "@rolldown/binding-linux-x64-musl": 1.0.0-beta.16
-    "@rolldown/binding-wasm32-wasi": 1.0.0-beta.16
-    "@rolldown/binding-win32-arm64-msvc": 1.0.0-beta.16
-    "@rolldown/binding-win32-ia32-msvc": 1.0.0-beta.16
-    "@rolldown/binding-win32-x64-msvc": 1.0.0-beta.16
-    "@rolldown/pluginutils": 1.0.0-beta.16
+    "@oxc-project/runtime": =0.73.2
+    "@oxc-project/types": =0.73.2
+    "@rolldown/binding-darwin-arm64": 1.0.0-beta.18
+    "@rolldown/binding-darwin-x64": 1.0.0-beta.18
+    "@rolldown/binding-freebsd-x64": 1.0.0-beta.18
+    "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-beta.18
+    "@rolldown/binding-linux-arm64-gnu": 1.0.0-beta.18
+    "@rolldown/binding-linux-arm64-musl": 1.0.0-beta.18
+    "@rolldown/binding-linux-x64-gnu": 1.0.0-beta.18
+    "@rolldown/binding-linux-x64-musl": 1.0.0-beta.18
+    "@rolldown/binding-wasm32-wasi": 1.0.0-beta.18
+    "@rolldown/binding-win32-arm64-msvc": 1.0.0-beta.18
+    "@rolldown/binding-win32-ia32-msvc": 1.0.0-beta.18
+    "@rolldown/binding-win32-x64-msvc": 1.0.0-beta.18
+    "@rolldown/pluginutils": 1.0.0-beta.18
     ansis: ^4.0.0
   dependenciesMeta:
     "@rolldown/binding-darwin-arm64":
@@ -26581,7 +26604,7 @@ __metadata:
       optional: true
   bin:
     rolldown: bin/cli.mjs
-  checksum: 45bda2acfcbd6bb0968985596b7cb6db8232620cc47aae7fc7998143122dc5363edf6d331cb756fd5b9899d59c17c18b0fc0757d9d88224dddb17869f3ee6c64
+  checksum: baaaaf14a52348c4bfdbb1766ca57d3c040049162e8d07afce238d6ff602dfc3076aeb4f229f25f6695e0625ef444514532fdb8bfff42f47e85e63a78040db1c
   languageName: node
   linkType: hard
 
@@ -28663,7 +28686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14":
+"tinyglobby@npm:^0.2.14":
   version: 0.2.14
   resolution: "tinyglobby@npm:0.2.14"
   dependencies:
@@ -30809,27 +30832,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:rolldown-vite@6.3.21":
-  version: 6.3.21
-  resolution: "rolldown-vite@npm:6.3.21"
+"vite@npm:rolldown-vite@^7.0.0":
+  version: 7.0.0
+  resolution: "rolldown-vite@npm:7.0.0"
   dependencies:
-    "@oxc-project/runtime": 0.73.0
-    fdir: ^6.4.4
+    "@oxc-project/runtime": 0.73.2
+    fdir: ^6.4.6
     fsevents: ~2.3.3
-    lightningcss: ^1.30.0
+    lightningcss: ^1.30.1
     picomatch: ^4.0.2
-    postcss: ^8.5.3
-    rolldown: 1.0.0-beta.16
-    tinyglobby: ^0.2.13
+    postcss: ^8.5.6
+    rolldown: 1.0.0-beta.18
+    tinyglobby: ^0.2.14
   peerDependencies:
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@types/node": ^20.19.0 || >=22.12.0
     esbuild: ^0.25.0
     jiti: ">=1.21.0"
-    less: "*"
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
     terser: ^5.16.0
     tsx: ^4.8.1
     yaml: ^2.4.2
@@ -30861,7 +30884,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 5f4016d61693dbbec42ffd1194487c769143b855f88370c5b24fc9ef68f45c37f89f9af19f11d97cd082dbb842e6de7c6c4363c22bbaf4e91e7f607c9ed9f8dc
+  checksum: 478127a9e61d4b17e21e82da29088fcdaf3a64f782ca7c497b7d6808d531beaafdc765a1982e81beb1940a21bd46c4b13fb95af9b594161333e47fc09d081ecc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The vite dependency in packages/playground/package.json was updated.

The version was changed from "npm:rolldown-vite@6.3.21" to "npm:rolldown-vite@^7.0.0".

(PR comes from a fork, trying cursor background agents, which requires public repos to be forked)