### PR TITLE
support for bots in playground

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,9 +10,11 @@
         "preview": "vite preview"
     },
     "dependencies": {
+        "@bufbuild/protobuf": "^2.2.2",
         "@connectrpc/connect-web": "^2.0.0",
         "@emoji-mart/data": "^1.1.2",
         "@hookform/resolvers": "^3.6.0",
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-icons": "^1.3.0",
@@ -23,6 +25,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.51.15",
+        "@towns-protocol/proto": "workspace:^",
         "@towns-protocol/react-sdk": "workspace:^",
         "@towns-protocol/sdk": "workspace:^",
         "@towns-protocol/web3": "workspace:^",

--- a/packages/playground/src/components/copy-button.tsx
+++ b/packages/playground/src/components/copy-button.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { CheckCircle, Copy } from 'lucide-react'
+import { Button, type ButtonProps } from './ui/button'
+
+type CopyButtonProps = {
+    text: string
+} & ButtonProps
+
+export function CopyButton({ text, ...props }: CopyButtonProps) {
+    const [copied, setCopied] = useState(false)
+
+    useEffect(() => {
+        if (copied) {
+            const timeout = setTimeout(() => {
+                setCopied(false)
+            }, 2000)
+
+            return () => clearTimeout(timeout)
+        }
+        return
+    }, [copied])
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(text)
+            setCopied(true)
+        } catch (error) {
+            console.error('Failed to copy text:', error)
+        }
+    }
+
+    return (
+        <Button
+            variant="ghost"
+            size="icon"
+            aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+            onClick={handleCopy}
+            {...props}
+        >
+            {copied ? (
+                <CheckCircle className="size-4 text-green-500" />
+            ) : (
+                <Copy className="size-4" />
+            )}
+        </Button>
+    )
+}

--- a/packages/playground/src/components/dialog/bot-install.tsx
+++ b/packages/playground/src/components/dialog/bot-install.tsx
@@ -1,0 +1,414 @@
+import { useCallback, useMemo, useState } from 'react'
+import { type Address, parseEther } from 'viem'
+import { useChannel, useSpace, useSyncAgent, useUserSpaces } from '@towns-protocol/react-sdk'
+import { ArrowLeftIcon, LoaderCircleIcon } from 'lucide-react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { AppRegistryDapp, SpaceAddressFromSpaceId, SpaceDapp } from '@towns-protocol/web3'
+import { makeBaseProvider } from '@towns-protocol/sdk'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog'
+import { Button } from '../ui/button'
+import { Label } from '../ui/label'
+import { Checkbox } from '../ui/checkbox'
+import { ScrollArea } from '../ui/scroll-area'
+
+interface BotInstallDialogProps {
+    appClientId: Address
+    appAddress: Address
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}
+
+type Step = 'space-selection' | 'channel-selection'
+
+export const BotInstallDialog = ({
+    appAddress,
+    appClientId,
+    open,
+    onOpenChange,
+}: BotInstallDialogProps) => {
+    const { spaceIds } = useUserSpaces()
+    const sync = useSyncAgent()
+    const signer = useEthersSigner()
+    const [currentStep, setCurrentStep] = useState<Step>('space-selection')
+    const [state, setState] = useState<{
+        spaceId: string
+        channelIds: Set<string>
+    }>({
+        spaceId: '',
+        channelIds: new Set(),
+    })
+
+    const handleSpaceSelect = useCallback((spaceId: string) => {
+        setState((prev) => ({ ...prev, spaceId, channelIds: new Set() }))
+        setCurrentStep('channel-selection')
+    }, [])
+
+    const handleChannelToggle = useCallback((channelId: string, checked: boolean) => {
+        setState((prev) => {
+            const newSet = new Set(prev.channelIds)
+            if (checked) {
+                newSet.add(channelId)
+            } else {
+                newSet.delete(channelId)
+            }
+            return { ...prev, channelIds: newSet }
+        })
+    }, [])
+
+    const handleBackToSpaceSelection = useCallback(() => {
+        setCurrentStep('space-selection')
+    }, [])
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: async () => {
+            if (!state.spaceId || state.channelIds.size === 0) {
+                return
+            }
+            if (!signer) {
+                throw new Error('No signer found')
+            }
+            const appRegistryDapp = new AppRegistryDapp(
+                sync.config.riverConfig.base.chainConfig,
+                makeBaseProvider(sync.config.riverConfig),
+            )
+            const spaceDapp = new SpaceDapp(
+                sync.config.riverConfig.base.chainConfig,
+                makeBaseProvider(sync.config.riverConfig),
+            )
+            const space = spaceDapp.getSpace(state.spaceId)
+
+            if (!space) {
+                throw new Error('Space not found')
+            }
+            const isBotInstalled = await space.AppAccount.read
+                .getInstalledApps()
+                .then((apps) => apps.includes(appAddress))
+            if (!isBotInstalled) {
+                const tx = await appRegistryDapp.installApp(
+                    signer,
+                    appAddress,
+                    SpaceAddressFromSpaceId(state.spaceId) as Address,
+                    parseEther('0.02'),
+                )
+                await tx.wait()
+                console.log('bot installed')
+            }
+            await sync.riverConnection.call((client) => client.joinUser(state.spaceId, appClientId))
+            await Promise.all(
+                // TODO: can we batch those into a single call?
+                Array.from(state.channelIds).map((channelId) =>
+                    sync.riverConnection.call((client) => client.joinUser(channelId, appClientId)),
+                ),
+            )
+        },
+        onSuccess: () => {
+            onOpenChange(false)
+            setState((prev) => ({ ...prev, spaceId: '', channelIds: new Set() }))
+            setCurrentStep('space-selection')
+        },
+        onError: (error) => {
+            console.error('Failed to install bot:', error)
+        },
+    })
+
+    const resetDialog = useCallback(() => {
+        setState((prev) => ({ ...prev, spaceId: '', channelIds: new Set() }))
+        setCurrentStep('space-selection')
+    }, [])
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(open) => {
+                onOpenChange(open)
+                if (!open) {
+                    resetDialog()
+                }
+            }}
+        >
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>
+                        Install Bot - Step {currentStep === 'space-selection' ? '1' : '2'} of 2
+                    </DialogTitle>
+                    <DialogDescription>
+                        {currentStep === 'space-selection'
+                            ? 'Select a space where you want to install the bot.'
+                            : 'Choose which channels the bot should join in the selected space.'}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-6">
+                    {currentStep === 'space-selection' && (
+                        <SpaceSelectionStep
+                            spaceIds={spaceIds}
+                            selectedSpaceId={state.spaceId}
+                            onSpaceSelect={handleSpaceSelect}
+                        />
+                    )}
+
+                    {currentStep === 'channel-selection' && (
+                        <ChannelSelectionStep
+                            spaceId={state.spaceId}
+                            selectedChannelIds={state.channelIds}
+                            appClientId={appClientId}
+                            isInstalling={isPending}
+                            onChannelToggle={handleChannelToggle}
+                            onSelectAllChannels={(channelIds) =>
+                                setState((prev) => ({ ...prev, channelIds }))
+                            }
+                            onBack={handleBackToSpaceSelection}
+                            onInstall={mutate}
+                        />
+                    )}
+
+                    {currentStep === 'space-selection' && (
+                        <div className="flex justify-end">
+                            <Button variant="outline" onClick={() => onOpenChange(false)}>
+                                Cancel
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+const SpaceSelectionStep = ({
+    spaceIds,
+    selectedSpaceId,
+    onSpaceSelect,
+}: {
+    spaceIds: string[]
+    selectedSpaceId: string
+    onSpaceSelect: (spaceId: string) => void
+}) => {
+    return (
+        <div className="space-y-3">
+            <Label className="text-sm font-medium">Select Space</Label>
+            <ScrollArea className="max-h-96">
+                <div className="space-y-2">
+                    {spaceIds &&
+                        spaceIds.length > 0 &&
+                        spaceIds.map((spaceId) => (
+                            <SpaceOption
+                                key={spaceId}
+                                spaceId={spaceId}
+                                selected={selectedSpaceId === spaceId}
+                                onSelect={() => onSpaceSelect(spaceId)}
+                            />
+                        ))}
+                </div>
+            </ScrollArea>
+            {spaceIds.length === 0 && (
+                <p className="pt-4 text-center text-sm text-muted-foreground">
+                    You're not in any spaces yet.
+                </p>
+            )}
+        </div>
+    )
+}
+
+const ChannelSelectionStep = ({
+    spaceId,
+    selectedChannelIds,
+    appClientId,
+    onChannelToggle,
+    onSelectAllChannels,
+    onBack,
+    onInstall,
+    isInstalling,
+}: {
+    spaceId: string
+    selectedChannelIds: Set<string>
+    appClientId: Address
+    onSelectAllChannels: (channelIds: Set<string>) => void
+    onChannelToggle: (channelId: string, checked: boolean) => void
+    onBack: () => void
+    onInstall: () => void
+    isInstalling: boolean
+}) => {
+    const { data: space } = useSpace(spaceId)
+    const spaceName = space?.metadata?.name || 'Unnamed Space'
+    const channelIds = useMemo(() => space?.channelIds || [], [space])
+    const sync = useSyncAgent()
+
+    const isAllChannelsSelected = useMemo(() => {
+        if (channelIds.length === 0) {
+            return false
+        }
+        if (selectedChannelIds.size === channelIds.length) {
+            return true
+        }
+        if (selectedChannelIds.size > 0) {
+            return 'indeterminate'
+        }
+        return false
+    }, [channelIds, selectedChannelIds])
+
+    const channelIdsThatBotIsIn = useCallback(
+        async (spaceId: string) => {
+            const botIsInChannelsId = []
+            const space = sync.spaces.getSpace(spaceId)
+            const channelIds = space.data.channelIds
+            for (const channelId of channelIds) {
+                const channel = space.getChannel(channelId)
+                const members = channel.members.value.data.userIds
+                if (members.includes(appClientId)) {
+                    botIsInChannelsId.push(channelId)
+                }
+            }
+            return botIsInChannelsId
+        },
+        [appClientId, sync.spaces],
+    )
+
+    const { data: botChannels } = useQuery({
+        queryKey: ['botChannels', spaceId, appClientId],
+        queryFn: () => channelIdsThatBotIsIn(spaceId),
+        enabled: !!spaceId && !!appClientId,
+    })
+
+    const handleSelectAllChannels = useCallback(
+        (checked: boolean) => {
+            if (checked) {
+                onSelectAllChannels(new Set(channelIds))
+            } else {
+                onSelectAllChannels(new Set())
+            }
+        },
+        [channelIds, onSelectAllChannels],
+    )
+
+    return (
+        <>
+            <div className="space-y-3">
+                <Label className="text-sm font-medium">Channels in {spaceName}</Label>
+
+                {channelIds.length > 0 && (
+                    <>
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-muted-foreground">
+                                Select channels for the bot to join
+                            </span>
+                            <div className="flex items-center space-x-2">
+                                <Checkbox
+                                    id="select-all"
+                                    checked={isAllChannelsSelected}
+                                    disabled={isInstalling}
+                                    onCheckedChange={handleSelectAllChannels}
+                                />
+                                <Label htmlFor="select-all" className="text-sm">
+                                    All channels
+                                </Label>
+                            </div>
+                        </div>
+
+                        <ScrollArea className="max-h-60">
+                            <div className="space-y-2">
+                                {channelIds.map((channelId) => (
+                                    <ChannelOption
+                                        key={channelId}
+                                        spaceId={spaceId}
+                                        channelId={channelId}
+                                        selected={
+                                            selectedChannelIds.has(channelId) ||
+                                            (botChannels?.includes(channelId) ?? false)
+                                        }
+                                        disabled={
+                                            isInstalling ||
+                                            (botChannels?.includes(channelId) ?? false)
+                                        }
+                                        onToggle={(checked) => onChannelToggle(channelId, checked)}
+                                    />
+                                ))}
+                            </div>
+                        </ScrollArea>
+                    </>
+                )}
+
+                {channelIds.length === 0 && (
+                    <p className="pt-4 text-center text-sm text-muted-foreground">
+                        This space doesn't have any channels yet.
+                    </p>
+                )}
+            </div>
+
+            <div className="flex justify-between">
+                <Button variant="outline" disabled={isInstalling} onClick={onBack}>
+                    <ArrowLeftIcon className="mr-2 h-4 w-4" />
+                    Back
+                </Button>
+                <Button
+                    disabled={selectedChannelIds.size === 0 || isInstalling}
+                    onClick={onInstall}
+                >
+                    {isInstalling && <LoaderCircleIcon className="mr-2 h-4 w-4 animate-spin" />}
+                    {isInstalling ? 'Installing...' : 'Install Bot'}
+                </Button>
+            </div>
+        </>
+    )
+}
+
+const SpaceOption = ({
+    spaceId,
+    selected,
+    onSelect,
+}: {
+    spaceId: string
+    selected: boolean
+    onSelect: () => void
+}) => {
+    const { data: space } = useSpace(spaceId)
+    const spaceName = space?.metadata?.name || 'Unnamed Space'
+
+    return (
+        <button
+            className={`w-full rounded-md border px-3 py-3 text-left transition-colors hover:bg-muted ${
+                selected ? 'border-primary bg-primary/10 text-primary' : 'border-border'
+            }`}
+            onClick={onSelect}
+        >
+            <div className="flex items-center justify-between">
+                <div className="font-medium">{spaceName}</div>
+                <div className="text-sm text-muted-foreground">
+                    {space?.channelIds?.length || 0} channels
+                </div>
+            </div>
+        </button>
+    )
+}
+
+const ChannelOption = ({
+    spaceId,
+    channelId,
+    selected,
+    onToggle,
+    disabled = false,
+}: {
+    spaceId: string
+    channelId: string
+    selected: boolean
+    onToggle: (checked: boolean) => void
+    disabled?: boolean
+}) => {
+    const { data: channel } = useChannel(spaceId, channelId)
+    const channelName = channel?.metadata?.name || 'Unnamed Channel'
+
+    return (
+        <div className="flex items-center space-x-2">
+            <Checkbox
+                id={channelId}
+                checked={selected}
+                disabled={disabled}
+                onCheckedChange={onToggle}
+            />
+            <Label htmlFor={channelId} className="flex-1 cursor-pointer">
+                #{channelName}
+            </Label>
+        </div>
+    )
+}

--- a/packages/playground/src/components/dialog/bot-settings.tsx
+++ b/packages/playground/src/components/dialog/bot-settings.tsx
@@ -1,0 +1,237 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useForm } from 'react-hook-form'
+import { type Address } from 'viem'
+import { useMutation } from '@tanstack/react-query'
+import { AppRegistryService } from '@towns-protocol/sdk'
+import { bin_fromHexString } from '@towns-protocol/dlog'
+import { LoaderCircleIcon } from 'lucide-react'
+import { useAccount } from 'wagmi'
+import { ForwardSettingValue } from '@towns-protocol/proto'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog'
+import {
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from '../ui/form'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+
+const messageForwardingLabel = {
+    [ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES]: 'All Messages',
+    [ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS]:
+        'Mentions, Replies & Reactions',
+    [ForwardSettingValue.FORWARD_SETTING_NO_MESSAGES]: 'No Messages',
+}
+
+const webhookFormSchema = z.object({
+    webhookUrl: z.string().url({
+        message: 'Must be a valid URL',
+    }),
+})
+
+const appSettingsFormSchema = z.object({
+    forwardSetting: z.nativeEnum(ForwardSettingValue),
+})
+
+const APP_REGISTRY_URL = 'https://localhost:6170'
+
+type WebhookFormSchema = z.infer<typeof webhookFormSchema>
+type AppSettingsFormSchema = z.infer<typeof appSettingsFormSchema>
+
+export const BotSettingsDialog = ({
+    appClientId,
+    open,
+    onOpenChange,
+}: {
+    appClientId: Address
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}) => {
+    const webhookForm = useForm<WebhookFormSchema>({
+        resolver: zodResolver(webhookFormSchema),
+        defaultValues: {
+            webhookUrl: '',
+        },
+    })
+
+    const appSettingsForm = useForm<AppSettingsFormSchema>({
+        resolver: zodResolver(appSettingsFormSchema),
+        defaultValues: {
+            forwardSetting: ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS,
+        },
+    })
+
+    const signer = useEthersSigner()
+    const { address: signerAddress } = useAccount()
+
+    const registerWebhookMutation = useMutation({
+        mutationFn: async ({ webhookUrl }: WebhookFormSchema) => {
+            if (!signer || !signerAddress) {
+                return
+            }
+
+            const { appRegistryRpcClient } = await AppRegistryService.authenticateWithSigner(
+                signerAddress,
+                signer,
+                APP_REGISTRY_URL,
+            )
+            await appRegistryRpcClient.registerWebhook({
+                appId: bin_fromHexString(appClientId),
+                webhookUrl,
+            })
+        },
+        onSuccess: () => {
+            registerWebhookMutation.reset()
+        },
+    })
+
+    const updateSettingsMutation = useMutation({
+        mutationFn: async ({ forwardSetting }: AppSettingsFormSchema) => {
+            if (!signer || !signerAddress) {
+                return
+            }
+
+            const { appRegistryRpcClient } = await AppRegistryService.authenticateWithSigner(
+                signerAddress,
+                signer,
+                APP_REGISTRY_URL,
+            )
+            await appRegistryRpcClient.setAppSettings({
+                appId: bin_fromHexString(appClientId),
+                settings: {
+                    forwardSetting,
+                },
+            })
+        },
+        onSuccess: () => {
+            appSettingsForm.reset()
+        },
+    })
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(open) => {
+                onOpenChange(open)
+                webhookForm.reset()
+                registerWebhookMutation.reset()
+                appSettingsForm.reset()
+                updateSettingsMutation.reset()
+            }}
+        >
+            <DialogContent className="overflow-y-auto sm:max-h-[90vh] sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Bot Settings</DialogTitle>
+                    <DialogDescription>
+                        Configure your bot's webhook URL to receive space events.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-6">
+                    <Form {...webhookForm}>
+                        <form
+                            className="space-y-4"
+                            onSubmit={webhookForm.handleSubmit(async (data) => {
+                                await registerWebhookMutation.mutateAsync(data)
+                            })}
+                        >
+                            <FormField
+                                control={webhookForm.control}
+                                name="webhookUrl"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Webhook URL</FormLabel>
+                                        <FormControl>
+                                            <Input placeholder="https://..." {...field} />
+                                        </FormControl>
+                                        <FormDescription>
+                                            The URL where your bot will receive space events
+                                        </FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <Button
+                                type="submit"
+                                className="w-full"
+                                disabled={registerWebhookMutation.isPending}
+                            >
+                                {registerWebhookMutation.isPending ? (
+                                    <LoaderCircleIcon className="mr-2 h-4 w-4 animate-spin" />
+                                ) : null}
+                                {registerWebhookMutation.isPending
+                                    ? 'Registering...'
+                                    : 'Register Webhook'}
+                            </Button>
+                        </form>
+                    </Form>
+
+                    <div className="my-4 h-px bg-border" />
+
+                    <Form {...appSettingsForm}>
+                        <form
+                            className="space-y-4"
+                            onSubmit={appSettingsForm.handleSubmit(async (data) => {
+                                await updateSettingsMutation.mutateAsync(data)
+                            })}
+                        >
+                            <FormField
+                                control={appSettingsForm.control}
+                                name="forwardSetting"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Message Forwarding</FormLabel>
+                                        <Select
+                                            value={field.value.toString()}
+                                            onValueChange={(value) => field.onChange(Number(value))}
+                                        >
+                                            <FormControl>
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select message forwarding setting" />
+                                                </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                                {Object.entries(messageForwardingLabel).map(
+                                                    ([key, label]) => (
+                                                        <SelectItem key={key} value={key}>
+                                                            {label}
+                                                        </SelectItem>
+                                                    ),
+                                                )}
+                                            </SelectContent>
+                                        </Select>
+                                        <FormDescription>
+                                            Choose which messages to forward to your bot
+                                        </FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <Button
+                                type="submit"
+                                className="w-full"
+                                disabled={updateSettingsMutation.isPending}
+                            >
+                                {updateSettingsMutation.isPending ? (
+                                    <LoaderCircleIcon className="mr-2 h-4 w-4 animate-spin" />
+                                ) : null}
+                                {updateSettingsMutation.isPending
+                                    ? 'Updating...'
+                                    : 'Update Settings'}
+                            </Button>
+                        </form>
+                    </Form>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
+++ b/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
@@ -38,13 +38,14 @@ JWT_SECRET=${data.jwtSecretBase64}`
                         Bot Created Successfully
                     </DialogTitle>
                     <DialogDescription>
-                        Your bot has been minted. The private credentials below are critical for your bot's operation.
+                        Your bot has been minted. The private credentials below are critical for
+                        your bot's operation.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4">
                     <SecretInformationBanner>
-                        These private keys and secrets are shown only once and cannot be recovered. 
+                        These private keys and secrets are shown only once and cannot be recovered.
                     </SecretInformationBanner>
 
                     <div className="flex flex-col gap-2 text-sm">
@@ -56,10 +57,10 @@ JWT_SECRET=${data.jwtSecretBase64}`
                             readOnly
                             value={envContent}
                             className={cn(
-                                "min-h-[200px] w-full rounded-md border font-mono text-xs shadow-sm resize-none",
-                                "bg-muted text-foreground",
-                                "px-4 py-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                                "disabled:cursor-not-allowed disabled:opacity-50"
+                                'min-h-[200px] w-full resize-none rounded-md border font-mono text-xs shadow-sm',
+                                'bg-muted text-foreground',
+                                'px-4 py-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                                'disabled:cursor-not-allowed disabled:opacity-50',
                             )}
                             placeholder="Environment variables will appear here..."
                         />
@@ -67,17 +68,24 @@ JWT_SECRET=${data.jwtSecretBase64}`
 
                     <div className="rounded-md bg-blue-50 p-4 dark:bg-blue-900/20">
                         <div className="text-sm">
-                            <h4 className="font-medium text-blue-900 dark:text-blue-100 mb-2">Next Steps:</h4>
-                            <ul className="list-disc list-inside space-y-1 text-blue-800 dark:text-blue-200">
+                            <h4 className="mb-2 font-medium text-blue-900 dark:text-blue-100">
+                                Next Steps:
+                            </h4>
+                            <ul className="list-inside list-disc space-y-1 text-blue-800 dark:text-blue-200">
                                 <li>Copy and securely store the App Private Data and JWT Secret</li>
                                 <li>Use these credentials to authenticate your bot application</li>
-                                <li>Never share these secrets publicly or commit them to version control</li>
+                                <li>
+                                    Never share these secrets publicly or commit them to version
+                                    control
+                                </li>
                             </ul>
                         </div>
                     </div>
 
                     <div className="flex justify-end pt-4">
-                        <Button onClick={() => onOpenChange(false)}>I've Saved My Credentials</Button>
+                        <Button onClick={() => onOpenChange(false)}>
+                            I've Saved My Credentials
+                        </Button>
                     </div>
                 </div>
             </DialogContent>

--- a/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
+++ b/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
@@ -1,0 +1,92 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { SecretInformationBanner } from '@/components/ui/secret-information-banner'
+import { CopyButton } from '@/components/copy-button'
+
+interface BotCredentialsData {
+    botAddress: string
+    appPrivateDataBase64: string
+    jwtSecretBase64: string
+}
+
+interface BotCredentialsDialogProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    data: BotCredentialsData | null
+}
+
+export const BotCredentialsDialog = ({ open, onOpenChange, data }: BotCredentialsDialogProps) => {
+    if (!data) {
+        return null
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>Bot Created Successfully</DialogTitle>
+                    <DialogDescription>
+                        Your bot has been created and deployed. Store this information securely.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <SecretInformationBanner>
+                        Store this information in a secure location. You won't be able to access it
+                        again.
+                    </SecretInformationBanner>
+
+                    <div className="flex flex-col gap-2 text-sm">
+                        <div className="flex items-center justify-between">
+                            <p className="text-muted-foreground">Bot Address:</p>
+                            <CopyButton text={data.botAddress} />
+                        </div>
+                        <pre className="overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-xs">
+                            {data.botAddress}
+                        </pre>
+                    </div>
+
+                    <div className="flex flex-col gap-2 text-sm">
+                        <div className="flex items-center justify-between">
+                            <p className="text-muted-foreground">App Private Data</p>
+                            <div className="flex items-center gap-2">
+                                <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                                    BASE64
+                                </span>
+                                <CopyButton text={data.appPrivateDataBase64} />
+                            </div>
+                        </div>
+                        <pre className="max-h-[4lh] overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-xs">
+                            {data.appPrivateDataBase64}
+                        </pre>
+                    </div>
+
+                    <div className="flex flex-col gap-2 text-sm">
+                        <div className="flex items-center justify-between">
+                            <p className="text-muted-foreground">JWT Secret</p>
+                            <div className="flex items-center gap-2">
+                                <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                                    BASE64
+                                </span>
+                                <CopyButton text={data.jwtSecretBase64} />
+                            </div>
+                        </div>
+                        <pre className="max-h-[4lh] overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-xs">
+                            {data.jwtSecretBase64}
+                        </pre>
+                    </div>
+
+                    <div className="flex justify-end pt-4">
+                        <Button onClick={() => onOpenChange(false)}>Close</Button>
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
+++ b/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { SecretInformationBanner } from '@/components/ui/secret-information-banner'
 import { CopyButton } from '@/components/copy-button'
+import { cn } from '@/utils'
 
 interface BotCredentialsData {
     botAddress: string
@@ -26,64 +27,57 @@ export const BotCredentialsDialog = ({ open, onOpenChange, data }: BotCredential
         return null
     }
 
+    const envContent = `APP_PRIVATE_DATA_BASE64=${data.appPrivateDataBase64}
+JWT_SECRET=${data.jwtSecretBase64}`
+
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="sm:max-w-2xl">
                 <DialogHeader>
-                    <DialogTitle>Bot Created Successfully</DialogTitle>
+                    <DialogTitle className="flex items-center gap-2">
+                        Bot Created Successfully
+                    </DialogTitle>
                     <DialogDescription>
-                        Your bot has been created and deployed. Store this information securely.
+                        Your bot has been minted. The private credentials below are critical for your bot's operation.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4">
                     <SecretInformationBanner>
-                        Store this information in a secure location. You won't be able to access it
-                        again.
+                        These private keys and secrets are shown only once and cannot be recovered. 
                     </SecretInformationBanner>
 
                     <div className="flex flex-col gap-2 text-sm">
                         <div className="flex items-center justify-between">
-                            <p className="text-muted-foreground">Bot Address:</p>
-                            <CopyButton text={data.botAddress} />
+                            <p className="text-muted-foreground">Environment Variables</p>
+                            <CopyButton text={envContent} />
                         </div>
-                        <pre className="overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-xs">
-                            {data.botAddress}
-                        </pre>
+                        <textarea
+                            readOnly
+                            value={envContent}
+                            className={cn(
+                                "min-h-[200px] w-full rounded-md border font-mono text-xs shadow-sm resize-none",
+                                "bg-muted text-foreground",
+                                "px-4 py-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                                "disabled:cursor-not-allowed disabled:opacity-50"
+                            )}
+                            placeholder="Environment variables will appear here..."
+                        />
                     </div>
 
-                    <div className="flex flex-col gap-2 text-sm">
-                        <div className="flex items-center justify-between">
-                            <p className="text-muted-foreground">App Private Data</p>
-                            <div className="flex items-center gap-2">
-                                <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-                                    BASE64
-                                </span>
-                                <CopyButton text={data.appPrivateDataBase64} />
-                            </div>
+                    <div className="rounded-md bg-blue-50 p-4 dark:bg-blue-900/20">
+                        <div className="text-sm">
+                            <h4 className="font-medium text-blue-900 dark:text-blue-100 mb-2">Next Steps:</h4>
+                            <ul className="list-disc list-inside space-y-1 text-blue-800 dark:text-blue-200">
+                                <li>Copy and securely store the App Private Data and JWT Secret</li>
+                                <li>Use these credentials to authenticate your bot application</li>
+                                <li>Never share these secrets publicly or commit them to version control</li>
+                            </ul>
                         </div>
-                        <pre className="max-h-[4lh] overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-xs">
-                            {data.appPrivateDataBase64}
-                        </pre>
-                    </div>
-
-                    <div className="flex flex-col gap-2 text-sm">
-                        <div className="flex items-center justify-between">
-                            <p className="text-muted-foreground">JWT Secret</p>
-                            <div className="flex items-center gap-2">
-                                <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-                                    BASE64
-                                </span>
-                                <CopyButton text={data.jwtSecretBase64} />
-                            </div>
-                        </div>
-                        <pre className="max-h-[4lh] overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-xs">
-                            {data.jwtSecretBase64}
-                        </pre>
                     </div>
 
                     <div className="flex justify-end pt-4">
-                        <Button onClick={() => onOpenChange(false)}>Close</Button>
+                        <Button onClick={() => onOpenChange(false)}>I've Saved My Credentials</Button>
                     </div>
                 </div>
             </DialogContent>

--- a/packages/playground/src/components/dialog/create-bot/index.tsx
+++ b/packages/playground/src/components/dialog/create-bot/index.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { AppRegistryDapp, Permission } from '@towns-protocol/web3'
+import { useSyncAgent, useTowns } from '@towns-protocol/react-sdk'
+import { ethers } from 'ethers'
+import type { Address } from 'viem'
+import {
+    AppRegistryService,
+    Client,
+    MockEntitlementsDelegate,
+    RiverDbManager,
+    getAppRegistryUrl,
+    makeBaseProvider,
+    makeRiverProvider,
+    makeRiverRpcClient,
+    makeSignerContext,
+} from '@towns-protocol/sdk'
+import { AppPrivateDataSchema } from '@towns-protocol/proto'
+import { create, toBinary } from '@bufbuild/protobuf'
+import { bin_fromHexString, bin_toBase64 } from '@towns-protocol/dlog'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
+import { getAllBotsQueryKey } from '@/hooks/useAllBots'
+import { BotFormData } from './types'
+import { InfoStep, infoSchema } from './steps/info'
+import { TypeStep } from './steps/type'
+import { ReviewStep } from './steps/review'
+import { WizardFooter } from './wizard-footer'
+import { BotCredentialsDialog } from './bot-credentials-dialog'
+
+const steps = [InfoStep, TypeStep, ReviewStep]
+
+const formSchema = infoSchema.extend({
+    botKind: z.enum(['simple', 'contract']),
+    contractAddress: z.string().optional(),
+})
+
+const ONE_YEAR_IN_SECONDS = 31536000
+
+interface CreateBotDialogProps {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+}
+
+export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) => {
+    const sync = useSyncAgent()
+    const queryClient = useQueryClient()
+    const form = useForm<BotFormData>({
+        resolver: zodResolver(formSchema),
+        mode: 'onChange',
+        defaultValues: {
+            name: '',
+            description: '',
+            permissions: [Permission.Read, Permission.Write],
+            installPrice: '0.01',
+            membershipDuration: String(ONE_YEAR_IN_SECONDS),
+            botKind: 'simple',
+            contractAddress: undefined,
+        },
+    })
+
+    const [step, setStep] = useState(0)
+    const [credentialsData, setCredentialsData] = useState<{
+        botAddress: string
+        appPrivateDataBase64: string
+        jwtSecretBase64: string
+    } | null>(null)
+    const [showCredentials, setShowCredentials] = useState(false)
+    const CurrentStep = steps[step]
+
+    useEffect(() => {
+        if (!open) {
+            form.reset()
+            setStep(0)
+            setCredentialsData(null)
+            setShowCredentials(false)
+        }
+    }, [open, form])
+
+    const next = () => {
+        if (step < steps.length - 1) {
+            setStep(step + 1)
+        }
+    }
+
+    const back = () => {
+        if (step > 0) {
+            setStep(step - 1)
+        }
+    }
+
+    const signer = useEthersSigner()
+    const { data: user } = useTowns((s) => s.user)
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: async (formData: BotFormData) => {
+            const {
+                name,
+                description,
+                installPrice,
+                membershipDuration,
+                permissions,
+                botKind,
+                contractAddress,
+            } = formData
+            console.log('mutate', formData)
+
+            const baseProvider = makeBaseProvider(sync.config.riverConfig)
+            if (!signer) {
+                throw new Error('Signer is not set')
+            }
+            const riverConfig = sync.config.riverConfig
+
+            const botWallet = ethers.Wallet.createRandom()
+            const appRegistryDapp = new AppRegistryDapp(riverConfig.base.chainConfig, baseProvider)
+            let appAddress = ''
+            if (botKind === 'simple') {
+                const tx = await appRegistryDapp.createApp(
+                    signer,
+                    name,
+                    permissions,
+                    botWallet.address as Address,
+                    ethers.utils.parseEther(installPrice).toBigInt(),
+                    BigInt(membershipDuration),
+                )
+                const receipt = await tx.wait()
+                const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+                appAddress = foundAppAddress
+            } else if (botKind === 'contract' && contractAddress) {
+                const tx = await appRegistryDapp.registerApp(
+                    signer,
+                    contractAddress,
+                    botWallet.address as Address,
+                )
+                const receipt = await tx.wait()
+                const { app: foundAppAddress } = appRegistryDapp.getRegisterAppEvent(receipt)
+                appAddress = foundAppAddress
+            } else {
+                throw new Error('Invalid bot kind or contract address')
+            }
+            const delegateWallet = ethers.Wallet.createRandom()
+            const signerContext = await makeSignerContext(botWallet, delegateWallet)
+            const rpcClient = await makeRiverRpcClient(
+                makeRiverProvider(riverConfig),
+                riverConfig.river.chainConfig,
+            )
+            const cryptoStore = RiverDbManager.getCryptoDb(appAddress)
+            const botClient = new Client(
+                signerContext,
+                rpcClient,
+                cryptoStore,
+                new MockEntitlementsDelegate(),
+            )
+            await botClient.initializeUser({ appAddress })
+            await botClient.uploadDeviceKeys()
+
+            const exportedDevice = await botClient.cryptoBackend?.exportDevice()
+            const appPrivateDataBase64 = bin_toBase64(
+                toBinary(
+                    AppPrivateDataSchema,
+                    create(AppPrivateDataSchema, {
+                        privateKey: botWallet.privateKey,
+                        encryptionDevice: exportedDevice,
+                    }),
+                ),
+            )
+
+            const { appRegistryRpcClient } = await AppRegistryService.authenticateWithSigner(
+                user.id,
+                signer,
+                getAppRegistryUrl(riverConfig.environmentId),
+            )
+            const { hs256SharedSecret } = await appRegistryRpcClient.register({
+                appId: bin_fromHexString(botWallet.address),
+                appOwnerId: bin_fromHexString(user.id),
+            })
+            const jwtSecretBase64 = bin_toBase64(hs256SharedSecret)
+
+            return {
+                botAddress: botWallet.address,
+                appPrivateDataBase64,
+                jwtSecretBase64,
+            }
+        },
+        onSuccess: (data) => {
+            onOpenChange?.(false)
+            setCredentialsData(data)
+            setShowCredentials(true)
+            if (user.id) {
+                queryClient.invalidateQueries({
+                    queryKey: getAllBotsQueryKey(user.id),
+                })
+            }
+            console.log('onSuccess', data)
+        },
+        onError: (error) => {
+            console.error('onError', error)
+        },
+    })
+
+    return (
+        <>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Create a Bot</DialogTitle>
+                    <DialogDescription>{CurrentStep.description}</DialogDescription>
+                </DialogHeader>
+                <FormProvider {...form}>
+                    <form
+                        className="space-y-6"
+                        onSubmit={form.handleSubmit((data) => mutate(data))}
+                    >
+                        <CurrentStep />
+                        <WizardFooter
+                            step={step}
+                            totalSteps={steps.length}
+                            isNextDisabled={!form.formState.isValid}
+                            isMinting={isPending}
+                            onBack={back}
+                            onNext={next}
+                        />
+                    </form>
+                </FormProvider>
+            </DialogContent>
+            <BotCredentialsDialog
+                open={showCredentials}
+                data={credentialsData}
+                onOpenChange={setShowCredentials}
+            />
+        </>
+    )
+}

--- a/packages/playground/src/components/dialog/create-bot/index.tsx
+++ b/packages/playground/src/components/dialog/create-bot/index.tsx
@@ -33,37 +33,41 @@ import { WizardFooter } from './wizard-footer'
 
 const steps = [InfoStep, TypeStep, ReviewStep]
 
-const typeStepSchema = z.object({
-    botKind: z.enum(['simple', 'contract']),
-    contractAddress: z.string().optional(),
-}).refine(
-    (data) => {
-        if (data.botKind === 'contract') {
-            return data.contractAddress && data.contractAddress.trim() !== ''
-        }
-        return true
-    },
-    {
-        message: 'Contract address is required for contract bots',
-        path: ['contractAddress'],
-    }
-)
+const typeStepSchema = z
+    .object({
+        botKind: z.enum(['simple', 'contract']),
+        contractAddress: z.string().optional(),
+    })
+    .refine(
+        (data) => {
+            if (data.botKind === 'contract') {
+                return data.contractAddress && data.contractAddress.trim() !== ''
+            }
+            return true
+        },
+        {
+            message: 'Contract address is required for contract bots',
+            path: ['contractAddress'],
+        },
+    )
 
-const formSchema = infoSchema.extend({
-    botKind: z.enum(['simple', 'contract']),
-    contractAddress: z.string().optional(),
-}).refine(
-    (data) => {
-        if (data.botKind === 'contract') {
-            return data.contractAddress && data.contractAddress.trim() !== ''
-        }
-        return true
-    },
-    {
-        message: 'Contract address is required for contract bots',
-        path: ['contractAddress'],
-    }
-)
+const formSchema = infoSchema
+    .extend({
+        botKind: z.enum(['simple', 'contract']),
+        contractAddress: z.string().optional(),
+    })
+    .refine(
+        (data) => {
+            if (data.botKind === 'contract') {
+                return data.contractAddress && data.contractAddress.trim() !== ''
+            }
+            return true
+        },
+        {
+            message: 'Contract address is required for contract bots',
+            path: ['contractAddress'],
+        },
+    )
 
 const stepSchemas = [
     infoSchema,
@@ -114,12 +118,12 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
     }, [open, form])
 
     const watchedValues = form.watch()
-    
+
     const isStepValid = useMemo(() => {
         const stepSchema = stepSchemas[step]
         try {
             let stepValues: unknown
-            
+
             switch (step) {
                 case 0: // Info step
                     stepValues = {
@@ -142,10 +146,10 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
                 default:
                     return false
             }
-            
+
             stepSchema.parse(stepValues)
             return true
-        } catch  {
+        } catch {
             return false
         }
     }, [step, watchedValues])
@@ -211,7 +215,7 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
                 if (!receipt) {
                     throw new Error('Transaction failed')
                 }
-                
+
                 const { app: foundAppAddress } = appRegistryDapp.getRegisterAppEvent(receipt)
                 appAddress = foundAppAddress
             } else {

--- a/packages/playground/src/components/dialog/create-bot/steps/info.tsx
+++ b/packages/playground/src/components/dialog/create-bot/steps/info.tsx
@@ -1,0 +1,139 @@
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
+import { Permission } from '@towns-protocol/web3'
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import { BotFormData } from '../types'
+
+export const infoSchema = z.object({
+    name: z.string().min(1, { message: 'Name is required' }),
+    description: z.string().optional(),
+    installPrice: z.string().min(1, { message: 'Install price is required' }),
+    membershipDuration: z.string().min(1, { message: 'Membership duration is required' }),
+    permissions: z.array(z.nativeEnum(Permission)).min(1, { message: 'Select at least one' }),
+})
+
+const membershipDurationOptions = [
+    { label: '10 minutes', value: '600' },
+    { label: '1 hour', value: '3600' },
+    { label: '1 week', value: '604800' },
+    { label: '1 month', value: '2592000' },
+    { label: '1 year', value: '31536000' },
+]
+
+export const InfoStep = () => {
+    const { control, watch, setValue } = useFormContext<BotFormData>()
+    const selected = watch('permissions')
+
+    const availablePermissions = Object.values(Permission).filter((p) => p !== Permission.Undefined)
+
+    const togglePermission = (p: Permission) => {
+        if (selected.includes(p)) {
+            setValue(
+                'permissions',
+                selected.filter((x) => x !== p),
+            )
+        } else {
+            setValue('permissions', [...selected, p])
+        }
+    }
+
+    return (
+        <div className="space-y-4">
+            <FormField
+                control={control as never}
+                name="name"
+                render={({ field }) => (
+                    <FormItem>
+                        <FormLabel>Name</FormLabel>
+                        <FormControl>
+                            <Input placeholder="My Bot" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+                control={control as never}
+                name="description"
+                render={({ field }) => (
+                    <FormItem>
+                        <FormLabel>Description</FormLabel>
+                        <FormControl>
+                            <Input placeholder="Optional description" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+                control={control as never}
+                name="installPrice"
+                render={({ field }) => (
+                    <FormItem>
+                        <FormLabel>Install Price (ETH)</FormLabel>
+                        <FormControl>
+                            <Input type="number" step="any" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+                control={control as never}
+                name="membershipDuration"
+                render={({ field }) => (
+                    <FormItem>
+                        <FormLabel>Membership Duration</FormLabel>
+                        <FormControl>
+                            <Select value={field.value} onValueChange={field.onChange}>
+                                <SelectTrigger>
+                                    <SelectValue placeholder="Select membership duration" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {membershipDurationOptions.map((option) => (
+                                        <SelectItem key={option.value} value={option.value}>
+                                            {option.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </FormControl>
+                        <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <div className="space-y-2">
+                <p className="text-sm font-medium">Permissions</p>
+                <div className="grid grid-cols-2 gap-2">
+                    {availablePermissions.map((p) => (
+                        <button
+                            key={p}
+                            type="button"
+                            className={
+                                'rounded border px-2 py-1 text-sm ' +
+                                (selected.includes(p)
+                                    ? 'bg-primary text-primary-foreground'
+                                    : 'bg-background')
+                            }
+                            onClick={() => togglePermission(p)}
+                        >
+                            {p}
+                        </button>
+                    ))}
+                </div>
+                {selected.length === 0 && (
+                    <p className="text-xs text-destructive">Select at least one permission</p>
+                )}
+            </div>
+        </div>
+    )
+}
+InfoStep.description = 'Configure your bot details'

--- a/packages/playground/src/components/dialog/create-bot/steps/review.tsx
+++ b/packages/playground/src/components/dialog/create-bot/steps/review.tsx
@@ -1,0 +1,35 @@
+import { useFormContext } from 'react-hook-form'
+import { BotFormData } from '../types'
+
+const pad = (label: string, len = 22) => label.padEnd(len, ' ')
+
+export const ReviewStep = () => {
+    const { getValues } = useFormContext<BotFormData>()
+    const v = getValues()
+
+    const lines: string[] = []
+    lines.push('══════════════════════════════════════════════')
+    lines.push('                  BOT RECEIPT                 ')
+    lines.push('══════════════════════════════════════════════')
+    lines.push('')
+    lines.push(`${pad('Name')}: ${v.name}`)
+    lines.push(`${pad('Description')}: ${v.description || '—'}`)
+    lines.push(`${pad('Install Price')}: ${v.installPrice} ETH`)
+    lines.push(`${pad('Membership Duration')}: ${v.membershipDuration} sec`)
+    lines.push(`${pad('Permissions')}: ${v.permissions.join(', ')}`)
+    lines.push(`${pad('Bot Type')}: ${v.botKind === 'simple' ? 'Simple' : 'Contract'}`)
+    if (v.botKind === 'contract') {
+        lines.push(`${pad('Contract Address')}: ${v.contractAddress}`)
+    }
+    lines.push('')
+    lines.push('══════════════════════════════════════════════')
+
+    return (
+        <div className="flex justify-center">
+            <pre className="whitespace-pre-wrap rounded-lg border-2 border-muted-foreground/20 bg-muted p-6 font-mono text-sm shadow-inner">
+                {lines.join('\n')}
+            </pre>
+        </div>
+    )
+}
+ReviewStep.description = 'Review the details of your new bot'

--- a/packages/playground/src/components/dialog/create-bot/steps/type.tsx
+++ b/packages/playground/src/components/dialog/create-bot/steps/type.tsx
@@ -1,0 +1,60 @@
+import { useFormContext } from 'react-hook-form'
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { BotFormData } from '../types'
+
+export const TypeStep = () => {
+    const { control, watch } = useFormContext<BotFormData>()
+    const kind = watch('botKind')
+    return (
+        <div className="space-y-4">
+            <FormField
+                control={control as never}
+                name="botKind"
+                render={({ field }) => (
+                    <FormItem>
+                        <div className="flex items-center gap-4">
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="radio"
+                                    value="simple"
+                                    checked={field.value === 'simple'}
+                                    onChange={(e) => field.onChange(e.target.value)}
+                                />
+                                Simple Bot
+                            </label>
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="radio"
+                                    value="contract"
+                                    checked={field.value === 'contract'}
+                                    onChange={(e) => field.onChange(e.target.value)}
+                                />
+                                Contract Bot
+                            </label>
+                        </div>
+                        <FormMessage />
+                    </FormItem>
+                )}
+            />
+            {kind === 'contract' && (
+                <FormField
+                    control={control as never}
+                    name="contractAddress"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Contract Address</FormLabel>
+                            <FormControl>
+                                <Input placeholder="0x..." {...field} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            )}
+        </div>
+    )
+}
+
+TypeStep.description =
+    'You can build a bot using a pre-existing contract or select a simple bot with an already defined contract'

--- a/packages/playground/src/components/dialog/create-bot/types.ts
+++ b/packages/playground/src/components/dialog/create-bot/types.ts
@@ -1,0 +1,11 @@
+import { type Address, Permission } from '@towns-protocol/web3'
+
+export interface BotFormData {
+    name: string
+    description: string
+    permissions: Permission[]
+    installPrice: string
+    membershipDuration: string
+    botKind: 'simple' | 'contract'
+    contractAddress?: Address
+}

--- a/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
+++ b/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components/ui/button'
+import { cn } from '@/utils/cn'
+
+export const WizardFooter = ({
+    step,
+    totalSteps,
+    onBack,
+    onNext,
+    isNextDisabled,
+    isMinting,
+}: {
+    step: number
+    totalSteps: number
+    onBack: () => void
+    onNext: () => void
+    isNextDisabled?: boolean
+    isMinting?: boolean
+}) => {
+    const isLast = step === totalSteps - 1
+
+    return (
+        <div className={cn('mt-6 flex justify-between', step === 0 && 'justify-end')}>
+            {step !== 0 && (
+                <Button variant="outline" disabled={step === 0} onClick={onBack}>
+                    Back
+                </Button>
+            )}
+            <Button
+                type={isLast ? 'submit' : 'button'}
+                disabled={isNextDisabled || isMinting}
+                onClick={onNext}
+            >
+                {isLast ? (isMinting ? 'Minting...' : 'Finish') : 'Next'}
+            </Button>
+        </div>
+    )
+}

--- a/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
+++ b/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
@@ -28,10 +28,14 @@ export const WizardFooter = ({
             <Button
                 type={isLast ? 'submit' : 'button'}
                 disabled={isNextDisabled || isMinting}
-                onClick={isLast ? undefined : (e) => {
-                    e.preventDefault()
-                    onNext()
-                }}
+                onClick={
+                    isLast
+                        ? undefined
+                        : (e) => {
+                              e.preventDefault()
+                              onNext()
+                          }
+                }
             >
                 {isLast ? (isMinting ? 'Minting...' : 'Mint') : 'Next'}
             </Button>

--- a/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
+++ b/packages/playground/src/components/dialog/create-bot/wizard-footer.tsx
@@ -28,9 +28,12 @@ export const WizardFooter = ({
             <Button
                 type={isLast ? 'submit' : 'button'}
                 disabled={isNextDisabled || isMinting}
-                onClick={onNext}
+                onClick={isLast ? undefined : (e) => {
+                    e.preventDefault()
+                    onNext()
+                }}
             >
-                {isLast ? (isMinting ? 'Minting...' : 'Finish') : 'Next'}
+                {isLast ? (isMinting ? 'Minting...' : 'Mint') : 'Next'}
             </Button>
         </div>
     )

--- a/packages/playground/src/components/ui/checkbox.tsx
+++ b/packages/playground/src/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { CheckIcon } from '@radix-ui/react-icons'
+import { cn } from '@/utils/index'
+
+const Checkbox = React.forwardRef<
+    React.ElementRef<typeof CheckboxPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+    <CheckboxPrimitive.Root
+        ref={ref}
+        className={cn(
+            'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+            className,
+        )}
+        {...props}
+    >
+        <CheckboxPrimitive.Indicator
+            className={cn('flex items-center justify-center text-current')}
+        >
+            <CheckIcon className="h-4 w-4" />
+        </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/packages/playground/src/components/ui/secret-information-banner.tsx
+++ b/packages/playground/src/components/ui/secret-information-banner.tsx
@@ -1,0 +1,10 @@
+import { AlertTriangle } from 'lucide-react'
+
+export const SecretInformationBanner = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <div className="flex items-center gap-2 rounded-sm bg-yellow-50 p-2 text-sm text-yellow-500 dark:bg-yellow-900/50">
+            <AlertTriangle className="mr-2 h-4 w-4" />
+            {children}
+        </div>
+    )
+}

--- a/packages/playground/src/hooks/useAllBots.ts
+++ b/packages/playground/src/hooks/useAllBots.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { useSyncAgent, useTowns } from '@towns-protocol/react-sdk'
+import { type Address, AppRegistryDapp } from '@towns-protocol/web3'
+import { makeBaseProvider } from '@towns-protocol/sdk'
+
+export const getAllBotsQueryKey = (userId: string) => ['all-bots', userId] as const
+
+export const useAllBots = () => {
+    const sync = useSyncAgent()
+    const { data: user } = useTowns((s) => s.user)
+
+    return useQuery({
+        queryKey: getAllBotsQueryKey(user.id ?? ''),
+        queryFn: async () => {
+            if (!user.id) {
+                return []
+            }
+
+            const baseProvider = makeBaseProvider(sync.config.riverConfig)
+            const riverConfig = sync.config.riverConfig
+            const appRegistryDapp = new AppRegistryDapp(riverConfig.base.chainConfig, baseProvider)
+            return appRegistryDapp.getAllAppsByOwner(user.id as Address)
+        },
+        enabled: !!sync.userId,
+    })
+}

--- a/packages/playground/src/routes/t/dashboard.tsx
+++ b/packages/playground/src/routes/t/dashboard.tsx
@@ -33,8 +33,8 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { CreateDm } from '@/components/form/dm/create'
 import { CreateBotDialog } from '@/components/dialog/create-bot'
 import { useAllBots } from '@/hooks/useAllBots'
-import { BotSettingsDialog } from '@/components/dialog/bot-settings'
 import { BotInstallDialog } from '@/components/dialog/bot-install'
+import { BotSettingsDialog } from '@/components/dialog/bot-settings'
 
 export const DashboardRoute = () => {
     const navigate = useNavigate()

--- a/packages/playground/src/routes/t/dashboard.tsx
+++ b/packages/playground/src/routes/t/dashboard.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useNavigate } from 'react-router-dom'
-import { Suspense, useCallback, useMemo, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import {
     useDm,
     useGdm,
@@ -14,7 +14,8 @@ import {
 } from '@towns-protocol/react-sdk'
 import { suspend } from 'suspend-react'
 import { Myself } from '@towns-protocol/sdk'
-import { DoorOpenIcon, PlusIcon } from 'lucide-react'
+import { DoorOpenIcon, DownloadIcon, PlusIcon, SettingsIcon } from 'lucide-react'
+import type { BotInfo } from '@towns-protocol/web3'
 import { GridSidePanel } from '@/components/layout/grid-side-panel'
 import { Button } from '@/components/ui/button'
 import { CreateSpace } from '@/components/form/space/create'
@@ -30,15 +31,25 @@ import {
 } from '@/components/ui/dialog'
 import { Tooltip } from '@/components/ui/tooltip'
 import { CreateDm } from '@/components/form/dm/create'
+import { CreateBotDialog } from '@/components/dialog/create-bot'
+import { useAllBots } from '@/hooks/useAllBots'
+import { BotSettingsDialog } from '@/components/dialog/bot-settings'
+import { BotInstallDialog } from '@/components/dialog/bot-install'
 
 export const DashboardRoute = () => {
     const navigate = useNavigate()
     const { spaceIds } = useUserSpaces()
     const { streamIds: gdmStreamIds } = useUserGdms()
     const { streamIds: dmStreamIds } = useUserDms()
+    const { data: bots, isLoading: botsLoading } = useAllBots()
+
+    useEffect(() => {
+        console.log('bots', bots)
+    }, [bots])
     const [joinSpaceDialogOpen, setJoinSpaceDialogOpen] = useState(false)
     const [createSpaceDialogOpen, setCreateSpaceDialogOpen] = useState(false)
     const [createDmDialogOpen, setCreateDmDialogOpen] = useState(false)
+    const [createAppDialogOpen, setCreateAppDialogOpen] = useState(false)
 
     const navigateToSpace = useCallback(
         (spaceId: string) => {
@@ -148,6 +159,45 @@ export const DashboardRoute = () => {
                             You're not in any group chats yet.
                         </p>
                     )}
+
+                    <hr className="my-2" />
+
+                    <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs">Your apps</span>
+                        <div className="flex items-center gap-2">
+                            <Dialog
+                                open={createAppDialogOpen}
+                                onOpenChange={setCreateAppDialogOpen}
+                            >
+                                <Tooltip title="Create an app">
+                                    <Button
+                                        variant="outline"
+                                        size="icon"
+                                        onClick={() => setCreateAppDialogOpen(true)}
+                                    >
+                                        <PlusIcon className="h-4 w-4" />
+                                    </Button>
+                                </Tooltip>
+                                <CreateBotDialog
+                                    open={createAppDialogOpen}
+                                    onOpenChange={setCreateAppDialogOpen}
+                                />
+                            </Dialog>
+                        </div>
+                    </div>
+                    <div className="flex flex-col gap-2">
+                        {botsLoading ? (
+                            <p className="pt-4 text-center text-sm text-secondary-foreground">
+                                Loading your apps...
+                            </p>
+                        ) : bots && bots.length > 0 ? (
+                            bots.map((bot) => <BotCard key={bot.appId} bot={bot} />)
+                        ) : (
+                            <p className="pt-4 text-center text-sm text-secondary-foreground">
+                                You don't have any apps yet.
+                            </p>
+                        )}
+                    </div>
 
                     <hr className="my-2" />
 
@@ -299,5 +349,36 @@ const NoSuspenseDmInfo = ({
                 {userId === sync.userId ? 'You' : displayName || username || shortenAddress(userId)}
             </p>
         </button>
+    )
+}
+
+const BotCard = ({ bot }: { bot: BotInfo }) => {
+    const [settingsOpen, setSettingsOpen] = useState(false)
+    const [installOpen, setInstallOpen] = useState(false)
+
+    return (
+        <div className="flex items-center justify-between gap-3">
+            <p className="font-mono text-sm font-medium">{shortenAddress(bot.app.client)}</p>
+            <div className="flex items-center gap-2">
+                <Button variant="outline" size="icon" onClick={() => setSettingsOpen(true)}>
+                    <SettingsIcon className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="icon" onClick={() => setInstallOpen(true)}>
+                    <DownloadIcon className="h-4 w-4" />
+                </Button>
+            </div>
+
+            <BotSettingsDialog
+                appClientId={bot.app.client}
+                open={settingsOpen}
+                onOpenChange={setSettingsOpen}
+            />
+            <BotInstallDialog
+                appAddress={bot.app.module}
+                appClientId={bot.app.client}
+                open={installOpen}
+                onOpenChange={setInstallOpen}
+            />
+        </div>
     )
 }

--- a/packages/playground/src/routes/t/space-channels.tsx
+++ b/packages/playground/src/routes/t/space-channels.tsx
@@ -1,7 +1,8 @@
 import { useChannel, useSpace } from '@towns-protocol/react-sdk'
 import { Link, Outlet, useNavigate, useParams } from 'react-router-dom'
 import { useCallback, useState } from 'react'
-import { ArrowLeftIcon, PlusIcon } from '@radix-ui/react-icons'
+import { ArrowLeftIcon, GearIcon, PlusIcon } from '@radix-ui/react-icons'
+import { BotIcon } from 'lucide-react'
 import { GridSidePanel } from '@/components/layout/grid-side-panel'
 import { SpaceProvider } from '@/hooks/current-space'
 import { CreateChannel } from '@/components/form/channel/create'
@@ -15,6 +16,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import { Tooltip } from '@/components/ui/tooltip'
+import { MintBotDialog } from '@/components/dialog/mint-bot'
 
 export const SelectChannelRoute = () => {
     const navigate = useNavigate()
@@ -43,6 +45,12 @@ export const SelectChannelRoute = () => {
                         <div className="flex items-center justify-between gap-2">
                             <h2 className="text-xs">Select a channel to start messaging</h2>
                             <div className="flex items-center gap-2">
+                                <Tooltip title="Mint a new bot">
+                                    <Button variant="outline" size="icon">
+                                        <BotIcon className="h-4 w-4" />
+                                    </Button>
+                                </Tooltip>
+
                                 <Dialog
                                     open={createChannelDialogOpen}
                                     onOpenChange={setCreateChannelDialogOpen}

--- a/packages/playground/src/routes/t/space-channels.tsx
+++ b/packages/playground/src/routes/t/space-channels.tsx
@@ -1,7 +1,7 @@
 import { useChannel, useSpace } from '@towns-protocol/react-sdk'
 import { Link, Outlet, useNavigate, useParams } from 'react-router-dom'
 import { useCallback, useState } from 'react'
-import { ArrowLeftIcon, GearIcon, PlusIcon } from '@radix-ui/react-icons'
+import { ArrowLeftIcon, PlusIcon } from '@radix-ui/react-icons'
 import { BotIcon } from 'lucide-react'
 import { GridSidePanel } from '@/components/layout/grid-side-panel'
 import { SpaceProvider } from '@/hooks/current-space'
@@ -16,7 +16,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import { Tooltip } from '@/components/ui/tooltip'
-import { MintBotDialog } from '@/components/dialog/mint-bot'
 
 export const SelectChannelRoute = () => {
     const navigate = useNavigate()

--- a/yarn.lock
+++ b/yarn.lock
@@ -6044,6 +6044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/primitive@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/primitive@npm:1.1.2"
+  checksum: 6cb2ac097faf77b7288bdfd87d92e983e357252d00ee0d2b51ad8e7897bf9f51ec53eafd7dd64c613671a2b02cb8166177bc3de444a6560ec60835c363321c18
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-arrow@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-arrow@npm:1.1.0"
@@ -6060,6 +6067,32 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 8522e0a8095ecc32d3a719f9c3bc0514c677a9c9d5ac26985d5416576dbc487c2a49ba2484397d9de502b54657856cb41ca3ea0b2165563eeeae45a83750885b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-checkbox@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@radix-ui/react-checkbox@npm:1.3.2"
+  dependencies:
+    "@radix-ui/primitive": 1.1.2
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-context": 1.1.2
+    "@radix-ui/react-presence": 1.1.4
+    "@radix-ui/react-primitive": 2.1.3
+    "@radix-ui/react-use-controllable-state": 1.2.2
+    "@radix-ui/react-use-previous": 1.1.1
+    "@radix-ui/react-use-size": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 4c895aa1d9fa469d429a1a7ce39c10c8c056aba7e55acd9b257d1169f3826721d815f5d3e1543014f563aed379885d60aabcb23629a75cbbf18d6257e860c20a
   languageName: node
   linkType: hard
 
@@ -6098,6 +6131,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 9a91f0213014ffa40c5b8aae4debb993be5654217e504e35aa7422887eb2d114486d37e53c482d0fffb00cd44f51b5269fcdf397b280c71666fa11b7f32f165d
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-context@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-context@npm:1.1.0"
@@ -6121,6 +6167,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 9a04db236685dacc2f5ab2bdcfc4c82b974998e712ab97d79b11d5b4ef073d24aa9392398c876ef6cb3c59f40299285ceee3646187ad818cdad4fe1c74469d3f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-context@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6d08437f23df362672259e535ae463e70bf7a0069f09bfa06c983a5a90e15250bde19da1d63ef8e3da06df1e1b4f92afa9d28ca6aa0297bb1c8aaf6ca83d28c5
   languageName: node
   linkType: hard
 
@@ -6427,6 +6486,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-presence@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-presence@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: d3b0976368fccdfa07100c1f07ca434d0092d4132d1ed4a5c213802f7318d77fc1fd61d1b7038b87e82912688fafa97d8af000a6cca4027b09d92c5477f79dd0
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-primitive@npm:2.0.0":
   version: 2.0.0
   resolution: "@radix-ui/react-primitive@npm:2.0.0"
@@ -6443,6 +6522,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 04afc0f3a5ccf1de6e4861f755a89f31640d5a07237c5ac5bffe47bcd8fdf318257961fa56fedc823af49281800ee755752a371561c36fd92f008536a0553748
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": 1.2.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 01f82e4bad76b57767198762c905e5bcea04f4f52129749791e31adfcb1b36f6fdc89c73c40017d812b6e25e4ac925d837214bb280cfeaa5dc383457ce6940b0
   languageName: node
   linkType: hard
 
@@ -6524,6 +6622,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 3c9cd90aabf08f541e20dbecb581744be01c552a0cd16e90d7c218381bcc5307aa8a6013d045864e692ba89d3d8c17bfae08df18ed18be6d223d9330ab0302fa
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": 1.1.2
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 2731089e15477dd5eef98a5757c36113dd932d0c52ff05123cd89f05f0412e95e5b205229185d1cd705cda4a674a838479cce2b3b46ed903f82f5d23d9e3f3c2
   languageName: node
   linkType: hard
 
@@ -6610,6 +6723,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-controllable-state@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
+  dependencies:
+    "@radix-ui/react-use-effect-event": 0.0.2
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: b438ee199d0630bf95eaafe8bf4bce219e73b371cfc8465f47548bfa4ee231f1134b5c6696b242890a01a0fd25fa34a7b172346bbfc5ee25cfb28b3881b1dc92
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 5a1950a30a399ea7e4b98154da9f536737a610de80189b7aacd4f064a89a3cd0d2a48571d527435227252e72e872bdb544ff6ffcfbdd02de2efd011be4aaa902
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-escape-keydown@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.0"
@@ -6638,6 +6782,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-layout-effect@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: bad2ba4f206e6255263582bedfb7868773c400836f9a1b423c0b464ffe4a17e13d3f306d1ce19cf7a19a492e9d0e49747464f2656451bb7c6a99f5a57bd34de2
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-previous@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-use-previous@npm:1.1.0"
@@ -6648,6 +6805,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 8a2407e3db6248ab52bf425f5f4161355d09f1a228038094959250ae53552e73543532b3bb80e452f6ad624621e2e1c6aebb8c702f2dfaa5e89f07ec629d9304
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-previous@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-previous@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: ea6ea13523a0561dda9b14b9d44e299484816a6762d7fb50b91b27b6aec89f78c85245b69d5a904750d43919dbb7ef6ce6d3823639346675aa3a5cb9de32d984
   languageName: node
   linkType: hard
 
@@ -6678,6 +6848,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 01a11d4c07fc620b8a081e53d7ec8495b19a11e02688f3d9f47cf41a5fe0428d1e52ed60b2bf88dfd447dc2502797b9dad2841097389126dd108530913c4d90d
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-size@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 64e61f65feb67ffc80e1fc4a8d5e32480fb6d68475e2640377e021178dead101568cba5f936c9c33e6c142c7cf2fb5d76ad7b23ef80e556ba142d56cf306147b
   languageName: node
   linkType: hard
 
@@ -8690,9 +8875,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@towns-protocol/playground@workspace:packages/playground"
   dependencies:
+    "@bufbuild/protobuf": ^2.2.2
     "@connectrpc/connect-web": ^2.0.0
     "@emoji-mart/data": ^1.1.2
     "@hookform/resolvers": ^3.6.0
+    "@radix-ui/react-checkbox": ^1.3.2
     "@radix-ui/react-dialog": ^1.1.1
     "@radix-ui/react-hover-card": ^1.1.1
     "@radix-ui/react-icons": ^1.3.0
@@ -8705,6 +8892,7 @@ __metadata:
     "@tanstack/react-query": ^5.51.15
     "@towns-protocol/eslint-config": "workspace:^"
     "@towns-protocol/prettier-config": "workspace:^"
+    "@towns-protocol/proto": "workspace:^"
     "@towns-protocol/react-sdk": "workspace:^"
     "@towns-protocol/sdk": "workspace:^"
     "@towns-protocol/web3": "workspace:^"


### PR DESCRIPTION
This PR adds support for creating bots, updating settings and installing them into spaces.

This PR **doesnt** add a bot install page, you can only install bots that you created
- Let me know if its a blocker and I can iterate on this

Useful for testing bot creation on alpha