### PR TITLE
Docs/pricing modules protocol fees

### DIFF
--- a/packages/docs/towns-smart-contracts/pricing-modules.mdx
+++ b/packages/docs/towns-smart-contracts/pricing-modules.mdx
@@ -31,6 +31,35 @@ Every newly deployed Space in the Towns ecosystem is equipped with two default p
    - **Minimum Price**: Sets a minimum price of $10 USD for a membership.
    - **Payment Method**: Also accepts ETH as payment.
 
+### Protocol Fee Structure
+
+When users purchase memberships, the Towns protocol collects a fee from the membership payment to support ecosystem infrastructure and development.
+
+#### Current Fee Configuration
+- **Protocol Fee Rate**: 10% of membership payment
+- **Minimum Protocol Fee**: 0.0005 ETH
+- **Price Threshold**: 0.001 ETH
+- **Free Membership Allocation**: 1,000 memberships per Space
+
+#### Fee Collection Logic
+
+The protocol fee is deducted from the membership payment using a two-tier system:
+
+1. **Below Threshold**: If membership price < 0.001 ETH → Protocol takes 0.0005 ETH
+2. **Above Threshold**: If membership price ≥ 0.001 ETH → Protocol takes 10% of the payment
+
+#### Revenue Distribution Examples
+
+| Membership Price | Protocol Fee | Space Owner Receives |
+|------------------|--------------|---------------------|
+| 0 ETH (Free) | 0 ETH | 0 ETH |
+| 0.0005 ETH | 0.0005 ETH | 0 ETH |
+| 0.001 ETH | 0.0001 ETH (10%) | 0.0009 ETH |
+| 0.01 ETH | 0.001 ETH (10%) | 0.009 ETH |
+| 0.1 ETH | 0.01 ETH (10%) | 0.09 ETH |
+
+**Note**: The protocol fee is automatically deducted from membership payments. Space owners receive the remainder after the protocol fee is collected.
+
 ### Transaction Fee Distribution
 
 An essential aspect of the pricing modules is the distribution of fees from transactions. These fees are split among key stakeholders:

--- a/packages/docs/towns-smart-contracts/space-ownership.mdx
+++ b/packages/docs/towns-smart-contracts/space-ownership.mdx
@@ -14,7 +14,7 @@ Space Ownership in Towns is designed with a unique approach emphasizing direct a
 
 ### Financial Management
 
-- **Funds Management**: The process of Membership minting channels all funds directly to a contract. This contract is wholly controlled by the ownership NFT. Access to these funds is granted through ERC6551, providing the NFT holder with exclusive financial control.
+- **Funds Management**: The process of Membership minting channels all funds directly to a contract. This contract is wholly controlled by the ownership NFT. Access to these funds is granted through direct ERC-721 ownership validation, providing the NFT holder with exclusive financial control.
 
 ### Transfer and Security
 

--- a/packages/docs/towns-token/staking.mdx
+++ b/packages/docs/towns-token/staking.mdx
@@ -4,7 +4,7 @@ title: Staking
 
 ### Staking Process
 
-The Towns token can be staked on Base to contribute to the security and decentralization of the Towns proof-of-stake network. Any holder of Towns tokens can participate by delegating their tokens to node operators within the ecosystem. Staking can be done directly on the contracts or via an interface at [towns.com/staking](https://towns.com/staking).
+The Towns token can be staked on Base to contribute to the security and decentralization of the Towns proof-of-stake network. Any holder of Towns tokens can participate by delegating their tokens to node operators within the ecosystem. Staking can be done directly on the contracts or via an interface at [towns.com/token](https://towns.com/token).
 
 Rewards for staking are continuously accrued and distributed on a biweekly schedule. Each operator receives rewards proportionally based on the total tokens staked to their node. Operators retain a defined commission, after which the remaining rewards are passed to delegators. Delegators then receive their portion of rewards proportional to the number of tokens they have staked with that operator.
 
@@ -13,9 +13,9 @@ Delegators rewards can be claimed at any time. Upon initiating an unstaking requ
 
 ### Staking Contracts
 
-Staking is handled by the v2 version of the [RewardsDistribution](https://github.com/towns-protocol/towns/blob/main/packages/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol) contract.
+Staking is handled by the v2 version of the [RewardsDistribution](https://github.com/towns-protocol/towns/blob/main/packages/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol) contract.
 
-External methods from RewardsDistribution can be called from the BaseRegistry diamond contract directly using any ethereum compatible client such as [cast](https://book.getfoundry.sh/cast/).
+External methods from RewardsDistribution can be called from the BaseRegistry diamond contract directly using any ethereum compatible client such as [cast](https://getfoundry.sh/cast/overview/).
 
 The BaseRegistry diamond is deployed on Base (see [contracts](../run/contracts)).
 
@@ -23,9 +23,11 @@ The BaseRegistry diamond is deployed on Base (see [contracts](../run/contracts))
 
 <Warning>Though we illustrate programmatic instructions below, interacting with the staking contract is best performed through the staking site available in [www.towns.com/staking](https://www.towns.com/staking).</Warning>
 
-To stake, the user must call the `stake(uint96 amount, address delegatee, address beneficiary)(uint256 depositIds)` method  of the RewardsDistribution facet from the BaseRegistry diamond contract.
+#### Basic Staking
 
-Users must select a delegatee, for instance an active operator (active operators are listed on [www.towns.com/staking](https://www.towns.com/staking)), to delegate to in order to earn periodic rewards.
+To stake, the user must call the `stake(uint96 amount, address delegatee, address beneficiary)(uint256 depositIds)` method of the RewardsDistribution facet from the BaseRegistry diamond contract.
+
+Users must select a delegatee, for instance an active operator (active operators are listed on [www.towns.com/token](https://www.towns.com/token)), to delegate to in order to earn periodic rewards.
 
 Users must also select a beneficiary, which is the address that will receive the rewards.
 
@@ -35,10 +37,37 @@ To increase the amount of stake, the deposit owner can call `increaseStake(uint2
 
 <Note>Users can switch their delegatee at any time without withdrawing their stake by calling `redelegate(uint256 depositId, address delegatee)`.</Note>
 
+#### Advanced Staking Methods
+
+**Gasless Staking with Permits**
+For users who want to stake without paying gas for token approvals:
+- `permitAndStake(uint96 amount, address delegatee, address beneficiary, uint256 nonce, uint256 deadline, bytes signature)`
+- `permitAndIncreaseStake(uint256 depositId, uint96 amount, uint256 nonce, uint256 deadline, bytes signature)`
+
+**Staking on Behalf of Others**
+Authorized users can stake on behalf of others using:
+- `stakeOnBehalf(uint96 amount, address delegatee, address beneficiary, address owner, uint256 nonce, bytes signature)`
+
+**Managing Your Stakes**
+- `changeBeneficiary(uint256 depositId, address newBeneficiary)` - Change who receives the rewards from a specific deposit
+
+#### Claiming Rewards
+
+Rewards can be claimed at any time using the `claimReward(address beneficiary, address recipient)` method:
+
+**For Regular Stakers:**
+- Call with `beneficiary = your_address` to claim your own staking rewards
+- You can send rewards to any `recipient` address (yourself or someone else)
+
+**For Node Operators:**
+Operators can claim both:
+1. **Their own staking rewards** (if they've staked tokens)
+2. **Commission rewards** from users who delegated to them
+
 
 #### Withdrawing Stake
 
-To withdraw stake, the owner of the depositId should follow the below steps or use the staking site available in [towns.com](https://www.towns.com/staking).
+To withdraw stake, the owner of the depositId should follow the below steps or use the staking site available in [towns.com](https://www.towns.com/token).
 
 1. Call `getDepositsByDepositor(address depositor)` to get the list of depositIds for the depositor.
 2. Call `initiateWithdraw(uint256 depositId)` with the depositId to start the withdrawal process.


### PR DESCRIPTION
### Description

This PR adds accurate protocol fee structure documentation to the pricing modules page. The documentation clarifies how protocol fees are collected from membership payments and how revenue is distributed between the protocol and Space owners.

### Changes

- **Added Protocol Fee Structure section**: Documents fee collection from membership payments (10% rate, 0.0005 ETH minimum fee, 0.001 ETH threshold)
- **Added two-tier fee collection logic**: Explains when fixed minimum fee vs percentage fee is deducted
- **Added revenue distribution table**: Shows how much Space owners receive after protocol fee deduction
- **Clarified payment flow**: Made explicit that protocol fees are deducted from payments
- **Improved fee transparency**: Helps Space owners understand their actual revenue after protocol fees

### Checklist

- [x] Tests added where required (N/A - documentation only)
- [x] Documentation updated where applicable  
- [x] Changes adhere to the repository's contribution guidelines
