### PR TITLE
Fix for retrySendMessage

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1253,7 +1253,7 @@ export class Client
         const timelineEvent = this.streamsView.timelinesView.value.timelines[streamId]?.find(
             (e) => e.eventId === eventId,
         )
-        check(isDefined(timelineEvent), 'event not found')
+        check(isDefined(timelineEvent), 'pin timeline event not found')
         const blockNumber = timelineEvent.confirmedInBlockNum
         let event: ParsedEvent | undefined
         if (blockNumber) {
@@ -1265,9 +1265,9 @@ export class Client
             check(isDefined(stream), 'stream not found')
             event = stream.view.minipoolEvents.get(eventId)?.remoteEvent
         }
-        check(isDefined(event), 'event not found')
+        check(isDefined(event), 'pin event not found')
         const streamEvent = event.event
-        check(isDefined(streamEvent), 'streamEvent not found')
+        check(isDefined(streamEvent), 'pin streamEvent not found')
         const result = await this.makeEventAndAddToStream(
             streamId,
             make_MemberPayload_Pin(event.hash, streamEvent),
@@ -1949,9 +1949,13 @@ export class Client
     async retrySendMessage(streamId: string, localId: string): Promise<void> {
         const stream = this.stream(streamId)
         check(isDefined(stream), 'stream not found' + streamId)
-        const event = stream.view.minipoolEvents.get(localId)
-        check(isDefined(event), 'event not found')
-        check(isDefined(event.localEvent), 'event not found')
+        const event =
+            stream.view.minipoolEvents.get(localId) ??
+            Array.from(stream.view.minipoolEvents.values()).find(
+                (e) => e.localEvent?.localId === localId,
+            )
+        check(isDefined(event), 'retry event not found')
+        check(isDefined(event.localEvent), 'retry local event not found')
         check(event.localEvent.status === 'failed', 'event not in failed state')
         await this.makeAndSendChannelMessageEvent(
             streamId,


### PR DESCRIPTION
When i refactored the timeline i stopped keeping two copies of the event in the events map in favor of keeping a minipool record…
This broke the lookup when retrying a message.