### PR TITLE
bot-framework: don't create `Hono` internally

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -30,10 +30,12 @@
         "@towns-protocol/web3": "workspace:^",
         "ethers": "^5.7.2",
         "fake-indexeddb": "^4.0.1",
-        "hono": "^4.7.11",
         "jsonwebtoken": "^9.0.2",
         "typed-emitter": "^2.1.0",
         "viem": "^2.29.3"
+    },
+    "peerDependencies": {
+        "hono": "^4.7.11"
     },
     "devDependencies": {
         "@types/jsonwebtoken": "^9.0.9",
@@ -44,6 +46,7 @@
         "eslint-import-resolver-typescript": "^4.3.2",
         "eslint-plugin-import-x": "^4.10.2",
         "eslint-plugin-tsdoc": "^0.3.0",
+        "hono": "^4.7.11",
         "typescript": "^5.8.2",
         "vitest": "^3.2.3"
     },

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {
     Client,
     makeBaseProvider,
@@ -32,6 +30,7 @@ import {
 } from '@towns-protocol/web3'
 import { createServer } from 'node:http2'
 import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
 
 const WEBHOOK_URL = `https://localhost:${process.env.BOT_PORT}/webhook`
 
@@ -193,10 +192,13 @@ describe('Bot', { sequential: true }, () => {
         bot = await makeTownsBot(appPrivateDataBase64, jwtSecretBase64, process.env.RIVER_ENV)
         expect(bot).toBeDefined()
         expect(bot.botId).toBe(botClientAddress)
-        const { fetch } = await bot.start()
+        const { jwtMiddleware, handler } = await bot.start()
+        const app = new Hono()
+        app.use(jwtMiddleware)
+        app.post('/webhook', handler)
         serve({
             port: Number(process.env.BOT_PORT!),
-            fetch,
+            fetch: app.fetch,
             createServer,
         })
         await appRegistryRpcClient.registerWebhook({
@@ -204,15 +206,11 @@ describe('Bot', { sequential: true }, () => {
             webhookUrl: WEBHOOK_URL,
         })
 
-        // Verify webhook registration
         const { isRegistered, validResponse } = await appRegistryRpcClient.getStatus({
             appId: bin_fromHexString(botClientAddress),
         })
         expect(isRegistered).toBe(true)
         expect(validResponse).toBe(true)
-        // await bobClient.riverConnection.call((client) =>
-        //     client.debugForceMakeMiniblock(channelId, { forceSnapshot: true }),
-        // )
     }
 
     it('should receive a message forwarded', async () => {

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -31,7 +31,9 @@ import {
     make_UserMetadataPayload_ProfileImage,
     spaceIdFromChannelId,
 } from '@towns-protocol/sdk'
-import { Hono, type Context } from 'hono'
+import { type Context, type Env, type Next } from 'hono'
+import { createMiddleware } from 'hono/factory'
+import { default as jwt } from 'jsonwebtoken'
 import EventEmitter from 'node:events'
 import TypedEmitter from 'typed-emitter'
 import {
@@ -84,10 +86,8 @@ import {
     type WriteContractParameters,
 } from 'viem/actions'
 import { base, baseSepolia } from 'viem/chains'
-
-// Import the jsonwebtoken library and necessary dlog utilities
-import { default as jwt } from 'jsonwebtoken'
 import { deriveKeyAndIV, encryptAESGCM, uint8ArrayToBase64 } from '@towns-protocol/sdk-crypto'
+import type { BlankEnv, BlankSchema, Schema } from 'hono/types'
 
 type BotActions = ReturnType<typeof buildBotActions>
 
@@ -120,6 +120,7 @@ export type UserData = {
     /** URL that points to the profile picture of the user */
     profilePictureUrl: string
 }
+
 export type BotEvents = {
     message: (
         handler: BotActions,
@@ -218,8 +219,9 @@ type BasePayload = {
     eventId: string
 }
 
-export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
-    private readonly server: Hono
+export class Bot<
+    HonoEnv extends Env = BlankEnv,
+> extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     private readonly client: ClientV2<BotActions>
     botId: string
     viemClient: ViemClient
@@ -233,45 +235,47 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
         this.viemClient = viemClient
         this.jwtSecret = bin_fromBase64(jwtSecretBase64)
         this.currentMessageTags = undefined
-        this.server = new Hono()
-        this.server.post('webhook', (c) => this.webhookResponseHandler(c))
     }
 
     async start() {
         await this.client.uploadDeviceKeys()
-        return { fetch: this.server.fetch }
+        const jwtMiddleware = createMiddleware<HonoEnv>(this.jwtMiddleware.bind(this))
+
+        return {
+            jwtMiddleware,
+            handler: this.webhookHandler.bind(this),
+        }
     }
 
-    private async webhookResponseHandler(c: Context) {
+    private async jwtMiddleware(c: Context<HonoEnv>, next: Next): Promise<Response | void> {
         const authHeader = c.req.header('Authorization')
 
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
             return c.text('Unauthorized: Missing or malformed token', 401)
-        } else {
-            const tokenString = authHeader.substring(7)
-            try {
-                // Convert botId (Ethereum address string, e.g., "0xABC") to raw bytes,
-                // then to a lowercase hex string for the audience check.
-                // This must match how the Go service creates the 'aud' claim.
-                const botAddressBytes = bin_fromHexString(this.botId)
-                // Assumes lowercase hex output without "0x"
-                const expectedAudience = bin_toHexString(botAddressBytes)
-
-                jwt.verify(tokenString, Buffer.from(this.jwtSecret), {
-                    algorithms: ['HS256'],
-                    audience: expectedAudience,
-                })
-            } catch (err) {
-                let errorMessage = 'Unauthorized: Token verification failed'
-                if (err instanceof jwt.TokenExpiredError) {
-                    errorMessage = 'Unauthorized: Token expired'
-                } else if (err instanceof jwt.JsonWebTokenError) {
-                    errorMessage = `Unauthorized: Invalid token (${err.message})`
-                }
-                return c.text(errorMessage, 401)
-            }
         }
 
+        const tokenString = authHeader.substring(7)
+        try {
+            const botAddressBytes = bin_fromHexString(this.botId)
+            const expectedAudience = bin_toHexString(botAddressBytes)
+            jwt.verify(tokenString, Buffer.from(this.jwtSecret), {
+                algorithms: ['HS256'],
+                audience: expectedAudience,
+            })
+        } catch (err) {
+            let errorMessage = 'Unauthorized: Token verification failed'
+            if (err instanceof jwt.TokenExpiredError) {
+                errorMessage = 'Unauthorized: Token expired'
+            } else if (err instanceof jwt.JsonWebTokenError) {
+                errorMessage = `Unauthorized: Invalid token (${err.message})`
+            }
+            return c.text(errorMessage, 401)
+        }
+
+        await next()
+    }
+
+    private async webhookHandler(c: Context<HonoEnv>) {
         const body = await c.req.arrayBuffer()
         const encryptionDevice = this.client.crypto.getUserDevice()
         const request = fromBinary(AppServiceRequestSchema, new Uint8Array(body))
@@ -667,7 +671,7 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     // }
 }
 
-export const makeTownsBot = async (
+export const makeTownsBot = async <HonoEnv extends Env = BlankEnv>(
     appPrivateDataBase64: string,
     jwtSecretBase64: string,
     env: Parameters<typeof makeRiverConfig>[0],
@@ -692,7 +696,7 @@ export const makeTownsBot = async (
             fromExportedDevice: encryptionDevice,
         },
     }).then((x) => x.extend((townsClient) => buildBotActions(townsClient, viemClient)))
-    return new Bot(client, viemClient, jwtSecretBase64)
+    return new Bot<HonoEnv>(client, viemClient, jwtSecretBase64)
 }
 
 const buildBotActions = (client: ClientV2, viemClient: ViemClient) => {

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -87,7 +87,7 @@ import {
 } from 'viem/actions'
 import { base, baseSepolia } from 'viem/chains'
 import { deriveKeyAndIV, encryptAESGCM, uint8ArrayToBase64 } from '@towns-protocol/sdk-crypto'
-import type { BlankEnv, BlankSchema, Schema } from 'hono/types'
+import type { BlankEnv } from 'hono/types'
 
 type BotActions = ReturnType<typeof buildBotActions>
 

--- a/packages/examples/bot-ask-poll/package.json
+++ b/packages/examples/bot-ask-poll/package.json
@@ -16,7 +16,8 @@
     "dependencies": {
         "@connectrpc/connect-node": "^2.0.0",
         "@hono/node-server": "^1.14.0",
-        "@towns-protocol/bot": "workspace:^"
+        "@towns-protocol/bot": "workspace:^",
+        "hono": "^4.7.11"
     },
     "devDependencies": {
         "@types/node": "^20.14.8",

--- a/packages/examples/bot-ask-poll/src/index.ts
+++ b/packages/examples/bot-ask-poll/src/index.ts
@@ -1,6 +1,8 @@
 import { serve } from '@hono/node-server'
 import { makeTownsBot } from '@towns-protocol/bot'
 import { createServer } from 'node:http2'
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
 
 type State = {
     messageToPoll: {
@@ -109,6 +111,15 @@ const countAnswers = (messageId: string) => {
     return answerCounts
 }
 
-const { fetch } = await bot.start()
-serve({ fetch, port: parseInt(process.env.PORT!), createServer })
+const { jwtMiddleware, handler } = await bot.start()
+
+const app = new Hono()
+app.use(logger())
+app.post('/webhook', jwtMiddleware, handler)
+
+serve({
+    fetch: app.fetch,
+    port: parseInt(process.env.PORT!),
+    createServer,
+})
 console.log(`✅ Poll Bot is running on https://localhost:${process.env.PORT}`)

--- a/packages/examples/bot-quickstart/package.json
+++ b/packages/examples/bot-quickstart/package.json
@@ -16,7 +16,8 @@
     "dependencies": {
         "@connectrpc/connect-node": "^2.0.0",
         "@hono/node-server": "^1.14.0",
-        "@towns-protocol/bot": "workspace:^"
+        "@towns-protocol/bot": "workspace:^",
+        "hono": "^4.7.11"
     },
     "devDependencies": {
         "@types/node": "^20.14.8",

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -1,6 +1,8 @@
 import { serve } from '@hono/node-server'
 import { makeTownsBot } from '@towns-protocol/bot'
 import { createServer } from 'node:http2'
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
 
 const bot = await makeTownsBot(
     process.env.APP_PRIVATE_DATA_BASE64!,
@@ -51,6 +53,15 @@ bot.onReaction(async (handler, { reaction, channelId, userId }) => {
     }
 })
 
-const { fetch } = await bot.start()
-serve({ fetch, port: parseInt(process.env.PORT!), createServer })
+const { jwtMiddleware, handler } = await bot.start()
+
+const app = new Hono()
+app.use(logger())
+app.post('/webhook', jwtMiddleware, handler)
+
+serve({
+    fetch: app.fetch,
+    port: parseInt(process.env.PORT!),
+    createServer,
+})
 console.log(`✅ Quickstart Bot is running on https://localhost:${process.env.PORT}`)

--- a/packages/examples/bot-thread-ai/package.json
+++ b/packages/examples/bot-thread-ai/package.json
@@ -17,6 +17,7 @@
         "@connectrpc/connect-node": "^2.0.0",
         "@hono/node-server": "^1.14.0",
         "@towns-protocol/bot": "workspace:^",
+        "hono": "^4.7.11",
         "openai": "^5.7.0"
     },
     "devDependencies": {

--- a/packages/examples/bot-thread-ai/src/index.ts
+++ b/packages/examples/bot-thread-ai/src/index.ts
@@ -2,6 +2,8 @@ import OpenAI from 'openai'
 import { makeTownsBot } from '@towns-protocol/bot'
 import { serve } from '@hono/node-server'
 import { createServer } from 'node:http2'
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
 
 type Context = {
     initialPrompt: string
@@ -94,6 +96,15 @@ const ai = async (context: Context) => {
 }
 const shortId = (id: string) => id.slice(0, 4) + '..' + id.slice(-4)
 
-const { fetch } = await bot.start()
-serve({ fetch, port: parseInt(process.env.PORT!), createServer })
+const { jwtMiddleware, handler } = await bot.start()
+
+const app = new Hono()
+app.use(logger())
+app.post('/webhook', jwtMiddleware, handler)
+
+serve({
+    fetch: app.fetch,
+    port: parseInt(process.env.PORT!),
+    createServer,
+})
 console.log(`✅ Thread AI Bot is running on https://localhost:${process.env.PORT}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8497,6 +8497,8 @@ __metadata:
     typescript: ^5.8.2
     viem: ^2.29.3
     vitest: ^3.2.3
+  peerDependencies:
+    hono: ^4.7.11
   languageName: unknown
   linkType: soft
 
@@ -8613,6 +8615,7 @@ __metadata:
     eslint: ^8.57.1
     eslint-import-resolver-typescript: ^4.3.2
     eslint-plugin-import-x: ^4.10.2
+    hono: ^4.7.11
     tsx: ^4.7.1
     typescript: ^5.8.2
   languageName: unknown
@@ -8631,6 +8634,7 @@ __metadata:
     eslint: ^8.57.1
     eslint-import-resolver-typescript: ^4.3.2
     eslint-plugin-import-x: ^4.10.2
+    hono: ^4.7.11
     tsx: ^4.7.1
     typescript: ^5.8.2
   languageName: unknown
@@ -8649,6 +8653,7 @@ __metadata:
     eslint: ^8.57.1
     eslint-import-resolver-typescript: ^4.3.2
     eslint-plugin-import-x: ^4.10.2
+    hono: ^4.7.11
     openai: ^5.7.0
     tsx: ^4.7.1
     typescript: ^5.8.2


### PR DESCRIPTION
This enable us to remove the dependency on Hono and move it to a peer dependency.

It also provides more developer freedom and better support for managing the Hono server, allowing to add more middlewares, getting access to Hono `env` (which its useful for deploying bots in cloudflare workers)

I wish I could use `hono/jwt` for the jwt middleware, ran into a few issues, will try again later.