### PR TITLE
esbuild example for bots

### DIFF
--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -17,3 +17,41 @@ bot.onMentioned((client, { channelId }) =>
 const { fetch } = await bot.start();
 serve({ fetch });
 ```
+
+## Running Bots
+
+The `@towns-protocol/bot` package is compatible with the following approaches:
+
+- **Bun ESM** - Bun runtime with ES modules
+- **esbuild + Node CJS** - Bundled CommonJS for Node.js
+- **tsx ESM** - TypeScript execution with ES modules
+
+For working examples and configurations, see the [examples directory](../examples/).
+
+### tsx with ESM
+
+Install tsx, then run your bot with:
+
+```bash
+tsx src/index.ts
+```
+
+### Bundled with esbuild as CommonJS
+
+Install esbuild, then bundle your bot to a single CJS file and run with Node.js:
+
+You can take a look at the [bot-quickstart example](../examples/bot-quickstart/esbuild.config.mjs) for a working esbuild configuration.
+
+```bash
+# Build the bundle
+yarn build
+
+# Run with Node.js
+node dist/bot.cjs
+```
+
+### Bun with ESM
+
+```bash
+bun run src/index.ts
+```

--- a/packages/examples/bot-quickstart/esbuild.config.mjs
+++ b/packages/examples/bot-quickstart/esbuild.config.mjs
@@ -1,0 +1,45 @@
+import { build, context } from 'esbuild'
+import process from 'node:process'
+import console from 'node:console'
+
+const isWatch = process.argv.includes('--watch')
+
+const config = {
+    bundle: true,
+    entryPoints: {
+        'bot-quickstart': './src/index.ts',
+    },
+    format: 'cjs',
+    logLevel: 'info',
+    loader: {
+        '.ts': 'ts',
+        '.wasm': 'file',
+    },
+    external: ['@towns-protocol/olm'],
+    outdir: 'dist',
+    outExtension: { '.js': '.cjs' },
+    platform: 'node',
+    assetNames: '[name]',
+    sourcemap: true,
+    target: 'es2022',
+    minify: false,
+    treeShaking: true,
+}
+
+if (isWatch) {
+    const ctx = await context(config)
+    await ctx.watch()
+
+    console.log('Watching for changes...')
+
+    process.on('SIGINT', () => {
+        void ctx.dispose().then(() => {
+            process.exit(0)
+        })
+    })
+} else {
+    build(config).catch((e) => {
+        console.error(e)
+        process.exit(1)
+    })
+}

--- a/packages/examples/bot-quickstart/package.json
+++ b/packages/examples/bot-quickstart/package.json
@@ -4,11 +4,13 @@
     "private": true,
     "packageManager": "yarn@3.8.0",
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/bot-quickstart.cjs",
     "scripts": {
-        "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 tsx --watch --env-file=.env src/index.ts",
-        "build": "tsc",
-        "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 tsx src/index.ts",
+        "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=.env ./esbuild.config.mjs --watch",
+        "build": "yarn typecheck && yarn compile",
+        "compile": "node ./esbuild.config.mjs",
+        "typecheck": "tsc --noEmit",
+        "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=.env dist/bot-quickstart.cjs",
         "clean": "rm -rf dist",
         "lint": "yarn eslint --format unix ./src  --max-warnings=0",
         "lint:fix": "yarn lint --fix"
@@ -23,10 +25,10 @@
         "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
+        "esbuild": "^0.21.5",
         "eslint": "^8.57.1",
         "eslint-import-resolver-typescript": "^4.3.2",
         "eslint-plugin-import-x": "^4.10.2",
-        "tsx": "^4.7.1",
         "typescript": "^5.8.2"
     },
     "files": [

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -4,57 +4,100 @@ import { createServer } from 'node:http2'
 import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 
-const bot = await makeTownsBot(
-    process.env.APP_PRIVATE_DATA_BASE64!,
-    process.env.JWT_SECRET!,
-    process.env.RIVER_ENV,
-)
+async function main() {
+    const bot = await makeTownsBot(
+        process.env.APP_PRIVATE_DATA_BASE64!,
+        process.env.JWT_SECRET!,
+        process.env.RIVER_ENV,
+    )
 
-bot.onMessage(async (handler, { message, channelId, userId, eventId }) => {
-    if (userId === bot.botId) return
+    bot.onMessage(async (handler, { message, channelId, userId, eventId }) => {
+        if (userId === bot.botId) return
 
-    if (message.toLowerCase().includes('hello')) {
-        await handler.sendMessage(channelId, 'Hello there! 👋')
-    }
+        if (message.toLowerCase().includes('hello')) {
+            await handler.sendMessage(channelId, 'Hello there! 👋')
+        }
 
-    if (message.toLowerCase().includes('help')) {
-        await handler.sendMessage(
-            channelId,
-            'I can respond to:\n• "hello" - I\'ll greet you back\n• "ping" - I\'ll respond with pong\n• "time" - I\'ll tell you the current time',
-        )
-    }
+        if (message.toLowerCase().includes('help')) {
+            await handler.sendMessage(
+                channelId,
+                'I can respond to:\n• "hello" - I\'ll greet you back\n• "ping" - I\'ll respond with pong\n• "time" - I\'ll tell you the current time',
+            )
+        }
 
-    if (message.toLowerCase().includes('ping')) {
-        await handler.sendMessage(channelId, 'Pong! 🏓')
-    }
+        if (message.toLowerCase().includes('ping')) {
+            await handler.sendMessage(channelId, 'Pong! 🏓')
+        }
 
-    if (message.toLowerCase().includes('time')) {
-        const currentTime = new Date().toLocaleString()
-        await handler.sendMessage(channelId, `Current time: ${currentTime} ⏰`)
-    }
+        if (message.toLowerCase().includes('time')) {
+            const currentTime = new Date().toLocaleString()
+            await handler.sendMessage(channelId, `Current time: ${currentTime} ⏰`)
+        }
 
-    if (message.toLowerCase().includes('react')) {
-        await handler.sendReaction(channelId, eventId, '👍')
-    }
+        if (message.toLowerCase().includes('react')) {
+            await handler.sendReaction(channelId, eventId, '👍')
+        }
+    })
+
+    bot.onReaction(async (handler, { reaction, channelId, userId }) => {
+        if (userId === bot.botId) return
+
+        if (reaction === '👋') {
+            await handler.sendMessage(channelId, 'Thanks for the wave! 👋')
+        }
+    })
+
+    bot.onMessage(async (handler, { message, channelId, userId, eventId }) => {
+        if (userId === bot.botId) return
+
+        if (message.toLowerCase().includes('hello')) {
+            await handler.sendMessage(channelId, 'Hello there! 👋')
+        }
+
+        if (message.toLowerCase().includes('help')) {
+            await handler.sendMessage(
+                channelId,
+                'I can respond to:\n• "hello" - I\'ll greet you back\n• "ping" - I\'ll respond with pong\n• "time" - I\'ll tell you the current time',
+            )
+        }
+
+        if (message.toLowerCase().includes('ping')) {
+            await handler.sendMessage(channelId, 'Pong! 🏓')
+        }
+
+        if (message.toLowerCase().includes('time')) {
+            const currentTime = new Date().toLocaleString()
+            await handler.sendMessage(channelId, `Current time: ${currentTime} ⏰`)
+        }
+
+        if (message.toLowerCase().includes('react')) {
+            await handler.sendReaction(channelId, eventId, '👍')
+        }
+    })
+
+    bot.onReaction(async (handler, { reaction, channelId, userId }) => {
+        if (userId === bot.botId) return
+
+        if (reaction === '👋') {
+            await handler.sendMessage(channelId, 'Thanks for the wave! 👋')
+        }
+    })
+
+    const { jwtMiddleware, handler } = await bot.start()
+
+    const app = new Hono()
+    app.use(logger())
+    app.post('/webhook', jwtMiddleware, handler)
+
+    serve({
+        fetch: app.fetch,
+        port: parseInt(process.env.PORT!),
+        createServer,
+    })
+    console.log(`✅ Quickstart Bot is running on https://localhost:${process.env.PORT}`)
+}
+
+main().catch((error) => {
+    console.error('Failed to start bot:', error)
+    process.exit(1)
 })
-
-bot.onReaction(async (handler, { reaction, channelId, userId }) => {
-    if (userId === bot.botId) return
-
-    if (reaction === '👋') {
-        await handler.sendMessage(channelId, 'Thanks for the wave! 👋')
-    }
-})
-
-const { jwtMiddleware, handler } = await bot.start()
-
-const app = new Hono()
-app.use(logger())
-app.post('/webhook', jwtMiddleware, handler)
-
-serve({
-    fetch: app.fetch,
-    port: parseInt(process.env.PORT!),
-    createServer,
-})
-console.log(`✅ Quickstart Bot is running on https://localhost:${process.env.PORT}`)

--- a/packages/examples/bot-quickstart/tsconfig.json
+++ b/packages/examples/bot-quickstart/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "esbuild.config.mjs"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8816,11 +8816,11 @@ __metadata:
     "@types/node": ^20.14.8
     "@typescript-eslint/eslint-plugin": ^8.29.0
     "@typescript-eslint/parser": ^8.29.0
+    esbuild: ^0.21.5
     eslint: ^8.57.1
     eslint-import-resolver-typescript: ^4.3.2
     eslint-plugin-import-x: ^4.10.2
     hono: ^4.7.11
-    tsx: ^4.7.1
     typescript: ^5.8.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR introduces an example esbuild configuration for running bots.

## Why its needed?

I tried running bots with `tsc + node`, but had the following issues:

1. our repo isn't using tsconfig `NodeNext`. 

This means that our import extensions aren't compatible with what Node ESM expects.

```diff
- import foo from './blah'
+ import foo from './blah.js' // even if blah is blah.ts
```

To solve this, we could either:
- add `.js` everywhere in our imports
- bundle packages

2. some of our deps aren't ESM compatible

We've been working on this. 

Below you can check the packages that aren't compatible with ESM.

https://pkg-size.dev/@towns-protocol%2Fsdk

`debug` package and `ethers@5` doesn't support ESM.

We need to move away from them if we want to support `tsc + node`

Moving away can be very time consuming. It's probably not worth going to `ethers@6`, and moving to `viem` require a good rewrite of the `web3` and `generated` package flow.

## Alternatives

### bun

After #3514, you will be able to use `bun` to run bots. No config needed. 

### tsx

Uses node under the hood, but solves the pain of module resolution + runs TS out of the box.