### PR TITLE
refactor: rename provideXChainRefund to requestXChainRefund and improve storage access

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployXChain.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployXChain.s.sol
@@ -15,7 +15,7 @@ library DeployXChain {
         res = new bytes4[](3);
         res[0] = XChain.postEntitlementCheckResult.selector;
         res[1] = XChain.isCheckCompleted.selector;
-        res[2] = XChain.provideXChainRefund.selector;
+        res[2] = XChain.requestXChainRefund.selector;
     }
 
     function makeCut(

--- a/packages/contracts/src/base/registry/facets/xchain/IXChain.sol
+++ b/packages/contracts/src/base/registry/facets/xchain/IXChain.sol
@@ -26,7 +26,25 @@ struct VoteResults {
     IEntitlementGatedBase.NodeVoteStatus finalStatus;
 }
 
-interface IXChain is IEntitlementGatedBase, IEntitlementCheckerBase {
+interface IXChainBase {
+    error Unauthorized();
+    error TransactionCheckAlreadyCompleted();
+    error RefundNotYetAvailable();
+    error InvalidValue();
+    error VotingInProgress();
+
+    /// @notice Emitted when a refund is processed
+    /// @param senderAddress The address that received the refund
+    /// @param transactionId The transaction ID that was refunded
+    /// @param amount The amount refunded
+    event RefundProcessed(
+        address indexed senderAddress,
+        bytes32 indexed transactionId,
+        uint256 amount
+    );
+}
+
+interface IXChain is IXChainBase, IEntitlementGatedBase, IEntitlementCheckerBase {
     /// @notice Checks if a specific entitlement check request has been completed
     /// @param transactionId The unique identifier of the transaction
     /// @param requestId The ID of the specific check request
@@ -38,9 +56,8 @@ interface IXChain is IEntitlementGatedBase, IEntitlementCheckerBase {
 
     /// @notice Allows protocol to provide a refund for a timed-out entitlement check
     /// @dev Will revert if the contract has insufficient funds
-    /// @param senderAddress The address to receive the refund
     /// @param transactionId The unique identifier of the transaction being checked
-    function provideXChainRefund(address senderAddress, bytes32 transactionId) external;
+    function requestXChainRefund(bytes32 transactionId) external;
 
     /// @notice Posts the result of an entitlement check from a node
     /// @param transactionId The unique identifier of the transaction being checked

--- a/packages/contracts/src/base/registry/facets/xchain/XChainCheckLib.sol
+++ b/packages/contracts/src/base/registry/facets/xchain/XChainCheckLib.sol
@@ -102,4 +102,24 @@ library XChainCheckLib {
             ? IEntitlementGatedBase.NodeVoteStatus.PASSED
             : IEntitlementGatedBase.NodeVoteStatus.FAILED;
     }
+
+    function completeVotes(XChainLib.Check storage self) internal {
+        uint256 requestIdsLength = self.requestIds.length();
+        if (requestIdsLength > 0) {
+            for (uint256 i; i < requestIdsLength; ++i) {
+                uint256 requestId = self.requestIds.at(i);
+                self.voteCompleted[requestId] = true;
+            }
+        }
+    }
+
+    function areAllRequestsCompleted(XChainLib.Check storage self) internal view returns (bool) {
+        uint256 requestIdsLength = self.requestIds.length();
+        for (uint256 i; i < requestIdsLength; ++i) {
+            if (!self.voteCompleted[self.requestIds.at(i)]) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/packages/contracts/src/base/registry/facets/xchain/XChainLib.sol
+++ b/packages/contracts/src/base/registry/facets/xchain/XChainLib.sol
@@ -10,6 +10,8 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 // contracts
 
 library XChainLib {
+    using EnumerableSet for EnumerableSet.UintSet;
+
     // keccak256(abi.encode(uint256(keccak256("xchain.entitlement.transactions.storage")) - 1)) &
     // ~bytes32(uint256(0xff))
     bytes32 internal constant STORAGE_SLOT =
@@ -37,10 +39,9 @@ library XChainLib {
         mapping(bytes32 => Check) checks;
     }
 
-    function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = STORAGE_SLOT;
+    function getLayout() internal pure returns (Layout storage $) {
         assembly {
-            l.slot := slot
+            $.slot := STORAGE_SLOT
         }
     }
 }


### PR DESCRIPTION
### Description

This PR refactors the cross-chain refund mechanism to be user-initiated rather than admin-controlled. It replaces the `provideXChainRefund` function with a `requestXChainRefund` function that allows users to directly request refunds after a timeout period, eliminating the need for admin intervention.

### Changes

- Renamed `provideXChainRefund` to `requestXChainRefund` and updated its signature to remove the `senderAddress` parameter
- Added a 4-hour timeout period (1200 blocks) before refunds can be requested
- Created a dedicated `IXChainBase` interface with common errors and events
- Added a `RefundProcessed` event to track refund transactions
- Improved code readability by using `$` as a shorthand for storage layout variables
- Added a `completeVotes` helper function to clean up check state
- Updated tests to reflect the new refund mechanism
- Simplified several storage access patterns

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines