### PR TITLE
refactor: distinguish stream reconciliation from client sync

### DIFF
--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -385,7 +385,7 @@ func (p *miniblockProducer) submitProposalBatch(ctx context.Context, proposals [
 	}
 
 	for _, job := range proposals {
-		if job.replicated || len(job.syncNodes) > 0 || job.candidate.Ref.Num%freq == 0 || job.candidate.Ref.Num == 1 {
+		if job.replicated || len(job.reconcileNodes) > 0 || job.candidate.Ref.Num%freq == 0 || job.candidate.Ref.Num == 1 {
 			filteredProposals = append(filteredProposals, job)
 		} else {
 			success = append(success, job.stream.streamId)
@@ -431,7 +431,7 @@ func (p *miniblockProducer) submitProposalBatch(ctx context.Context, proposals [
 		"mbFrequency", freq,
 	)
 
-	streamsOutOfSync := make([]*mbJob, 0, len(invalidProposals))
+	streamsNeedingReconciliation := make([]*mbJob, 0, len(invalidProposals))
 
 	for _, job := range proposals {
 		if slices.Contains(success, job.stream.streamId) && !job.skipPromotion {
@@ -449,13 +449,13 @@ func (p *miniblockProducer) submitProposalBatch(ctx context.Context, proposals [
 				p.jobDone(ctx, job)
 			}()
 		} else if slices.Contains(invalidProposals, job.stream.streamId) && !job.skipPromotion {
-			streamsOutOfSync = append(streamsOutOfSync, job)
+			streamsNeedingReconciliation = append(streamsNeedingReconciliation, job)
 		} else {
 			p.jobDone(ctx, job)
 		}
 	}
 
-	if err := p.promoteConfirmedCandidates(ctx, streamsOutOfSync); err != nil {
+	if err := p.promoteConfirmedCandidates(ctx, streamsNeedingReconciliation); err != nil {
 		log.Errorw("processMiniblockProposalBatch: Error promoting confirmed miniblock candidates", "error", err)
 	}
 }

--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -97,9 +97,9 @@ func (s *StreamCache) onStreamPlacementUpdated(
 		event.Stream.Stream.Nodes[0] == s.params.Wallet.Address {
 		go s.writeLatestMbToBlockchain(ctx, stream)
 	} else {
-		// Always submit a sync task, since this only happens on stream placement updates it happens
+		// Always submit a reconciliation task, since this only happens on stream placement updates it happens
 		// rarely. If local node was in quorum, it should be up-to-date making this a no-op task.
-		s.SubmitSyncStreamTask(stream, event.Stream)
+		s.SubmitReconcileStreamTask(stream, event.Stream)
 	}
 }
 

--- a/core/node/events/tracked_stream_view.go
+++ b/core/node/events/tracked_stream_view.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TrackedStreamView presents an interface that can be used to apply the returned
-// data structures of a stream synced from another node in order to render an up-to-date
+// data structures of a stream reconciled from another node in order to render an up-to-date
 // view of the stream locally.
 type TrackedStreamView interface {
 	// ApplyBlock applies the block to the internal view, updating the stream with the latest

--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -96,7 +96,7 @@ func (s *Service) ensureStreamIsUpToDate(
 
 		retryCount++
 		if retryCount == 5 { // schedules task after 100ms + 200ms + 400ms + 800ms = 1500ms
-			s.cache.SubmitSyncStreamTask(localStream, nil)
+			s.cache.SubmitReconcileStreamTask(localStream, nil)
 		}
 
 		if err := backoff.Wait(ctx, RiverError(Err_BAD_BLOCK_NUMBER, "Stream out-of-sync",

--- a/core/node/rpc/node2node.go
+++ b/core/node/rpc/node2node.go
@@ -168,7 +168,7 @@ func (s *Service) proposeMiniblock(
 	if err != nil {
 		// Err_MINIBLOCK_TOO_NEW indicates that the local node is behind the stream head.
 		if IsRiverErrorCode(err, Err_MINIBLOCK_TOO_NEW) {
-			s.cache.SubmitSyncStreamTask(stream, nil)
+			s.cache.SubmitReconcileStreamTask(stream, nil)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Renamed all occurrences of "sync" to "reconcile/reconciliation" when referring to node-to-node stream replication to clearly distinguish it from client synchronization (SyncCookie).

Changes:
- Renamed stream_sync_task.go to stream_reconcile_task.go
- Updated method names: SubmitSyncStreamTask → SubmitReconcileStreamTask
- Updated method names: GetQuorumAndSyncNodesAndIsLocal → GetQuorumAndReconcileNodesAndIsLocal
- Updated method names: GetSyncNodes → GetReconcileNodes
- Fixed typo: retryableReconcilationTasks → retryableReconciliationTasks
- Updated field/variable names: syncNodes → reconcileNodes
- Updated comments to use "reconcile" terminology for node-to-node replication

Client synchronization functionality (SyncCookie, SyncResultReceiver, etc.) remains unchanged.

