### PR TITLE
Update for key exchange eligibility

### DIFF
--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -814,7 +814,7 @@ export class StreamStateView {
             case 'channelContent':
             case 'spaceContent':
             case 'gdmChannelContent':
-                return this.getMembers().joinedParticipants()
+                return this.getMembers().joinedOrPendingJoinedParticipants()
             case 'dmChannelContent':
                 return this.getMembers().participants() // send keys to all participants
             default:

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -619,6 +619,10 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
         return this.joinedUsers
     }
 
+    joinedOrPendingJoinedParticipants(): Set<string> {
+        return new Set([...this.joinedUsers, ...this.pendingJoinedUsers])
+    }
+
     joinedOrInvitedParticipants(): Set<string> {
         return new Set([...this.joinedUsers, ...this.invitedUsers])
     }

--- a/packages/stress/src/utils/stressClient.ts
+++ b/packages/stress/src/utils/stressClient.ts
@@ -164,7 +164,7 @@ export class StressClient {
         }
         const stream = streamsClient.stream(streamId)
         const streamStateView = stream?.view ?? (await streamsClient.getStream(streamId))
-        return streamStateView.userIsEntitledToKeyExchange(this.userId)
+        return streamStateView.membershipContent.joinedParticipants().has(this.userId)
     }
 
     async createSpace(spaceName: string) {


### PR DESCRIPTION
I’ve seen cases where a user joins a stream and requests keys in the same block. In this case, the key request will be received and enqueued, and possibly processed before the membership is confirmed so the client will fail.
We want the client to continue, and it is safe to continue, because the client responding to key requests will check isEntitled on the blockchain before sending any sensitive key material.