### PR TITLE
feat: simplify AppRegistry schema and add Base deployment address

### DIFF
--- a/packages/contracts/deployments/omega/base/addresses/appRegistry.json
+++ b/packages/contracts/deployments/omega/base/addresses/appRegistry.json
@@ -1,0 +1,3 @@
+{
+  "address": "0xB3173F2a02855F07A0C4BfB26D3D87c323fe42BE"
+}

--- a/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
@@ -31,8 +31,7 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
 
     DeployFacet private facetHelper = new DeployFacet();
 
-    string internal constant APP_REGISTRY_SCHEMA =
-        "address app, address owner, address client, bytes32[] permissions, ExecutionManifest manifest, uint48 duration";
+    string internal constant APP_REGISTRY_SCHEMA = "address app, address client";
 
     function versionName() public pure override returns (string memory) {
         return "appRegistry";

--- a/packages/contracts/test/attest/AppRegistry.t.sol
+++ b/packages/contracts/test/attest/AppRegistry.t.sol
@@ -72,10 +72,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
 
     function test_getAppSchema() external view {
         string memory schema = registry.getAppSchema();
-        assertEq(
-            schema,
-            "address app, address owner, address client, bytes32[] permissions, ExecutionManifest manifest, uint48 duration"
-        );
+        assertEq(schema, "address app, address client");
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
### Description

Simplified the AppRegistry schema by removing unnecessary fields, keeping only the essential app and client address fields. Also added the AppRegistry address for the Base network deployment.

### Changes

- Simplified the `APP_REGISTRY_SCHEMA` constant in `DeployAppRegistry.s.sol` to only include "address app, address client"
- Updated the corresponding test in `AppRegistry.t.sol` to match the new schema
- Added AppRegistry contract address for Base network in a new JSON file

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines