### PR TITLE
feat: add token transfer control system for apps

### DIFF
--- a/packages/contracts/src/spaces/facets/account/AppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccount.sol
@@ -53,6 +53,15 @@ contract AppAccount is IAppAccount, AppAccountBase, ReentrancyGuard, Facet {
     }
 
     /// @inheritdoc IAppAccount
+    function onRequestTransfer(
+        address token,
+        address to,
+        uint256 amount
+    ) external returns (bool success) {
+        return _onRequestTransfer(msg.sender, token, to, amount);
+    }
+
+    /// @inheritdoc IAppAccount
     function enableApp(address app) external onlyOwner {
         _enableApp(app);
     }

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -68,4 +68,16 @@ interface IAppAccount is IAppAccountBase {
         address publicKey,
         bytes32 permission
     ) external view returns (bool);
+
+    /// @notice Request a transfer of tokens during app execution
+    /// @dev Can only be called by apps during authorized execution
+    /// @param token Token address (address(0) or NATIVE_TOKEN for ETH)
+    /// @param to Recipient address
+    /// @param amount Amount to transfer
+    /// @return success Whether the transfer was successful
+    function onRequestTransfer(
+        address token,
+        address to,
+        uint256 amount
+    ) external returns (bool success);
 }

--- a/packages/contracts/src/spaces/facets/account/transfers/ITransferControl.sol
+++ b/packages/contracts/src/spaces/facets/account/transfers/ITransferControl.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+// Interfaces
+
+/// @notice Spending limits for a token
+/// @param maxPerTransaction Max amount per single transaction
+/// @param maxPerPeriod Max amount per time period
+/// @param spentInPeriod Amount spent in current period
+/// @param resetPeriod Time period in seconds (e.g., 86400 for daily)
+/// @param periodStart When current period started
+/// @param enabled Whether limits are enabled
+struct SpendingLimits {
+    uint256 maxPerTransaction;
+    uint256 maxPerPeriod;
+    uint256 spentInPeriod;
+    uint32 resetPeriod;
+    uint48 periodStart;
+    bool enabled;
+}
+
+interface ITransferControlBase {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           ERRORS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    error TransferControlDisabled();
+    error UnauthorizedTransferRequest();
+    error SpendingLimitExceeded();
+    error PeriodSpendingLimitExceeded();
+    error UnsupportedToken(address token);
+    error InsufficientBalance();
+    error TransferFailed();
+    error InvalidLimits();
+    error InvalidArrayLength();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           EVENTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    event TransferRequested(
+        address indexed app,
+        address indexed token,
+        address indexed to,
+        uint256 amount
+    );
+    event SpendingPeriodReset(address indexed app, address indexed token, uint48 newPeriodStart);
+    event SpendingRecorded(
+        address indexed app,
+        address indexed token,
+        uint256 amount,
+        uint256 totalInPeriod,
+        uint256 limit
+    );
+
+    event TransferControlEnabledSet(bool enabled);
+    event SupportedTokenAdded(address indexed token, SpendingLimits limits);
+    event SupportedTokenRemoved(address indexed token);
+    event DefaultTokenLimitsSet(address indexed token, SpendingLimits limits);
+    event AppTokenLimitsSet(address indexed app, address indexed token, SpendingLimits limits);
+    event AppTokenLimitsRemoved(address indexed app, address indexed token);
+}

--- a/packages/contracts/src/spaces/facets/account/transfers/TransferControlBase.sol
+++ b/packages/contracts/src/spaces/facets/account/transfers/TransferControlBase.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// Internal libraries
+import {TransferControlStorage} from "./TransferControlStorage.sol";
+import {CustomRevert} from "../../../../utils/libraries/CustomRevert.sol";
+import {CurrencyTransfer} from "../../../../utils/libraries/CurrencyTransfer.sol";
+import {ITransferControlBase, SpendingLimits} from "./ITransferControl.sol";
+
+abstract contract TransferControlBase is ITransferControlBase {
+    using CustomRevert for bytes4;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CORE TRANSFER LOGIC                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Request a transfer of ETH or ERC20 tokens
+    /// @dev Must be called during authorized execution context
+    /// @param token Token address (NATIVE_TOKEN for ETH)
+    /// @param to Recipient address
+    /// @param amount Amount to transfer
+    /// @return success Whether the transfer was successful
+    function _requestTransfer(
+        address app,
+        address token,
+        address to,
+        uint256 amount
+    ) internal returns (bool success) {
+        if (amount == 0) return true;
+
+        // Normalize token address (convert address(0) to NATIVE_TOKEN for consistency)
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        // Validate and update spending limits
+        _validateAndUpdateSpending(app, normalizedToken, amount);
+
+        // Execute transfer
+        _executeTransfer(normalizedToken, to, amount);
+
+        emit TransferRequested(app, normalizedToken, to, amount);
+        return true;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SPENDING CONTROL                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _validateAndUpdateSpending(address app, address token, uint256 amount) internal {
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+
+        if (!$.transferControlEnabled) return;
+
+        // Check if token is supported
+        if (!$.allowedTokens[token]) {
+            UnsupportedToken.selector.revertWith(token);
+        }
+
+        // Get effective spending limits
+        SpendingLimits memory limits = _getEffectiveLimits(app, token);
+        if (!limits.enabled) return;
+
+        // Validate per-transaction limit
+        if (amount > limits.maxPerTransaction) {
+            SpendingLimitExceeded.selector.revertWith();
+        }
+
+        // Get spending tracker
+        SpendingLimits storage tracker = $.limitsByApp[app][token];
+
+        // Reset period if needed
+        _resetSpendingPeriodIfNeeded(app, token, limits.resetPeriod, tracker);
+
+        // Validate period limit
+        uint256 newPeriodTotal = tracker.spentInPeriod + amount;
+        if (newPeriodTotal > limits.maxPerPeriod) {
+            PeriodSpendingLimitExceeded.selector.revertWith();
+        }
+
+        // Update tracker
+        tracker.spentInPeriod = newPeriodTotal;
+
+        emit SpendingRecorded(app, token, amount, newPeriodTotal, limits.maxPerPeriod);
+    }
+
+    function _getEffectiveLimits(
+        address app,
+        address token
+    ) internal view returns (SpendingLimits memory) {
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+
+        SpendingLimits memory appLimits = $.limitsByApp[app][token];
+
+        // If app has custom limits (indicated by enabled flag or maxPerTransaction > 0)
+        if (appLimits.enabled || appLimits.maxPerTransaction > 0) {
+            return appLimits;
+        }
+
+        // Return default limits for this token
+        return $.limitsByToken[token];
+    }
+
+    function _resetSpendingPeriodIfNeeded(
+        address app,
+        address token,
+        uint32 resetPeriod,
+        SpendingLimits storage tracker
+    ) internal {
+        uint48 currentTime = uint48(block.timestamp);
+
+        // Initialize period if first spend
+        if (tracker.periodStart == 0) {
+            tracker.periodStart = currentTime;
+            return;
+        }
+
+        // Reset if period expired
+        if (currentTime >= tracker.periodStart + resetPeriod) {
+            tracker.spentInPeriod = 0;
+            tracker.periodStart = currentTime;
+
+            emit SpendingPeriodReset(app, token, currentTime);
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       TRANSFER EXECUTION                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _executeTransfer(address token, address to, uint256 amount) internal {
+        // Validate sufficient balance
+        _validateSufficientBalance(token, amount);
+
+        // Execute transfer using CurrencyTransfer library
+        CurrencyTransfer.transferCurrency(token, address(this), to, amount);
+    }
+
+    function _validateSufficientBalance(address token, uint256 amount) internal view {
+        uint256 balance;
+
+        if (token == CurrencyTransfer.NATIVE_TOKEN) {
+            balance = address(this).balance;
+        } else {
+            // For ERC20 tokens, get balance from token contract
+            balance = _getTokenBalance(token);
+        }
+
+        if (balance < amount) {
+            InsufficientBalance.selector.revertWith();
+        }
+    }
+
+    function _validateLimits(SpendingLimits calldata limits) internal pure {
+        if (limits.enabled) {
+            if (limits.maxPerTransaction == 0 || limits.maxPerPeriod == 0) {
+                InvalidLimits.selector.revertWith();
+            }
+            if (limits.maxPerTransaction > limits.maxPerPeriod) {
+                InvalidLimits.selector.revertWith();
+            }
+            if (limits.resetPeriod == 0) {
+                InvalidLimits.selector.revertWith();
+            }
+        }
+    }
+
+    function _getTokenBalance(address token) internal view returns (uint256) {
+        // Use low-level call to avoid importing IERC20
+        bytes memory data = abi.encodeWithSignature("balanceOf(address)", address(this));
+        (bool success, bytes memory result) = token.staticcall(data);
+
+        if (!success || result.length < 32) {
+            return 0;
+        }
+
+        return abi.decode(result, (uint256));
+    }
+}

--- a/packages/contracts/src/spaces/facets/account/transfers/TransferControlFacet.sol
+++ b/packages/contracts/src/spaces/facets/account/transfers/TransferControlFacet.sol
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {ITransferControlBase, SpendingLimits} from "./ITransferControl.sol";
+import {CurrencyTransfer} from "../../../../utils/libraries/CurrencyTransfer.sol";
+
+// libraries
+import {TransferControlStorage} from "./TransferControlStorage.sol";
+import {CustomRevert} from "../../../../utils/libraries/CustomRevert.sol";
+
+// contracts
+import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
+import {TransferControlBase} from "./TransferControlBase.sol";
+import {TokenOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/token/TokenOwnableBase.sol";
+
+/**
+ * @title TransferControlFacet
+ * @notice Management interface for transfer control settings
+ * @dev Allows space owners to configure spending limits and supported tokens
+ */
+contract TransferControlFacet is
+    ITransferControlBase,
+    TransferControlBase,
+    TokenOwnableBase,
+    Facet
+{
+    using CustomRevert for bytes4;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       GLOBAL SETTINGS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Enable or disable transfer control system
+    /// @param enabled Whether transfer control should be enabled
+    function setTransferControlEnabled(bool enabled) external onlyOwner {
+        TransferControlStorage.getLayout().transferControlEnabled = enabled;
+        emit TransferControlEnabledSet(enabled);
+    }
+
+    /// @notice Check if transfer control is enabled
+    /// @return enabled Whether transfer control is enabled
+    function isTransferControlEnabled() external view returns (bool enabled) {
+        return TransferControlStorage.getLayout().transferControlEnabled;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       TOKEN MANAGEMENT                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Add a supported token with default limits
+    /// @param token Token address (NATIVE_TOKEN for ETH)
+    /// @param defaultLimits Default spending limits for this token
+    function addSupportedToken(
+        address token,
+        SpendingLimits calldata defaultLimits
+    ) external onlyOwner {
+        _validateLimits(defaultLimits);
+
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+
+        // Normalize token address
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        $.allowedTokens[normalizedToken] = true;
+        $.limitsByToken[normalizedToken] = defaultLimits;
+
+        emit SupportedTokenAdded(normalizedToken, defaultLimits);
+    }
+
+    /// @notice Remove a supported token
+    /// @param token Token address to remove
+    function removeSupportedToken(address token) external onlyOwner {
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        $.allowedTokens[normalizedToken] = false;
+        delete $.limitsByToken[normalizedToken];
+
+        emit SupportedTokenRemoved(normalizedToken);
+    }
+
+    /// @notice Update default limits for a supported token
+    /// @param token Token address
+    /// @param defaultLimits New default limits
+    function setDefaultTokenLimits(
+        address token,
+        SpendingLimits calldata defaultLimits
+    ) external onlyOwner {
+        _validateLimits(defaultLimits);
+
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        if (!$.allowedTokens[normalizedToken]) {
+            UnsupportedToken.selector.revertWith(normalizedToken);
+        }
+
+        $.limitsByToken[normalizedToken] = defaultLimits;
+        emit DefaultTokenLimitsSet(normalizedToken, defaultLimits);
+    }
+
+    /// @notice Check if a token is supported
+    /// @param token Token address to check
+    /// @return supported Whether the token is supported
+    function isSupportedToken(address token) external view returns (bool supported) {
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+        return TransferControlStorage.getLayout().allowedTokens[normalizedToken];
+    }
+
+    /// @notice Get default limits for a token
+    /// @param token Token address
+    /// @return limits Default spending limits for the token
+    function getDefaultTokenLimits(
+        address token
+    ) external view returns (SpendingLimits memory limits) {
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+        return TransferControlStorage.getLayout().limitsByToken[normalizedToken];
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       APP LIMITS MANAGEMENT                */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Set custom spending limits for an app on a specific token
+    /// @param app App address
+    /// @param token Token address
+    /// @param limits Custom spending limits
+    function setAppTokenLimits(
+        address app,
+        address token,
+        SpendingLimits calldata limits
+    ) external onlyOwner {
+        _validateLimits(limits);
+
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        if (!$.allowedTokens[normalizedToken]) {
+            UnsupportedToken.selector.revertWith(normalizedToken);
+        }
+
+        $.limitsByApp[app][normalizedToken] = limits;
+        emit AppTokenLimitsSet(app, normalizedToken, limits);
+    }
+
+    /// @notice Set custom spending limits for an app across multiple tokens
+    /// @param app App address
+    /// @param tokens Array of token addresses
+    /// @param limits Array of spending limits (must match tokens length)
+    function setAppTokenLimitsBatch(
+        address app,
+        address[] calldata tokens,
+        SpendingLimits[] calldata limits
+    ) external onlyOwner {
+        if (tokens.length != limits.length) {
+            InvalidArrayLength.selector.revertWith();
+        }
+
+        for (uint256 i; i < tokens.length; ++i) {
+            _validateLimits(limits[i]);
+
+            address normalizedToken = tokens[i] == address(0)
+                ? CurrencyTransfer.NATIVE_TOKEN
+                : tokens[i];
+
+            TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+            if (!$.allowedTokens[normalizedToken]) {
+                UnsupportedToken.selector.revertWith(normalizedToken);
+            }
+
+            $.limitsByApp[app][normalizedToken] = limits[i];
+            emit AppTokenLimitsSet(app, normalizedToken, limits[i]);
+        }
+    }
+
+    /// @notice Remove custom limits for an app on a token (falls back to defaults)
+    /// @param app App address
+    /// @param token Token address
+    function removeAppTokenLimits(address app, address token) external onlyOwner {
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+        delete TransferControlStorage.getLayout().limitsByApp[app][normalizedToken];
+        emit AppTokenLimitsRemoved(app, normalizedToken);
+    }
+
+    /// @notice Get effective spending limits for an app on a token
+    /// @param app App address
+    /// @param token Token address
+    /// @return limits Effective spending limits (custom or default)
+    function getAppTokenLimits(
+        address app,
+        address token
+    ) external view returns (SpendingLimits memory limits) {
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        SpendingLimits memory appLimits = $.limitsByApp[app][normalizedToken];
+
+        // If app has custom limits
+        if (appLimits.enabled || appLimits.maxPerTransaction > 0) {
+            return appLimits;
+        }
+
+        // Return default limits
+        return $.limitsByToken[normalizedToken];
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SPENDING STATUS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Get current spending status for an app on a token
+    /// @param app App address
+    /// @param token Token address
+    /// @return limits Current effective limits
+    /// @return spentInPeriod Amount spent in current period
+    /// @return periodStart When current period started
+    /// @return remainingInPeriod Amount remaining in period
+    /// @return periodEnd When current period ends
+    function getAppSpendingStatus(
+        address app,
+        address token
+    )
+        external
+        view
+        returns (
+            SpendingLimits memory limits,
+            uint256 spentInPeriod,
+            uint48 periodStart,
+            uint256 remainingInPeriod,
+            uint48 periodEnd
+        )
+    {
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        // Get effective limits
+        SpendingLimits memory appLimits = $.limitsByApp[app][normalizedToken];
+        if (appLimits.enabled || appLimits.maxPerTransaction > 0) {
+            limits = appLimits;
+        } else {
+            limits = $.limitsByToken[normalizedToken];
+        }
+
+        // Get current spending tracker
+        SpendingLimits memory tracker = $.limitsByApp[app][normalizedToken];
+        spentInPeriod = tracker.spentInPeriod;
+        periodStart = tracker.periodStart;
+
+        // Calculate remaining and period end
+        if (spentInPeriod <= limits.maxPerPeriod) {
+            remainingInPeriod = limits.maxPerPeriod - spentInPeriod;
+        } else {
+            remainingInPeriod = 0;
+        }
+
+        if (periodStart > 0) {
+            periodEnd = periodStart + limits.resetPeriod;
+        } else {
+            periodEnd = uint48(block.timestamp) + limits.resetPeriod;
+        }
+    }
+
+    /// @notice Reset spending period for an app on a token (emergency function)
+    /// @param app App address
+    /// @param token Token address
+    function resetAppSpendingPeriod(address app, address token) external onlyOwner {
+        address normalizedToken = token == address(0) ? CurrencyTransfer.NATIVE_TOKEN : token;
+
+        TransferControlStorage.Layout storage $ = TransferControlStorage.getLayout();
+        SpendingLimits storage tracker = $.limitsByApp[app][normalizedToken];
+
+        tracker.spentInPeriod = 0;
+        tracker.periodStart = uint48(block.timestamp);
+
+        emit SpendingPeriodReset(app, normalizedToken, uint48(block.timestamp));
+    }
+}

--- a/packages/contracts/src/spaces/facets/account/transfers/TransferControlStorage.sol
+++ b/packages/contracts/src/spaces/facets/account/transfers/TransferControlStorage.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// Internal libraries
+import {SpendingLimits} from "./ITransferControl.sol";
+
+library TransferControlStorage {
+    // keccak256(abi.encode(uint256(keccak256("spaces.facets.account.transfercontrol.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant STORAGE_SLOT =
+        0xd7affc4eb57929463883bdf445e7a9e74073e0cb099a7adfeee3b43d8669ee00;
+
+    struct Layout {
+        mapping(address app => mapping(address token => SpendingLimits)) limitsByApp;
+        mapping(address token => SpendingLimits) limitsByToken;
+        mapping(address token => bool) allowedTokens;
+        // Global settings
+        bool transferControlEnabled;
+        address[] monitoredTokens;
+    }
+
+    function getLayout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+}

--- a/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
+++ b/packages/contracts/src/spaces/facets/executor/ExecutorStorage.sol
@@ -36,6 +36,8 @@ library ExecutorStorage {
         mapping(bytes32 scheduleId => Schedule schedule) schedules;
         // Hook Config ID => Hook Config
         mapping(bytes32 configId => HookConfig config) hooks;
+        // Executing Target => Execution ID
+        mapping(address target => bytes32 executionId) executingTarget;
     }
 
     function getLayout() internal pure returns (Layout storage l) {


### PR DESCRIPTION
### Description

This PR adds a token transfer control system for apps running within a space. It enables spaces to securely allow apps to transfer tokens (ETH and ERC20) with configurable spending limits, while ensuring transfers only occur during authorized execution contexts.

### Changes

- Added `onRequestTransfer` method to `AppAccount` to allow apps to request token transfers
- Implemented `TransferControlBase` with core transfer validation and execution logic
- Created `TransferControlFacet` for managing token spending limits and permissions
- Added support for per-app and per-token spending limits with time-based restrictions
- Implemented validation to ensure transfers only occur during authorized app execution
- Enhanced `ExecutorBase` to track execution context for security validation
- Added spending period tracking and automatic reset functionality

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines