### PR TITLE
Fix for erroneous error “Unable to load from persistence”

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -255,7 +255,12 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
                 const syncedStreams = await this.getSyncedStreams(streamIds)
                 const retVal: Record<string, LoadedStream | undefined> = {}
                 for (const streamId of streamIds) {
-                    retVal[streamId] = await this.loadStream(streamId, syncedStreams[streamId])
+                    if (syncedStreams[streamId]) {
+                        const stream = await this.loadStream(streamId, syncedStreams[streamId])
+                        if (stream) {
+                            retVal[streamId] = stream
+                        }
+                    }
                 }
                 return retVal
             },

--- a/packages/sdk/src/syncedStreamsExtension.ts
+++ b/packages/sdk/src/syncedStreamsExtension.ts
@@ -227,14 +227,18 @@ export class SyncedStreamsExtension {
         persistedData: LoadedStream | undefined,
     ) {
         const allowGetStream = this.highPriorityIds.has(streamId)
-        try {
-            await this.delegate.initStream(streamId, allowGetStream, persistedData)
-            this.loadedStreamCount++
-            this.numStreamsLoadedFromCache++
-            this.streamIds.delete(streamId)
-        } catch (err) {
+        if (persistedData === undefined && !allowGetStream) {
             this.streamCountRequiringNetworkAccess++
-            this.logError('Error initializing stream from persistence', streamId, err)
+        } else {
+            try {
+                await this.delegate.initStream(streamId, allowGetStream, persistedData)
+                this.loadedStreamCount++
+                this.numStreamsLoadedFromCache++
+                this.streamIds.delete(streamId)
+            } catch (err) {
+                this.streamCountRequiringNetworkAccess++
+                this.logError('Error initializing stream from persistence', streamId, err)
+            }
         }
         this.emitClientStatus()
     }


### PR DESCRIPTION
I hate this code…
If we don’t have persisted data we try to load it anyway and throw an error which we catch to increment a value which we decrement in a subsequent task that’s enqueued…
This change
1. shortcuts this to prevent the log
2. stops trying to re-look up the sycned stream object after batch looking up the sycned stream object in the persistence store