### PR TITLE
refactor: simplify snapshot handling in miniblocks

### DIFF
--- a/core/cmd/registry_cmd.go
+++ b/core/cmd/registry_cmd.go
@@ -237,19 +237,16 @@ func validateStream(
 
 	fmt.Printf("      Miniblocks: %d\n", len(stream.Miniblocks))
 	var lastBlock *MiniblockRef
+	opts := events.NewParsedMiniblockInfoOpts().WithDoNotParseEvents(true).WithApplyOnlyMatchingSnapshot()
 	for i, mb := range stream.Miniblocks {
-		info, err := events.NewMiniblockInfoFromProto(
-			mb, stream.GetSnapshotByMiniblockIndex(i),
-			events.NewParsedMiniblockInfoOpts().
-				WithDoNotParseEvents(true),
-		)
+		info, err := events.NewMiniblockInfoFromProto(mb, stream.Snapshot, opts)
 		if err != nil {
 			return err
 		}
 		lastBlock = info.Ref
 		header := info.Header()
 		var snapshot string
-		if header.IsSnapshot() {
+		if info.Snapshot != nil {
 			snapshot = "snapshot"
 		}
 		fmt.Printf(

--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -71,18 +71,15 @@ func getStreamFromNode(
 	stream := response.Msg.GetStream()
 	fmt.Println("MBs: ", len(stream.GetMiniblocks()), " Events: ", len(stream.GetEvents()))
 
-	for i, mb := range stream.GetMiniblocks() {
-		info, err := events.NewMiniblockInfoFromProto(
-			mb, stream.GetSnapshotByMiniblockIndex(i),
-			events.NewParsedMiniblockInfoOpts().
-				WithDoNotParseEvents(true),
-		)
+	opt := events.NewParsedMiniblockInfoOpts().WithDoNotParseEvents(true).WithApplyOnlyMatchingSnapshot()
+	for _, mb := range stream.GetMiniblocks() {
+		info, err := events.NewMiniblockInfoFromProto(mb, stream.Snapshot, opt)
 		if err != nil {
 			return err
 		}
 
 		fmt.Print(info.Ref, "  ", info.Header().GetTimestamp().AsTime().Local())
-		if info.Header().IsSnapshot() {
+ 		if info.Snapshot != nil {
 			fmt.Print(" SNAPSHOT")
 		}
 		fmt.Println()

--- a/core/node/events/snapshot.go
+++ b/core/node/events/snapshot.go
@@ -59,7 +59,7 @@ func MakeSnapshotEnvelope(wallet *crypto.Wallet, snapshot *Snapshot) (*Envelope,
 
 // ParseSnapshot parses the given envelope into a snapshot.
 // It verifies the hash and signature of the envelope.
-func ParseSnapshot(envelope *Envelope, signer common.Address) (*ParsedSnapshot, error) {
+func ParseSnapshot(envelope *Envelope, signer common.Address) (*Snapshot, error) {
 	hash := crypto.TownsHashForSnapshots.Hash(envelope.Event)
 	if !bytes.Equal(hash[:], envelope.Hash) {
 		return nil, RiverError(Err_BAD_EVENT_HASH, "Bad hash provided",
@@ -86,10 +86,7 @@ func ParseSnapshot(envelope *Envelope, signer common.Address) (*ParsedSnapshot, 
 			Func("ParseSnapshot")
 	}
 
-	return &ParsedSnapshot{
-		Snapshot: &sn,
-		Envelope: envelope,
-	}, nil
+	return &sn, nil
 }
 
 func Make_GenesisSnapshot(events []*ParsedEvent) (*Snapshot, error) {

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -293,7 +293,7 @@ func (s *Stream) importMiniblocksLocked(
 		allNewEvents = append(allNewEvents, newEvents...)
 		allNewEvents = append(allNewEvents, miniblock.headerEvent.Envelope)
 		if len(miniblock.Header().GetSnapshotHash()) > 0 {
-			snapshot = miniblock.Snapshot
+			snapshot = miniblock.SnapshotEnvelope
 		}
 	}
 
@@ -381,7 +381,7 @@ func (s *Stream) applyMiniblockImplLocked(
 	newEvents = append(newEvents, info.headerEvent.Envelope)
 	var snapshot *Envelope
 	if len(info.Header().GetSnapshotHash()) > 0 {
-		snapshot = info.Snapshot
+		snapshot = info.SnapshotEnvelope
 	}
 	s.notifySubscribersLocked(newEvents, newSyncCookie, snapshot)
 	return nil

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -34,15 +34,13 @@ func MakeStreamView(streamData *storage.ReadStreamFromLastSnapshotResult) (*Stre
 	}
 
 	miniblocks := make([]*MiniblockInfo, len(streamData.Miniblocks))
-	lastMiniblockNumber := int64(-2)
 	snapshotIndex := -1
+	var snapshot *Snapshot
+	firstMbNum := streamData.Miniblocks[0].Number
+	opts := NewParsedMiniblockInfoOpts()
 	for i, mb := range streamData.Miniblocks {
-		miniblock, err := NewMiniblockInfoFromDescriptor(&storage.MiniblockDescriptor{
-			Number:   lastMiniblockNumber + 1,
-			Data:     mb.Data,
-			Hash:     mb.Hash,
-			Snapshot: mb.Snapshot,
-		})
+		opts = opts.WithExpectedBlockNumber(firstMbNum + int64(i))
+		miniblock, err := NewMiniblockInfoFromDescriptorWithOpts(mb, opts)
 		if err != nil {
 			return nil, AsRiverError(
 				err,
@@ -51,17 +49,12 @@ func MakeStreamView(streamData *storage.ReadStreamFromLastSnapshotResult) (*Stre
 				Func("MakeStreamView")
 		}
 		miniblocks[i] = miniblock
-		lastMiniblockNumber = miniblock.Header().MiniblockNum
-		if snapshotIndex == -1 && miniblock.Header().IsSnapshot() {
+		if miniblock.Snapshot != nil {
+			snapshot = miniblock.Snapshot
 			snapshotIndex = i
 		}
 	}
 
-	if snapshotIndex == -1 {
-		return nil, RiverError(Err_STREAM_BAD_EVENT, "no snapshot").Func("MakeStreamView")
-	}
-
-	snapshot := miniblocks[snapshotIndex].GetSnapshot()
 	if snapshot == nil {
 		return nil, RiverError(Err_STREAM_BAD_EVENT, "no snapshot").Func("MakeStreamView")
 	}
@@ -115,22 +108,28 @@ func MakeRemoteStreamView(stream *StreamAndCookie) (*StreamView, error) {
 	}
 
 	miniblocks := make([]*MiniblockInfo, len(stream.Miniblocks))
-	lastMiniblockNumber := int64(-1)
-	for i, binMiniblock := range stream.Miniblocks {
-		opts := NewParsedMiniblockInfoOpts()
-		// Ignore block number of first block, but enforce afterward
+	var snapshot *Snapshot
+	var snapshotIndex int
+	opts := NewParsedMiniblockInfoOpts().WithApplyOnlyMatchingSnapshot()
+	for i, mbProto := range stream.Miniblocks {
+		// Make sure block numbers are consecutive.
 		if i > 0 {
-			opts = opts.WithExpectedBlockNumber(lastMiniblockNumber + 1)
+			opts = opts.WithExpectedBlockNumber(miniblocks[0].Ref.Num + int64(i))
 		}
-		miniblock, err := NewMiniblockInfoFromProto(binMiniblock, stream.GetSnapshotByMiniblockIndex(i), opts)
+
+		miniblock, err := NewMiniblockInfoFromProto(mbProto, stream.Snapshot, opts)
 		if err != nil {
 			return nil, err
 		}
-		lastMiniblockNumber = miniblock.Header().MiniblockNum
+
+		if miniblock.Snapshot != nil {
+			snapshot = miniblock.Snapshot
+			snapshotIndex = i
+		}
+
 		miniblocks[i] = miniblock
 	}
 
-	snapshot := miniblocks[0].GetSnapshot()
 	if snapshot == nil {
 		return nil, RiverError(Err_STREAM_BAD_EVENT, "no snapshot").Func("MakeStreamView")
 	}
@@ -166,7 +165,7 @@ func MakeRemoteStreamView(stream *StreamAndCookie) (*StreamView, error) {
 		blocks:        miniblocks,
 		minipool:      newMiniPoolInstance(minipoolEvents, generation, eventNumOffset),
 		snapshot:      snapshot,
-		snapshotIndex: 0,
+		snapshotIndex: snapshotIndex,
 	}, nil
 }
 
@@ -357,7 +356,7 @@ func (r *StreamView) makeMiniblockCandidate(
 	eventNumOffset := last.Header().EventNumOffset + int64(len(last.Events())) + 1 // +1 for header
 	nextMiniblockNum := last.Header().MiniblockNum + 1
 	miniblockNumOfPrevSnapshot := last.Header().PrevSnapshotMiniblockNum
-	if last.Header().IsSnapshot() {
+	if last.Snapshot != nil {
 		miniblockNumOfPrevSnapshot = last.Header().MiniblockNum
 	}
 
@@ -494,8 +493,8 @@ func (r *StreamView) copyAndApplyBlock(
 	var startIndex int
 	var snapshotIndex int
 	var snapshot *Snapshot
-	if header.IsSnapshot() {
-		snapshot = miniblock.GetSnapshot()
+	if miniblock.Snapshot != nil {
+		snapshot = miniblock.Snapshot
 		startIndex = max(0, len(r.blocks)-recencyConstraintsGenerations)
 		snapshotIndex = len(r.blocks) - startIndex
 	} else {
@@ -635,7 +634,7 @@ func (r *StreamView) MiniblocksFromLastSnapshot() (miniblocks []*Miniblock, snap
 		miniblocks = append(miniblocks, r.blocks[i].Proto)
 	}
 	if len(miniblocks) > 0 {
-		snapshot = r.blocks[r.snapshotIndex].Snapshot
+		snapshot = r.blocks[r.snapshotIndex].SnapshotEnvelope
 	}
 	return
 }
@@ -661,7 +660,7 @@ func (r *StreamView) shouldSnapshot(cfg *crypto.OnChainSettings) bool {
 	// count the events in blocks since the last snapshot
 	for i := len(r.blocks) - 1; i >= 0; i-- {
 		block := r.blocks[i]
-		if block.Header().IsSnapshot() {
+		if block.Snapshot != nil {
 			break
 		}
 		count += len(block.Events())
@@ -832,7 +831,7 @@ func (r *StreamView) GetStats() StreamViewStats {
 
 	for _, block := range r.blocks {
 		stats.EventsInMiniblocks += len(block.Events()) + 1 // +1 for header
-		if block.Header().IsSnapshot() {
+		if block.Snapshot != nil {
 			stats.SnapshotsInMiniblocks++
 		}
 	}

--- a/core/node/events/stream_view_test.go
+++ b/core/node/events/stream_view_test.go
@@ -220,24 +220,15 @@ func TestLoad(t *testing.T) {
 	// test copy and apply block
 	// how many blocks do we currently have?
 	assert.Equal(t, len(view.blocks), 1)
-	// create a new block
-	miniblockHeaderEvent, err := MakeParsedEventWithPayload(
-		userWallet,
-		Make_MiniblockHeader(miniblockHeader),
-		view.LastBlock().Ref,
-	)
-	assert.NoError(t, err)
-	miniblock, err := NewMiniblockInfoFromParsed(miniblockHeaderEvent, mbCandidate.Events(), mbCandidate.snapshot)
-	assert.NoError(t, err)
 	// with 5 generations (5 blocks kept in memory)
-	newSV1, newEvents, err := view.copyAndApplyBlock(miniblock, cfg)
+	newSV1, newEvents, err := view.copyAndApplyBlock(mbCandidate, cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, len(newSV1.blocks), 2) // we should have both blocks in memory
 	assert.Empty(t, newEvents)
 
 	// with 0 generations (0 in memory block history)
 	cfg.RecencyConstraintsGen = 0
-	newSV2, newEvents, err := view.copyAndApplyBlock(miniblock, cfg)
+	newSV2, newEvents, err := view.copyAndApplyBlock(mbCandidate, cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, len(newSV2.blocks), 1) // we should only have the latest block in memory
 	assert.Empty(t, newEvents)

--- a/core/node/events/stream_viewstate_space_test.go
+++ b/core/node/events/stream_viewstate_space_test.go
@@ -266,7 +266,7 @@ func TestSpaceViewState(t *testing.T) {
 	view3, err = MakeStreamView(
 		&storage.ReadStreamFromLastSnapshotResult{
 			Miniblocks: []*storage.MiniblockDescriptor{
-				{Data: miniblockProtoBytes, Snapshot: snapshotBytes},
+				{Number: 1, Data: miniblockProtoBytes, Snapshot: snapshotBytes},
 			},
 		},
 	)
@@ -334,7 +334,7 @@ func TestChannelViewState_JoinedMembers(t *testing.T) {
 	streamView, err = MakeStreamView(
 		&storage.ReadStreamFromLastSnapshotResult{
 			Miniblocks: []*storage.MiniblockDescriptor{
-				{Data: miniblockProtoBytes, Snapshot: snapshotBytes},
+				{Number: 1, Data: miniblockProtoBytes, Snapshot: snapshotBytes},
 			},
 		},
 	)
@@ -398,7 +398,7 @@ func TestChannelViewState_RemainingMembers(t *testing.T) {
 	streamView, err = MakeStreamView(
 		&storage.ReadStreamFromLastSnapshotResult{
 			Miniblocks: []*storage.MiniblockDescriptor{
-				{Data: miniblockProtoBytes, Snapshot: snapshotBytes},
+				{Number: 1, Data: miniblockProtoBytes, Snapshot: snapshotBytes},
 			},
 		},
 	)

--- a/core/node/events/tracked_stream_view.go
+++ b/core/node/events/tracked_stream_view.go
@@ -69,7 +69,7 @@ func (ts *TrackedStreamViewImpl) ApplyBlock(
 	mb, err := NewMiniblockInfoFromProto(
 		miniblock,
 		snapshot,
-		NewParsedMiniblockInfoOpts(),
+		NewParsedMiniblockInfoOpts().WithApplyOnlyMatchingSnapshot(),
 	)
 	if err != nil {
 		return err

--- a/core/node/protocol/helpers.go
+++ b/core/node/protocol/helpers.go
@@ -69,26 +69,6 @@ func (x *GetMiniblocksResponse) GetMiniblockSnapshot(num int64) *Envelope {
 	return x.Snapshots[num]
 }
 
-// GetSnapshotByMiniblockIndex returns the snapshot by the given miniblock index in the list.
-// StreamAndCookie contains a list of miniblocks starting from the latest snapshot.
-// Meaning the first miniblock in the list is the latest snapshot.
-// Meaning it returns the snapshot only when i is 0.
-func (x *StreamAndCookie) GetSnapshotByMiniblockIndex(i int) *Envelope {
-	if i == 0 {
-		return x.GetSnapshot()
-	}
-
-	return nil
-}
-
-// IsSnapshot returns true if the miniblock header has a snapshot.
-func (x *MiniblockHeader) IsSnapshot() bool {
-	if x == nil {
-		return false
-	}
-	return x.GetSnapshot() != nil || len(x.GetSnapshotHash()) > 0
-}
-
 // TargetSyncIDs returns the list of target sync IDs from the ModifySyncRequest.
 func (r *ModifySyncRequest) TargetSyncIDs() []string {
 	var targetSyncIds []string

--- a/core/node/rpc/get_miniblocks.go
+++ b/core/node/rpc/get_miniblocks.go
@@ -42,8 +42,8 @@ func (s *Service) localGetMiniblocks(
 	snapshots := make(map[int64]*Envelope)
 	for i, info := range mbsInfo {
 		miniblocks[i] = info.Proto
-		if !req.Msg.GetOmitSnapshots() && info.Snapshot != nil {
-			snapshots[info.Ref.Num] = info.Snapshot
+		if !req.Msg.GetOmitSnapshots() && info.SnapshotEnvelope != nil {
+			snapshots[info.Ref.Num] = info.SnapshotEnvelope
 		}
 	}
 
@@ -100,7 +100,7 @@ func (s *Service) applyExclusionFilter(info *MiniblockInfo, exclusionFilter []*E
 	return &MiniblockInfo{
 		Proto:    filteredMiniblock,
 		Ref:      info.Ref,
-		Snapshot: info.Snapshot,
+		SnapshotEnvelope: info.SnapshotEnvelope,
 	}
 }
 

--- a/core/node/rpc/miniblocks.go
+++ b/core/node/rpc/miniblocks.go
@@ -50,7 +50,7 @@ func (s *Service) SaveMbCandidate(
 		connect.NewRequest(&SaveMiniblockCandidateRequest{
 			StreamId:  streamId[:],
 			Miniblock: candidate.Proto,
-			Snapshot:  candidate.Snapshot,
+			Snapshot:  candidate.SnapshotEnvelope,
 		}),
 	)
 

--- a/core/node/scrub/miniblock_scrub_task.go
+++ b/core/node/scrub/miniblock_scrub_task.go
@@ -150,7 +150,7 @@ var maxBlocksPerScan = 100
 
 func optsFromPrevMiniblock(prevMb *events.MiniblockInfo) *events.ParsedMiniblockInfoOpts {
 	expectedPrevSnapshotNum := prevMb.Header().PrevSnapshotMiniblockNum
-	if prevMb.Header().IsSnapshot() {
+	if prevMb.Snapshot != nil {
 		expectedPrevSnapshotNum = prevMb.Header().MiniblockNum
 	}
 

--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -202,11 +202,11 @@ func (ssr *syncSessionRunner) applyUpdateToStream(
 		return
 	}
 
-	for i, block := range streamAndCookie.GetMiniblocks() {
+	for _, block := range streamAndCookie.GetMiniblocks() {
 		if !reset {
 			if err := trackedView.ApplyBlock(
 				block,
-				streamAndCookie.GetSnapshotByMiniblockIndex(i),
+				streamAndCookie.Snapshot,
 			); err != nil {
 				log.Errorw("Unable to apply block", "error", err)
 			}

--- a/core/tools/migrate_db/river_migrate_db.go
+++ b/core/tools/migrate_db/river_migrate_db.go
@@ -1643,7 +1643,7 @@ func lastSnapshotIndexFromMiniblocks(
 				printMaxSeqNum = true
 			}
 
-			if mbInfo.GetSnapshot() != nil {
+			if mbInfo.Snapshot != nil {
 				if verbose {
 					fmt.Printf("debug -- saw a snapshot for stream %s, seq_num %d\n", streamId, seqNum)
 				}


### PR DESCRIPTION
This change is related to #3571 - now GetStream can be used to get preceding miniblocks as well. 

Some refactoring: `snapshot` and `Snapshot` fields are removed/renamed in `MiniblockInfo` to avoid confusion, some checks hardened, `Snapshot` is always set even it's legacy snapshot from the header.

- Remove GetSnapshotByMiniblockIndex method and simplify snapshot retrieval
- Add ApplyOnlyMatchingSnapshot option to MiniblockInfo parsing
- Unify snapshot storage in MiniblockInfo with Snapshot and SnapshotEnvelope fields
- Update all callers to use the new simplified snapshot handling
- Remove IsSnapshot method from MiniblockHeader, use miniblock.Snapshot \!= nil instead

This refactor improves code clarity by consolidating snapshot handling logic and removing unnecessary indirection in snapshot retrieval.

