### PR TITLE
test(contract): implement snapshot-based verification for fork tests

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -30,7 +30,6 @@ fs_permissions = [
   { access = "read", path = "./scripts/bytecode-diff/source-diffs" },
 ] # Configures permissions for cheatcodes that touch the filesystem
 gas_reports = ["*"] # The contracts to print gas reports for.
-no_match_contract = "Fork"
 
 [rpc_endpoints]
 mainnet = "${ETH_RPC_URL}"

--- a/packages/contracts/test/base/registry/RewardsVerifier.t.sol
+++ b/packages/contracts/test/base/registry/RewardsVerifier.t.sol
@@ -54,17 +54,17 @@ abstract contract RewardsVerifier is StdAssertions, IRewardsDistributionBase {
             "earningPower"
         );
 
-        //        assertEq(
-        //            rewardsDistributionFacet.treasureByBeneficiary(delegatee).earningPower,
-        //            deposit.commissionEarningPower,
-        //            "commissionEarningPower"
-        //        );
-        //
-        //        address proxy = rewardsDistributionFacet.delegationProxyById(depositId);
-        //        if (proxy != address(0)) {
-        //            assertEq(towns.delegates(proxy), delegatee, "proxy delegatee");
-        //            assertEq(towns.getVotes(delegatee), amount, "votes");
-        //        }
+        assertEq(
+            rewardsDistributionFacet.treasureByBeneficiary(delegatee).earningPower,
+            deposit.commissionEarningPower,
+            "commissionEarningPower"
+        );
+
+        address proxy = rewardsDistributionFacet.delegationProxyById(depositId);
+        if (proxy != address(0)) {
+            assertEq(towns.delegates(proxy), delegatee, "proxy delegatee");
+            assertEq(towns.getVotes(delegatee), amount, "votes");
+        }
     }
 
     function verifyWithdraw(

--- a/packages/contracts/test/base/registry/RewardsVerifier.t.sol
+++ b/packages/contracts/test/base/registry/RewardsVerifier.t.sol
@@ -54,17 +54,17 @@ abstract contract RewardsVerifier is StdAssertions, IRewardsDistributionBase {
             "earningPower"
         );
 
-        assertEq(
-            rewardsDistributionFacet.treasureByBeneficiary(delegatee).earningPower,
-            deposit.commissionEarningPower,
-            "commissionEarningPower"
-        );
-
-        address proxy = rewardsDistributionFacet.delegationProxyById(depositId);
-        if (proxy != address(0)) {
-            assertEq(towns.delegates(proxy), delegatee, "proxy delegatee");
-            assertEq(towns.getVotes(delegatee), amount, "votes");
-        }
+        //        assertEq(
+        //            rewardsDistributionFacet.treasureByBeneficiary(delegatee).earningPower,
+        //            deposit.commissionEarningPower,
+        //            "commissionEarningPower"
+        //        );
+        //
+        //        address proxy = rewardsDistributionFacet.delegationProxyById(depositId);
+        //        if (proxy != address(0)) {
+        //            assertEq(towns.delegates(proxy), delegatee, "proxy delegatee");
+        //            assertEq(towns.getVotes(delegatee), amount, "votes");
+        //        }
     }
 
     function verifyWithdraw(


### PR DESCRIPTION
### Description

Implement snapshot-based state verification for `ForkRewardsDistribution` tests to handle existing Base mainnet state instead of assuming clean state.

### Changes

- Added `StateSnapshot` struct to track operator votes, earning power, and staked amounts
- Added `takeSnapshot()` function to capture pre-action state
- Refactored `verifyStake` to use `verifyStakeWithSnapshot` with delta-based assertions
- Updated fork tests to use snapshot verification instead of absolute value checks
- Added snapshot storage mechanisms for test state management
- Fixed operator votes verification to handle existing Base mainnet votes
- Added `totalStaked` state tracking for accurate bounds checking

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines