### PR TITLE
BaseContractShim: add retries to read contract

### DIFF
--- a/packages/web3/src/BaseContractShim.ts
+++ b/packages/web3/src/BaseContractShim.ts
@@ -4,6 +4,7 @@ import { Connect, ContractType } from './types/typechain'
 import { Abi } from 'abitype'
 import { TransactionOpts } from './types/ContractTypes'
 import { wrapTransaction } from './space-dapp/wrapTransaction'
+import { readRetryWrapper } from './readContractRetryer'
 export type PromiseOrValue<T> = T | Promise<T>
 
 export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
@@ -54,7 +55,7 @@ export class BaseContractShim<
             this.readContract = this.connect(this.address, this.provider)
             this.contractInterface = this.readContract.interface
         }
-        return this.readContract
+        return readRetryWrapper(this.readContract)
     }
 
     public write(signer: ethers.Signer): T_CONTRACT {

--- a/packages/web3/src/readContractRetryer.ts
+++ b/packages/web3/src/readContractRetryer.ts
@@ -1,0 +1,149 @@
+import { ethers } from 'ethers'
+import { Connect, ContractType } from './types/typechain'
+import { dlogger } from '@towns-protocol/dlog'
+const logger = dlogger('csb:readContractRetryer')
+
+type RetryOptions = {
+    maxAttempts?: number
+    initialRetryDelay?: number
+    maxRetryDelay?: number
+}
+
+const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+    maxAttempts: 4,
+    initialRetryDelay: 1000,
+    maxRetryDelay: 8000,
+}
+
+async function withRetry<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+    const opts = { ...DEFAULT_RETRY_OPTIONS, ...options }
+    let attempt = 0
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        attempt++
+
+        try {
+            return await operation()
+        } catch (error) {
+            if (attempt >= opts.maxAttempts) {
+                logger.error(`Read contract call failed after ${attempt} attempts:`, error)
+                throw error
+            }
+
+            const retryDelay = Math.min(
+                opts.maxRetryDelay,
+                opts.initialRetryDelay * Math.pow(2, attempt - 1),
+            )
+
+            logger.log(
+                `Read contract call failed (attempt ${attempt}/${opts.maxAttempts}), retrying in ${retryDelay}ms:`,
+                error,
+            )
+            await new Promise((resolve) => setTimeout(resolve, retryDelay))
+        }
+    }
+}
+
+export function readRetryWrapper<T_CONTRACT extends ContractType<Connect<ethers.Contract>>>(
+    contract: T_CONTRACT,
+    retryOptions: RetryOptions = {},
+): T_CONTRACT {
+    const wrapper = Object.create(Object.getPrototypeOf(contract) as object) as T_CONTRACT
+
+    // ethers/typechain contracts have a set of functions.
+    // these functions are defined on the class itself, i.e. contract[myFunction]
+    // as well as in these properties, i.e. contract.callStatic.myFunction
+    // so, we're gonna replace all these with retry wrapper
+    const contractMethodProperties = [
+        'functions',
+        'callStatic',
+        'estimateGas',
+        'populateTransaction',
+    ] as const
+
+    // add them to the wrapper only if they exist on the original contract
+    for (const key of contractMethodProperties) {
+        if (contract[key] && typeof contract[key] === 'object') {
+            Object.defineProperty(wrapper, key, {
+                value: {},
+            })
+        }
+    }
+
+    const functionNames = Object.keys(contract.functions)
+
+    // copy all non-contract-method properties
+    // ethers defines these all as readonly, i don't think it's important that we do that - these are read only methods that we care about
+    for (const key of Object.getOwnPropertyNames(contract)) {
+        const descriptor = Object.getOwnPropertyDescriptor(contract, key)
+        if (
+            descriptor &&
+            typeof contract[key] !== 'function' &&
+            !contractMethodProperties.includes(key as (typeof contractMethodProperties)[number]) &&
+            !Object.prototype.hasOwnProperty.call(wrapper, key)
+        ) {
+            try {
+                Object.defineProperty(wrapper, key, descriptor)
+            } catch {
+                // skip properties that can't be defined (some may be non-configurable)
+            }
+        }
+    }
+
+    // the functions on the class
+    for (const funcName of functionNames) {
+        const ogFunction = contract[funcName]
+        if (typeof ogFunction === 'function') {
+            ;(wrapper as Record<string, unknown>)[funcName] = function (...args: unknown[]) {
+                return withRetry(
+                    () =>
+                        (ogFunction as (...args: unknown[]) => Promise<unknown>).apply(
+                            contract,
+                            args,
+                        ),
+                    retryOptions,
+                )
+            }
+        }
+    }
+
+    // the functions nested on the contract properties
+    for (const prop of contractMethodProperties) {
+        // check if the property exists on the contract before accessing its methods
+        if (contract[prop] && typeof contract[prop] === 'object') {
+            for (const funcName of functionNames) {
+                const ogFunction = contract[prop][funcName]
+                if (typeof ogFunction === 'function') {
+                    wrapper[prop][funcName] = function (...args: unknown[]) {
+                        return withRetry(
+                            () =>
+                                (ogFunction as (...args: unknown[]) => Promise<unknown>).apply(
+                                    contract[prop],
+                                    args,
+                                ),
+                            retryOptions,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // copy other methods that might exist
+    if (contract.deployed && typeof contract.deployed === 'function') {
+        wrapper.deployed = function () {
+            return withRetry(() => contract.deployed(), retryOptions)
+        }
+    }
+
+    if (contract.attach && typeof contract.attach === 'function') {
+        wrapper.attach = contract.attach.bind(contract)
+    }
+
+    if (contract.connect && typeof contract.connect === 'function') {
+        wrapper.connect = contract.connect.bind(contract)
+    }
+
+    return wrapper
+}

--- a/packages/web3/src/readContractRetryer.ts
+++ b/packages/web3/src/readContractRetryer.ts
@@ -15,41 +15,12 @@ const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
     maxRetryDelay: 8000,
 }
 
-async function withRetry<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-    const opts = { ...DEFAULT_RETRY_OPTIONS, ...options }
-    let attempt = 0
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-        attempt++
-
-        try {
-            return await operation()
-        } catch (error) {
-            if (attempt >= opts.maxAttempts) {
-                logger.error(`Read contract call failed after ${attempt} attempts:`, error)
-                throw error
-            }
-
-            const retryDelay = Math.min(
-                opts.maxRetryDelay,
-                opts.initialRetryDelay * Math.pow(2, attempt - 1),
-            )
-
-            logger.log(
-                `Read contract call failed (attempt ${attempt}/${opts.maxAttempts}), retrying in ${retryDelay}ms:`,
-                error,
-            )
-            await new Promise((resolve) => setTimeout(resolve, retryDelay))
-        }
-    }
-}
-
 export function readRetryWrapper<T_CONTRACT extends ContractType<Connect<ethers.Contract>>>(
     contract: T_CONTRACT,
     retryOptions: RetryOptions = {},
 ): T_CONTRACT {
-    const wrapper = Object.create(Object.getPrototypeOf(contract) as object) as T_CONTRACT
+    const opts = { ...DEFAULT_RETRY_OPTIONS, ...retryOptions }
+    const wrapper = Object.create(contract) as T_CONTRACT
 
     // ethers/typechain contracts have a set of functions.
     // these functions are defined on the class itself, i.e. contract[myFunction]
@@ -62,87 +33,69 @@ export function readRetryWrapper<T_CONTRACT extends ContractType<Connect<ethers.
         'populateTransaction',
     ] as const
 
-    // add them to the wrapper only if they exist on the original contract
-    for (const key of contractMethodProperties) {
-        if (contract[key] && typeof contract[key] === 'object') {
-            Object.defineProperty(wrapper, key, {
-                value: {},
-            })
-        }
-    }
-
     const functionNames = Object.keys(contract.functions)
 
-    // copy all non-contract-method properties
-    // ethers defines these all as readonly, i don't think it's important that we do that - these are read only methods that we care about
-    for (const key of Object.getOwnPropertyNames(contract)) {
-        const descriptor = Object.getOwnPropertyDescriptor(contract, key)
-        if (
-            descriptor &&
-            typeof contract[key] !== 'function' &&
-            !contractMethodProperties.includes(key as (typeof contractMethodProperties)[number]) &&
-            !Object.prototype.hasOwnProperty.call(wrapper, key)
-        ) {
-            try {
-                Object.defineProperty(wrapper, key, descriptor)
-            } catch {
-                // skip properties that can't be defined (some may be non-configurable)
+    const objectsWithContractMethods = ['root', ...contractMethodProperties]
+
+    for (const target of objectsWithContractMethods) {
+        const isRoot = target === 'root'
+        const source = isRoot ? wrapper : (wrapper[target] as Record<string, unknown>)
+        const destination = isRoot ? wrapper : Object.create((wrapper[target] as object) || {})
+
+        for (const funcName of functionNames) {
+            const ogFunction = source?.[funcName] as unknown
+            if (typeof ogFunction === 'function') {
+                Object.defineProperty(destination, funcName, {
+                    value: function (this: T_CONTRACT, ...args: unknown[]) {
+                        return (async () => {
+                            let attempt = 0
+
+                            // eslint-disable-next-line no-constant-condition
+                            while (true) {
+                                attempt++
+
+                                try {
+                                    const result = (
+                                        ogFunction as (...args: unknown[]) => unknown
+                                    ).apply(this, args)
+
+                                    return await result
+                                } catch (error) {
+                                    if (attempt >= opts.maxAttempts) {
+                                        logger.error(
+                                            `Read contract call failed after ${attempt} attempts:`,
+                                            error,
+                                        )
+                                        throw error
+                                    }
+
+                                    const retryDelay = Math.min(
+                                        opts.maxRetryDelay,
+                                        opts.initialRetryDelay * Math.pow(2, attempt - 1),
+                                    )
+
+                                    logger.log(
+                                        `Read contract call failed for ${funcName} (attempt ${attempt}/${opts.maxAttempts}), retrying in ${retryDelay}ms:`,
+                                        error,
+                                    )
+                                    await new Promise((resolve) => setTimeout(resolve, retryDelay))
+                                }
+                            }
+                        })()
+                    },
+                    configurable: true,
+                    writable: true,
+                })
             }
         }
-    }
 
-    // the functions on the class
-    for (const funcName of functionNames) {
-        const ogFunction = contract[funcName]
-        if (typeof ogFunction === 'function') {
-            ;(wrapper as Record<string, unknown>)[funcName] = function (...args: unknown[]) {
-                return withRetry(
-                    () =>
-                        (ogFunction as (...args: unknown[]) => Promise<unknown>).apply(
-                            contract,
-                            args,
-                        ),
-                    retryOptions,
-                )
-            }
+        if (!isRoot) {
+            Object.defineProperty(wrapper, target, {
+                value: destination,
+                configurable: true,
+                writable: true,
+            })
         }
-    }
-
-    // the functions nested on the contract properties
-    for (const prop of contractMethodProperties) {
-        // check if the property exists on the contract before accessing its methods
-        if (contract[prop] && typeof contract[prop] === 'object') {
-            for (const funcName of functionNames) {
-                const ogFunction = contract[prop][funcName]
-                if (typeof ogFunction === 'function') {
-                    wrapper[prop][funcName] = function (...args: unknown[]) {
-                        return withRetry(
-                            () =>
-                                (ogFunction as (...args: unknown[]) => Promise<unknown>).apply(
-                                    contract[prop],
-                                    args,
-                                ),
-                            retryOptions,
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    // copy other methods that might exist
-    if (contract.deployed && typeof contract.deployed === 'function') {
-        wrapper.deployed = function () {
-            return withRetry(() => contract.deployed(), retryOptions)
-        }
-    }
-
-    if (contract.attach && typeof contract.attach === 'function') {
-        wrapper.attach = contract.attach.bind(contract)
-    }
-
-    if (contract.connect && typeof contract.connect === 'function') {
-        wrapper.connect = contract.connect.bind(contract)
     }
 
     return wrapper

--- a/packages/web3/tests/BaseContractShim.test.ts
+++ b/packages/web3/tests/BaseContractShim.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @group main
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { MockERC721AShim } from '../src/test-helpers/MockERC721AShim'
+import { ethers } from 'ethers'
+
+describe('BaseContractShim read method with retry logic', () => {
+    const mockAddress = '0x1234567890123456789012345678901234567890'
+
+    const createTestSetup = () => {
+        const provider = new ethers.providers.JsonRpcProvider(process.env.BASE_CHAIN_RPC_URL)
+        const mockShim = new MockERC721AShim(mockAddress, provider)
+        return { provider, mockShim }
+    }
+
+    describe.concurrent('retry functionality', () => {
+        it('should succeed on first try when contract call works', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            // Mock the provider to return a successful response
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.balanceOf(mockAddress)
+
+            expect(result.toString()).toBe('1')
+            expect(spy).toHaveBeenCalledTimes(1)
+        })
+
+        it('should retry on network failure and eventually succeed', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            // Mock provider to fail twice, then succeed
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValueOnce(new Error('Network error'))
+                .mockRejectedValueOnce(new Error('Timeout'))
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000005',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.balanceOf(mockAddress)
+
+            expect(result.toString()).toBe('5')
+            expect(spy).toHaveBeenCalledTimes(3)
+        })
+
+        it('should fail after max retry attempts', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            // Mock provider to always fail
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValue(new Error('Persistent network error'))
+
+            const contract = mockShim.read
+
+            await expect(contract.balanceOf(mockAddress)).rejects.toThrow(
+                'Persistent network error',
+            )
+            expect(spy).toHaveBeenCalledTimes(4) // Initial + 3 retries
+        })
+
+        it('should work with different contract methods', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            // Test with tokenURI method
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValueOnce(new Error('RPC error'))
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001068747470733a2f2f746573742e636f6d00000000000000000000000000000000',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.tokenURI(1)
+
+            expect(typeof result).toBe('string')
+            expect(spy).toHaveBeenCalledTimes(2)
+        })
+
+        it('should work with callStatic methods', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValueOnce(new Error('Static call error'))
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.callStatic.balanceOf(mockAddress)
+
+            expect(result.toString()).toBe('1')
+            expect(spy).toHaveBeenCalledTimes(2)
+        })
+
+        it('should handle different error types', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValueOnce({ code: 'NETWORK_ERROR', message: 'Network unreachable' })
+                .mockRejectedValueOnce({ code: 'TIMEOUT', message: 'Request timeout' })
+                .mockRejectedValueOnce(new Error('Generic error'))
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000003',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.balanceOf(mockAddress)
+
+            expect(result.toString()).toBe('3')
+            expect(spy).toHaveBeenCalledTimes(4)
+        })
+
+        it('should retry with delays (simplified timing test)', async () => {
+            const { provider, mockShim } = createTestSetup()
+
+            // Test that retries happen with delays without getting into complex timer mocking
+            const start = Date.now()
+            const spy = vi
+                .spyOn(provider, 'call')
+                .mockRejectedValueOnce(new Error('Error 1'))
+                .mockRejectedValueOnce(new Error('Error 2'))
+                .mockResolvedValueOnce(
+                    '0x0000000000000000000000000000000000000000000000000000000000000002',
+                )
+
+            const contract = mockShim.read
+            const result = await contract.balanceOf(mockAddress)
+            const elapsed = Date.now() - start
+
+            expect(result.toString()).toBe('2')
+            expect(spy).toHaveBeenCalledTimes(3)
+            // Should take at least 1000ms for the first retry delay, but allow for test timing variance
+            expect(elapsed).toBeGreaterThan(500) // Be lenient for CI/test environments
+        })
+    })
+})


### PR DESCRIPTION
### Description

The `BaseContractShim` provides a `read` contract which is used for reading data. This PR updates the read contract methods to bake in retries.

I only applied the retries to shims configured for Base networks - tests failed with shims configured on River - there were timeouts b/c getStreams retried instead of failing immediately, and I'm not sure if that would have real world consequence. So for now let's just retry Base reads, which is where we're getting failures in prod anyway.

This contract is not used for writes, as there is a separate `write` contract.

### Checklist

- [x] Tests added where required

