### PR TITLE
Node channel scrubbing for bots

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -332,7 +332,12 @@ func (params *aeParams) canAddUserPayload(payload *StreamEvent_UserPayload) rule
 			requireParentEvent(ru.parentEventForUserMembership)
 
 		isApp, _ := params.streamView.IsAppUser()
-		if isApp {
+		isNodeInitiator := params.isValidNode(content.UserMembership.Inviter)
+		isNodeBoot := content.UserMembership.Op == MembershipOp_SO_LEAVE && isNodeInitiator
+		// Adding bots to spaces and channels requires ownership, but removals can also be initiated
+		// by nodes when streams are scrubbed. Thus we require space owner permissions only for app
+		// payloads that are not node-initiated leave events.
+		if isApp && !isNodeBoot {
 			builder = builder.requireChainAuth(ru.ownerChainAuthForInviter)
 		}
 		return builder

--- a/packages/sdk/src/tests/multi/channelScrubbing.test.ts
+++ b/packages/sdk/src/tests/multi/channelScrubbing.test.ts
@@ -11,10 +11,20 @@ import {
     setupChannelWithCustomRole,
     expectUserCanJoinChannel,
     waitFor,
+    setupWalletsAndContexts,
+    everyoneMembershipStruct,
+    createSpaceAndDefaultChannel,
 } from '../testUtils'
 import { dlog } from '@towns-protocol/dlog'
-import { Address, TestERC721 } from '@towns-protocol/web3'
+import {
+    Address,
+    TestERC721,
+    AppRegistryDapp,
+    Permission,
+    SpaceAddressFromSpaceId,
+} from '@towns-protocol/web3'
 import { ethers } from 'ethers'
+import { makeBaseChainConfig } from '../../riverConfig'
 const log = dlog('csb:test:channelsWithEntitlements')
 
 describe('channelScrubbing', () => {
@@ -66,5 +76,111 @@ describe('channelScrubbing', () => {
             expect(membership?.op).toBe(MembershipOp.SO_LEAVE)
             expect(membership?.reason).toBe(MembershipReason.MR_NOT_ENTITLED)
         })
+    })
+
+    test('Bot loses membership and is scrubbed from channel when uninstalled from space', async () => {
+        const {
+            alice: spaceOwner,
+            aliceProvider: spaceOwnerProvider,
+            aliceSpaceDapp: spaceOwnerSpaceDapp,
+            bob: bot,
+            bobsWallet: botWallet,
+            bobProvider: botProvider,
+        } = await setupWalletsAndContexts()
+
+        const appRegistryDapp = new AppRegistryDapp(
+            makeBaseChainConfig().chainConfig,
+            spaceOwnerProvider,
+        )
+
+        // Create bot app contract
+        const tx = await appRegistryDapp.createApp(
+            botProvider.signer,
+            'scrub-test-bot',
+            [Permission.Read, Permission.Write],
+            botWallet.address as Address,
+            ethers.utils.parseEther('0.01').toBigInt(),
+            31536000n,
+        )
+        const receipt = await tx.wait()
+        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        expect(foundAppAddress).toBeDefined()
+
+        // Create bot user streams
+        await expect(bot.initializeUser({ appAddress: foundAppAddress })).resolves.toBeDefined()
+        bot.startSync()
+
+        // Create a town with channels (everyone can join)
+        const everyoneMembership = await everyoneMembershipStruct(spaceOwnerSpaceDapp, spaceOwner)
+        const { spaceId, defaultChannelId: channelId } = await createSpaceAndDefaultChannel(
+            spaceOwner,
+            spaceOwnerSpaceDapp,
+            spaceOwnerProvider.wallet,
+            "space owner's town",
+            everyoneMembership,
+        )
+
+        // Install the bot to the space (as space owner)
+        const installTx = await appRegistryDapp.installApp(
+            spaceOwnerProvider.signer,
+            foundAppAddress as Address,
+            SpaceAddressFromSpaceId(spaceId) as Address,
+            ethers.utils.parseEther('0.02').toBigInt(),
+        )
+        const installReceipt = await installTx.wait()
+        expect(installReceipt.status).toBe(1)
+
+        // Verify bot is installed
+        const space = spaceOwnerSpaceDapp.getSpace(spaceId)
+        const installedApps = await space!.AppAccount.read.getInstalledApps()
+        expect(installedApps).toContain(foundAppAddress)
+
+        // Have space owner add bot to space and channel
+        await expect(spaceOwner.joinUser(spaceId, bot.userId)).resolves.toBeDefined()
+        await expect(spaceOwner.joinUser(channelId, bot.userId)).resolves.toBeDefined()
+
+        // Validate bot is a member of both space and channel
+        const botUserStreamView = bot.stream(bot.userStreamId!)!.view
+        await waitFor(() => {
+            expect(botUserStreamView.userContent.isMember(spaceId, MembershipOp.SO_JOIN)).toBe(true)
+            expect(botUserStreamView.userContent.isMember(channelId, MembershipOp.SO_JOIN)).toBe(
+                true,
+            )
+        })
+
+        // Uninstall the bot from the space (this should make it lose membership eligibility)
+        // Note: Using removeApp method - in a real implementation this might be a different method
+        // like uninstallApp, but removeApp should serve the same purpose for testing
+        const removeAppTx = await appRegistryDapp.uninstallApp(
+            spaceOwnerProvider.signer,
+            foundAppAddress as Address,
+            space?.Address as Address,
+        )
+        const removeAppReceipt = await removeAppTx.wait()
+        expect(removeAppReceipt.status).toBe(1)
+
+        // Verify bot is no longer installed
+        const installedAppsAfterRemoval = await space!.AppAccount.read.getInstalledApps()
+        expect(installedAppsAfterRemoval).not.toContain(foundAppAddress)
+
+        // Wait 5 seconds so the channel stream will become eligible for scrubbing
+        await new Promise((f) => setTimeout(f, 5000))
+
+        // Have the bot attempt to post a message to the channel to trigger scrubbing
+        // This should fail with a permission error since the bot is no longer installed/entitled, and trigger a scrub
+        await expect(bot.sendMessage(channelId, 'test message from bot')).rejects.toThrow(
+            /PERMISSION_DENIED/,
+        )
+
+        // Wait for bot's user stream to have the leave event due to being scrubbed
+        await waitFor(() => {
+            const membership = botUserStreamView.userContent.getMembership(channelId)
+            expect(membership?.op).toBe(MembershipOp.SO_LEAVE)
+            expect(membership?.reason).toBe(MembershipReason.MR_NOT_ENTITLED)
+        })
+
+        // Cleanup
+        await bot.stopSync()
+        await spaceOwner.stopSync()
     })
 })


### PR DESCRIPTION
Update the event rules to allow nodes to boot bots from channels and add an e2e test case that verifies bot channel scrubs.

### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
