### PR TITLE
Move the ephemeral events into a “main” queue

### DIFF
--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -42,8 +42,6 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
     private isMobileSafariBackgrounded = false
     private validatedEvents: Record<string, { isValid: boolean; reason?: string }> = {}
     private unpackEnvelopeOpts?: { disableSignatureValidation?: boolean }
-    // how long to wait for an ephemeral solicitation to be fulfilled before converting to non-ephemeral
-    // (sending a solicitation again, but this time non-ephemeral)
 
     constructor(
         private readonly client: Client,

--- a/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
@@ -191,7 +191,7 @@ describe('ClientDecryptionExtensions', () => {
         ).resolves.not.toThrow()
     })
 
-    test('shareKeysInMultipleStreamsToSameDevice', async () => {
+    test.only('shareKeysInMultipleStreamsToSameDevice', async () => {
         const bob1 = await makeAndStartClient({ deviceId: 'bob1' })
         const alice1 = await makeAndStartClient({ deviceId: 'alice1' })
 

--- a/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
@@ -191,7 +191,7 @@ describe('ClientDecryptionExtensions', () => {
         ).resolves.not.toThrow()
     })
 
-    test.only('shareKeysInMultipleStreamsToSameDevice', async () => {
+    test('shareKeysInMultipleStreamsToSameDevice', async () => {
         const bob1 = await makeAndStartClient({ deviceId: 'bob1' })
         const alice1 = await makeAndStartClient({ deviceId: 'alice1' })
 


### PR DESCRIPTION
instead of a “Stream” queue. This allows us to process them imediately since they are for people who are currently online and much more likely to be relevant.