### PR TITLE
feat: add end-to-end test for claiming with penalty

### DIFF
--- a/packages/contracts/test/airdrop/scripts/index.mjs
+++ b/packages/contracts/test/airdrop/scripts/index.mjs
@@ -8,7 +8,6 @@ const json = JSON.parse(
 const values = [];
 
 for (const condition of json.conditions) {
-  console.log(condition);
   values.push([condition.account, condition.amount, condition.points]);
 }
 


### PR DESCRIPTION
### Description

Added an end-to-end test for claiming tokens with a penalty, which verifies the correct token distribution and point deduction when a user claims with a penalty applied.

### Changes

- Added a new test case `test_e2e_claimWithPenalty()` that validates the penalty-based claiming functionality
- Fixed the path to the airdrop scripts in `givenOffChainRoot()` function
- Added a comment clarifying that PENALTY_BPS represents 50%
- Removed commented-out test code that was no longer needed
- Added console import for debugging purposes

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines