### PR TITLE
add unpack envelope options for bots

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -30,6 +30,7 @@ import {
     make_MemberPayload_DisplayName,
     make_UserMetadataPayload_ProfileImage,
     spaceIdFromChannelId,
+    type CreateTownsClientParams,
 } from '@towns-protocol/sdk'
 import { Hono, type Context } from 'hono'
 import EventEmitter from 'node:events'
@@ -671,8 +672,11 @@ export const makeTownsBot = async (
     appPrivateDataBase64: string,
     jwtSecretBase64: string,
     env: Parameters<typeof makeRiverConfig>[0],
-    baseRpcUrl?: string,
+    opts: {
+        baseRpcUrl?: string
+    } & Partial<Omit<CreateTownsClientParams, 'env' | 'encryptionDevice'>> = {},
 ) => {
+    const { baseRpcUrl, ...clientOpts } = opts
     const { privateKey, encryptionDevice } = fromBinary(
         AppPrivateDataSchema,
         bin_fromBase64(appPrivateDataBase64),
@@ -691,6 +695,7 @@ export const makeTownsBot = async (
         encryptionDevice: {
             fromExportedDevice: encryptionDevice,
         },
+        ...clientOpts,
     }).then((x) => x.extend((townsClient) => buildBotActions(townsClient, viemClient)))
     return new Bot(client, viemClient, jwtSecretBase64)
 }

--- a/packages/sdk/src/client-v2.ts
+++ b/packages/sdk/src/client-v2.ts
@@ -88,9 +88,13 @@ export type Prettify<T> = {
     [K in keyof T]: T[K]
 } & {}
 
-type CreateTownsClientParams = {
+export type CreateTownsClientParams = {
     env: Parameters<typeof makeRiverConfig>[0]
     encryptionDevice?: EncryptionDeviceInitOpts
+    /** Toggle hash validation of Envelopes. Defaults to `false`. */
+    hashValidation?: boolean
+    /** Toggle signature validation of Envelopes. Defaults to `false`. */
+    signatureValidation?: boolean
 }
 export const createTownsClient = async (
     params: (
@@ -279,6 +283,7 @@ export const createTownsClient = async (
     crypto = new GroupEncryptionCrypto(buildGroupEncryptionClient(), cryptoStore)
     await crypto.init(params.encryptionDevice)
 
+    const { hashValidation = false, signatureValidation = false } = params
     const client = {
         crypto,
         keychain: cryptoStore,
@@ -286,8 +291,8 @@ export const createTownsClient = async (
         rpc,
         signer,
         userId,
-        disableHashValidation: false,
-        disableSignatureValidation: false,
+        disableHashValidation: !hashValidation,
+        disableSignatureValidation: !signatureValidation,
         getStream,
         unpackEnvelope,
         unpackEnvelopes,


### PR DESCRIPTION
This PR adds support for unpack envelope options in the Bot client.
 By default, the validation is turned off. 