### PR TITLE
refactor: extract membership points minting to reusable function for  joins and renewals

### DIFF
--- a/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
+++ b/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
@@ -383,15 +383,7 @@ abstract contract MembershipJoin is
         _releaseCapturedValue(transactionId, paymentRequired);
         _captureData(transactionId, "");
 
-        // calculate points and credit them
-        address airdropDiamond = _getAirdropDiamond();
-        uint256 points = _getPoints(
-            airdropDiamond,
-            ITownsPointsBase.Action.JoinSpace,
-            abi.encode(membershipPrice)
-        );
-        _mintPoints(airdropDiamond, receiver, points);
-        _mintPoints(airdropDiamond, _owner(), points);
+        _mintMembershipPoints(receiver, membershipPrice);
     }
 
     /// @notice Issues a membership token to the receiver
@@ -521,6 +513,8 @@ abstract contract MembershipJoin is
             Membership__InvalidPayment.selector.revertWith();
         }
 
+        _mintMembershipPoints(receiver, membershipPrice);
+
         uint256 protocolFee = _collectProtocolFee(payer, membershipPrice);
 
         uint256 remainingDue = membershipPrice - protocolFee;
@@ -537,5 +531,21 @@ abstract contract MembershipJoin is
         }
 
         _renewSubscription(tokenId, uint64(duration));
+    }
+
+    /// @notice Mints points to a member based on their paid amount
+    /// @dev This function handles point minting for both new joins and renewals
+    /// @param receiver The address receiving the points
+    /// @param paidAmount The amount paid for membership
+    function _mintMembershipPoints(address receiver, uint256 paidAmount) internal {
+        // calculate points and credit them
+        address airdropDiamond = _getAirdropDiamond();
+        uint256 points = _getPoints(
+            airdropDiamond,
+            ITownsPointsBase.Action.JoinSpace,
+            abi.encode(paidAmount)
+        );
+        _mintPoints(airdropDiamond, receiver, points);
+        _mintPoints(airdropDiamond, _owner(), points);
     }
 }


### PR DESCRIPTION
### Description

This PR adds point minting functionality for membership renewals and refactors the existing point minting logic into a reusable internal function to ensure consistent behavior across both new memberships and renewals.

### Changes

- Extracted point minting logic into a new internal function `_mintMembershipPoints` to avoid code duplication
- Added point minting for membership renewals in the renewal flow
- Added tests to verify points are correctly minted during membership renewals
- Updated existing tests to check point balances after renewal operations

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines