### PR TITLE
Handle redelegate events in subgraph

### DIFF
--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -340,6 +340,38 @@ ponder.on('BaseRegistry:IncreaseStake', async ({ event, context }) => {
     }
 })
 
+ponder.on('BaseRegistry:Redelegate', async ({ event, context }) => {
+    // Get block number
+    const blockNumber = event.block.number
+
+    try {
+        // Find existing stake record by depositId
+        const existingStake = await context.db.sql.query.stakers.findFirst({
+            where: eq(schema.stakers.depositId, event.args.depositId),
+        })
+
+        if (existingStake) {
+            // Update delegatee
+            await context.db.sql
+                .update(schema.stakers)
+                .set({
+                    delegatee: event.args.delegatee,
+                    createdAt: blockNumber,
+                })
+                .where(eq(schema.stakers.depositId, event.args.depositId))
+        } else {
+            console.warn(
+                `No existing stake found for depositId ${event.args.depositId} in Redelegate event`,
+            )
+        }
+    } catch (error) {
+        console.error(
+            `Error processing BaseRegistry:Redelegate at blockNumber ${blockNumber}:`,
+            error,
+        )
+    }
+})
+
 ponder.on('BaseRegistry:Withdraw', async ({ event, context }) => {
     // Get block number
     const blockNumber = event.block.number


### PR DESCRIPTION
### Description

Handle Redelegate events in the subgraph staker schema by updating `delegatee` field for `depositId`.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
