### PR TITLE
refactor(contract): remove redundant refund logic in `SwapFacet`

### DIFF
--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -122,9 +122,6 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
 
         address swapRouter = _validateSwapPrerequisites();
 
-        // take snapshot of balance before Permit2 transfer for refund calculation
-        uint256 tokenInBalanceBefore = params.tokenIn.balanceOf(address(this));
-
         // execute swap through the router with permit
         uint256 protocolFee;
         (amountOut, protocolFee) = ISwapRouter(swapRouter).executeSwapWithPermit(
@@ -138,9 +135,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         // no approval reset needed since Permit2 handles token transfers
         _afterSwap(params, amountOut, protocolFee, poster);
 
-        // handle refunds of unconsumed input tokens
-        // for Permit2, tokens are ERC20 only (no ETH support)
-        _handleRefunds(params.tokenIn, tokenInBalanceBefore);
+        // Note: SwapRouter already handles refunds to permit.owner, so no additional refund needed
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -111,6 +111,8 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
     }
 
     /// @inheritdoc ISwapFacet
+    /// @dev Permit is forwarded directly to SwapRouter which handles all token operations,
+    /// e.g. Permit2 transfers, approvals, refunds
     function executeSwapWithPermit(
         ExactInputParams calldata params,
         RouterParams calldata routerParams,
@@ -132,10 +134,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         );
 
         // post-swap processing (points minting and events)
-        // no approval reset needed since Permit2 handles token transfers
         _afterSwap(params, amountOut, protocolFee, poster);
-
-        // Note: SwapRouter already handles refunds to permit.owner, so no additional refund needed
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
### Description

Remove redundant refund logic in `SwapFacet.executeSwapWithPermit`.

### Changes

- Removed balance snapshot and refund handling from `SwapFacet.executeSwapWithPermit`.
- Added clarification that `SwapRouter` already manages refunds for unconsumed input tokens.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
