### PR TITLE
Update error log for no ciphertext to send

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2860,7 +2860,10 @@ export class Client
             try {
                 const ciphertext = await this.encryptWithDeviceKeys(payloadClearText, deviceKeys)
                 if (Object.keys(ciphertext).length === 0) {
-                    this.logError('encryptAndShareGroupSessions: no ciphertext to send', userId)
+                    // if you only have one device this is a valid state
+                    if (userId !== this.userId) {
+                        this.logError('encryptAndShareGroupSessions: no ciphertext to send', userId)
+                    }
                     return
                 }
                 const toStreamId: string = makeUserInboxStreamId(userId)


### PR DESCRIPTION
to filter out the valid case where you only have one device and you’re sending to yourself.