### PR TITLE
(Claude) Improve RPC error handling by including base error and tag information

### DIFF
--- a/core/node/rpc/add_media_event.go
+++ b/core/node/rpc/add_media_event.go
@@ -100,7 +100,7 @@ func (s *Service) getGenesisMediaEvent(ctx context.Context, streamId StreamId) (
 
 	var mediaEvent StreamEvent
 	if err = proto.Unmarshal(mb.GetEvents()[0].Event, &mediaEvent); err != nil {
-		return nil, RiverError(Err_INTERNAL, "Failed to decode stream event from genesis miniblock")
+		return nil, RiverErrorWithBase(Err_INTERNAL, "Failed to decode stream event from genesis miniblock", err)
 	}
 
 	if mediaEvent.GetMediaPayload().GetInception() == nil {

--- a/core/node/rpc/create_media_stream.go
+++ b/core/node/rpc/create_media_stream.go
@@ -69,6 +69,14 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 		streamIdBytes := event.StreamId
 		stream, err := s.cache.GetStreamNoWait(ctx, streamIdBytes)
 		if err != nil || stream == nil {
+			// Include the base error if it exists.
+			if err != nil {
+				return nil, RiverErrorWithBase(
+					Err_PERMISSION_DENIED,
+					"stream does not exist",
+					err,
+				).Tag("streamId", streamIdBytes)
+			}
 			return nil, RiverError(Err_PERMISSION_DENIED, "stream does not exist", "streamId", streamIdBytes)
 		}
 	}
@@ -82,12 +90,12 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 			creatorStreamView, err = stream.GetView(ctx)
 		}
 		if err != nil {
-			return nil, RiverError(Err_PERMISSION_DENIED, "failed to load creator stream", "error", err)
+			return nil, RiverErrorWithBase(Err_PERMISSION_DENIED, "failed to load creator stream", err)
 		}
 		for _, streamIdBytes := range csRules.RequiredMemberships {
 			streamId, err := StreamIdFromBytes(streamIdBytes)
 			if err != nil {
-				return nil, RiverError(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", "error", err)
+				return nil, RiverErrorWithBase(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", err)
 			}
 			if !creatorStreamView.IsMemberOf(streamId) {
 				return nil, RiverError(Err_PERMISSION_DENIED, "not a member of", "requiredStreamId", streamId)
@@ -99,12 +107,20 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 	for _, userAddress := range csRules.RequiredUserAddrs {
 		addr, err := BytesToAddress(userAddress)
 		if err != nil {
-			return nil, RiverError(Err_PERMISSION_DENIED, "invalid user id", "requiredUser", userAddress)
+			return nil, RiverErrorWithBase(
+				Err_PERMISSION_DENIED,
+				"invalid user id",
+				err,
+			).Tag("requiredUser", userAddress)
 		}
 		userStreamId := UserStreamIdFromAddr(addr)
 		_, err = s.cache.GetStreamNoWait(ctx, userStreamId)
 		if err != nil {
-			return nil, RiverError(Err_PERMISSION_DENIED, "user does not exist", "requiredUser", userAddress)
+			return nil, RiverErrorWithBase(
+				Err_PERMISSION_DENIED,
+				"user does not exist",
+				err,
+			).Tag("requiredUser", userAddress)
 		}
 	}
 
@@ -135,7 +151,7 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 	for _, de := range csRules.DerivedEvents {
 		_, err = s.AddEventPayload(ctx, de.StreamId, de.Payload, de.Tags)
 		if err != nil {
-			return nil, RiverError(Err_INTERNAL, "failed to add derived event", "error", err)
+			return nil, RiverErrorWithBase(Err_INTERNAL, "failed to add derived event", err)
 		}
 	}
 
@@ -146,7 +162,9 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 		// Make sure the given chunk index is 0 as it is the first chunk
 		if chunk.GetChunkIndex() != 0 {
 			return nil, RiverError(Err_INVALID_ARGUMENT, "initial chunk index must be zero").
-				Func("createMediaStream")
+				Func("createMediaStream").
+				Tag("streamId", streamId).
+				Tag("chunkIndex", chunk.GetChunkIndex())
 		}
 
 		// Make sure the given chunk size does not exceed the maximum chunk size
@@ -156,7 +174,8 @@ func (s *Service) createMediaStream(ctx context.Context, req *CreateMediaStreamR
 				"chunk size must be less than or equal to",
 				"s.chainConfig.Get().MediaMaxChunkSize",
 				s.chainConfig.Get().MediaMaxChunkSize).
-				Func("createMediaStream")
+				Func("createMediaStream").
+				Tag("chunkSize", len(chunk.GetData()))
 		}
 
 		mbHash, err := s.replicatedAddMediaEvent(

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -39,7 +39,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 
 	streamId, err := StreamIdFromBytes(req.StreamId)
 	if err != nil {
-		return nil, nil, RiverError(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", "error", err)
+		return nil, nil, RiverErrorWithBase(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", err)
 	}
 
 	if len(req.Events) == 0 {
@@ -72,6 +72,14 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 			streamIdBytes := event.StreamId
 			stream, err := s.cache.GetStreamNoWait(ctx, streamIdBytes)
 			if err != nil || stream == nil {
+				// Include the base error if it exists.
+				if err != nil {
+					return nil, nil, RiverErrorWithBase(
+						Err_PERMISSION_DENIED,
+						"stream does not exist",
+						err,
+					).Tag("streamId", streamIdBytes)
+				}
 				return nil, nil, RiverError(Err_PERMISSION_DENIED, "stream does not exist", "streamId", streamIdBytes)
 			}
 		}
@@ -86,12 +94,17 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 			creatorStreamView, err = stream.GetView(ctx)
 		}
 		if err != nil {
-			return nil, nil, RiverError(Err_PERMISSION_DENIED, "failed to load creator stream", "error", err)
+			return nil, nil, RiverErrorWithBase(
+				Err_PERMISSION_DENIED,
+				"failed to load creator stream",
+				err,
+			).Tag("streamId", streamId).
+				Tag("creatorStreamId", csRules.CreatorStreamId)
 		}
 		for _, streamIdBytes := range csRules.RequiredMemberships {
 			streamId, err := StreamIdFromBytes(streamIdBytes)
 			if err != nil {
-				return nil, nil, RiverError(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", "error", err)
+				return nil, nil, RiverErrorWithBase(Err_BAD_STREAM_CREATION_PARAMS, "invalid stream id", err)
 			}
 			if !creatorStreamView.IsMemberOf(streamId) {
 				return nil, nil, RiverError(Err_PERMISSION_DENIED, "not a member of", "requiredStreamId", streamId)
@@ -103,12 +116,24 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 	for _, userAddress := range csRules.RequiredUserAddrs {
 		addr, err := BytesToAddress(userAddress)
 		if err != nil {
-			return nil, nil, RiverError(Err_PERMISSION_DENIED, "invalid user id", "requiredUser", userAddress)
+			return nil, nil, RiverErrorWithBase(
+				Err_PERMISSION_DENIED,
+				"invalid user id",
+				err,
+				"requiredUser",
+				userAddress,
+			)
 		}
 		userStreamId := UserStreamIdFromAddr(addr)
 		_, err = s.cache.GetStreamNoWait(ctx, userStreamId)
 		if err != nil {
-			return nil, nil, RiverError(Err_PERMISSION_DENIED, "user does not exist", "requiredUser", userAddress)
+			return nil, nil, RiverErrorWithBase(
+				Err_PERMISSION_DENIED,
+				"user does not exist",
+				err,
+				"requiredUser",
+				userAddress,
+			)
 		}
 	}
 
@@ -144,7 +169,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 			newEvents, err := s.AddEventPayload(ctx, de.StreamId, de.Payload, de.Tags)
 			derivedEvents = append(derivedEvents, newEvents...)
 			if err != nil {
-				return resp, derivedEvents, RiverError(Err_INTERNAL, "failed to add derived event", "error", err)
+				return resp, derivedEvents, RiverErrorWithBase(Err_INTERNAL, "failed to add derived event", err)
 			}
 		}
 	}


### PR DESCRIPTION
This should help to ensure that more information is propogated back to the caller in the event of an error, so we can debug more effectively from web app error responses. 

- Replace RiverError calls with RiverErrorWithBase when original errors are available
- Fix cases where errors were passed as tags instead of base errors
- Ensure error chains are preserved for better debugging
- Add conditional error handling for cases where errors may or may not exist

Files changed:
- core/node/rpc/create_stream.go: Fix stream ID validation error handling
- core/node/rpc/create_media_stream.go: Fix multiple error handling patterns
- core/node/rpc/add_media_event.go: Fix proto.Unmarshal error handling

This ensures that original errors are not lost and debugging is easier.

### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
