### PR TITLE
docs: Fix reference from River to Towns in introduction.mdx

### DIFF
--- a/packages/docs/run/introduction.mdx
+++ b/packages/docs/run/introduction.mdx
@@ -7,7 +7,7 @@ description: "The Towns Protocol is powered by a network of Stream Nodes that ar
 
 [Towns Stream Nodes](https://github.com/towns-protocol/towns/tree/main/core/node) are software components that are able to be run by anyone. Towns Protocol's incentive structure supports Towns Stream Node operators as a first-class actor in the network. Operators, once registered and approved by the DAO , can run a Stream Node on Towns Chain and participate in block validation as well as reward distribution.
 
-Given the open-source nature of River, the Foundation also encourages developers who would like to run instances of Towns Chain on a network of their choice connected to self-hosted Towns Stream Nodes. Though these nodes would not technically be connected to the Towns protocol node network that is deployed on [Base Mainnet](https://basescan.org/), developers may find value in experimenting with different rollup implementation features.
+Given the open-source nature of Towns, the Foundation also encourages developers who would like to run instances of Towns Chain on a network of their choice connected to self-hosted Towns Stream Nodes. Though these nodes would not technically be connected to the Towns protocol node network that is deployed on [Base Mainnet](https://basescan.org/), developers may find value in experimenting with different rollup implementation features.
 
 ### Operator Onboarding Lifecycle
 


### PR DESCRIPTION
Description
Fixed an incorrect reference in the documentation where "River" was used instead of "Towns" in the introduction page. 