### PR TITLE
refactor: use transient storage for execution tracking

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -15,7 +15,7 @@ src = "src" # The path to the contract sources relative to the root of the proje
 test = "test" # The path to the test contract sources relative to the root of the project.
 extra_output = ["abi", "bin"]
 extra_output_files = ["abi", "bin"]
-ignored_error_codes = [2394]
+
 
 
 # Test settings

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -15,6 +15,8 @@ src = "src" # The path to the contract sources relative to the root of the proje
 test = "test" # The path to the test contract sources relative to the root of the project.
 extra_output = ["abi", "bin"]
 extra_output_files = ["abi", "bin"]
+ignored_error_codes = [2394]
+
 
 # Test settings
 fuzz = { runs = 256 } # The amount of fuzz runs to perform for each fuzz test case.

--- a/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorBase.sol
@@ -427,7 +427,7 @@ abstract contract ExecutorBase is IExecutorBase {
     function _isTargetExecuting(address target) internal view returns (bool) {
         bytes32 globalId = ExecutorStorage.getTransientExecutionId();
         bytes32 targetId = ExecutorStorage.getTargetExecutionId(target);
-        return globalId != 0 && targetId != 0 && targetId == globalId;
+        return globalId != 0 && targetId == globalId;
     }
 
     /// @notice Computes a unique hash for an operation.

--- a/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
@@ -18,6 +18,10 @@ library ExecutorStorage {
     bytes32 internal constant STORAGE_SLOT =
         0xb7e2813a9de15ce5ee4c1718778708cd70fd7ee3d196d203c0f40369a8d4a600;
 
+    // keccak256(abi.encode(uint256(keccak256("spaces.facets.executor.transient.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant TRANSIENT_STORAGE_SLOT =
+        0x50b382cc42d5e85c7df990b4496d41f5c12a6bb29194f1db29e58a2d7a053600;
+
     struct Layout {
         // Execution ID
         bytes32 executionId;
@@ -34,6 +38,37 @@ library ExecutorStorage {
     function getLayout() internal pure returns (Layout storage l) {
         assembly {
             l.slot := STORAGE_SLOT
+        }
+    }
+
+    function getTransientExecutionId() internal view returns (bytes32 id) {
+        assembly {
+            id := tload(TRANSIENT_STORAGE_SLOT)
+        }
+    }
+
+    function setTransientExecutionId(bytes32 id) internal {
+        assembly {
+            tstore(TRANSIENT_STORAGE_SLOT, id)
+        }
+    }
+
+    function getTargetExecutionId(address target) internal view returns (bytes32 id) {
+        assembly {
+            id := tload(target)
+        }
+    }
+
+    function setTargetExecutionId(address target, bytes32 id) internal {
+        assembly {
+            tstore(target, id)
+        }
+    }
+
+    function clearTransientStorage(address target) internal {
+        assembly {
+            tstore(TRANSIENT_STORAGE_SLOT, 0)
+            tstore(target, 0)
         }
     }
 }


### PR DESCRIPTION
### Description

Refactored the executor's execution context tracking to use transient storage instead of persistent storage. This change improves gas efficiency and prevents potential composability issues by ensuring execution context data is properly cleared after each operation.

### Changes

- Replaced persistent storage for execution IDs with transient storage using `tstore` and `tload` EVM opcodes
- Added new transient storage functions in `ExecutorStorage.sol` to manage execution context
- Updated `_executeOperation` to use transient storage for tracking execution context
- Simplified `_isTargetExecuting` and `_isExecuting` functions to use the new transient storage
- Added `ignored_error_codes = [2394]` to foundry.toml to suppress warnings related to transient storage usage

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines