### PR TITLE
fix: prevent panic from submitting to closed worker pool during startup

### DIFF
--- a/core/node/events/stream_reconcile_task.go
+++ b/core/node/events/stream_reconcile_task.go
@@ -39,7 +39,7 @@ func (s *StreamCache) submitReconcileStreamTaskToPool(
 	if streamRecord == nil {
 		s.submitGetRecordTask(pool, stream)
 	} else {
-		s.submitReconciliationTask(pool, stream, streamRecord)
+		s.submitReconciliationTask(s.onlineReconcileWorkerPool, stream, streamRecord)
 	}
 }
 
@@ -64,7 +64,7 @@ func (s *StreamCache) submitGetRecordTask(
 	}
 
 	s.submitToPool(pool, func() {
-		s.getRecordTask(pool, stream)
+		s.getRecordTask(s.onlineReconcileWorkerPool, stream)
 	})
 }
 
@@ -84,7 +84,7 @@ func (s *StreamCache) getRecordTask(
 		return
 	}
 
-	s.submitReconciliationTask(pool, stream, streamRecord)
+	s.submitReconciliationTask(s.onlineReconcileWorkerPool, stream, streamRecord)
 }
 
 func (s *StreamCache) submitReconciliationTask(
@@ -206,8 +206,8 @@ func (s *StreamCache) reconciliationTask(
 	}
 
 	if schedule {
-		s.submitToPool(pool, func() {
-			s.reconciliationTask(pool, streamId)
+		s.submitToPool(s.onlineReconcileWorkerPool, func() {
+			s.reconciliationTask(s.onlineReconcileWorkerPool, streamId)
 		})
 	}
 }

--- a/core/node/events/stream_reconcile_task.go
+++ b/core/node/events/stream_reconcile_task.go
@@ -39,7 +39,7 @@ func (s *StreamCache) submitReconcileStreamTaskToPool(
 	if streamRecord == nil {
 		s.submitGetRecordTask(pool, stream)
 	} else {
-		s.submitReconciliationTask(s.onlineReconcileWorkerPool, stream, streamRecord)
+		s.submitReconciliationTask(pool, stream, streamRecord)
 	}
 }
 
@@ -64,7 +64,7 @@ func (s *StreamCache) submitGetRecordTask(
 	}
 
 	s.submitToPool(pool, func() {
-		s.getRecordTask(s.onlineReconcileWorkerPool, stream)
+		s.getRecordTask(pool, stream)
 	})
 }
 

--- a/core/node/events/stream_reconcile_task.go
+++ b/core/node/events/stream_reconcile_task.go
@@ -64,12 +64,11 @@ func (s *StreamCache) submitGetRecordTask(
 	}
 
 	s.submitToPool(pool, func() {
-		s.getRecordTask(pool, stream)
+		s.getRecordTask(stream)
 	})
 }
 
 func (s *StreamCache) getRecordTask(
-	pool *workerpool.WorkerPool,
 	stream *Stream,
 ) {
 	s.scheduledGetRecordTasks.Delete(stream.streamId)
@@ -115,13 +114,12 @@ func (s *StreamCache) submitReconciliationTask(
 
 	if schedule {
 		s.submitToPool(pool, func() {
-			s.reconciliationTask(pool, stream.StreamId())
+			s.reconciliationTask(stream.StreamId())
 		})
 	}
 }
 
 func (s *StreamCache) reconciliationTask(
-	pool *workerpool.WorkerPool,
 	streamId StreamId,
 ) {
 	corrupt := false
@@ -207,7 +205,7 @@ func (s *StreamCache) reconciliationTask(
 
 	if schedule {
 		s.submitToPool(s.onlineReconcileWorkerPool, func() {
-			s.reconciliationTask(s.onlineReconcileWorkerPool, streamId)
+			s.reconciliationTask(streamId)
 		})
 	}
 }


### PR DESCRIPTION
Fixed a race condition where reconciliation tasks submitted to the
initialReconcileWorkerPool would try to recursively submit more tasks
to the same pool after it had already been stopped via StopWait().

The fix ensures that any recursive task submissions use the long-lived
onlineReconcileWorkerPool instead of the temporary startup pool.

```
panic: send on closed channel

goroutine 502417 gp=0xc005e2bc00 m=8 mp=0xc000518008 [running]:
panic({0x18af100?, 0x1f51850?})
	runtime/panic.go:811 +0x168 fp=0xc0244fbc00 sp=0xc0244fbb50 pc=0x47bf88
runtime.chansend(0xc008883730, 0xc0244fbcd0, 0x1, 0xc0244fbcb8?)
	runtime/chan.go:226 +0x55e fp=0xc0244fbc70 sp=0xc0244fbc00 pc=0x41353e
runtime.chansend1(0x1a33ae0?, 0x0?)
	runtime/chan.go:161 +0x17 fp=0xc0244fbca0 sp=0xc0244fbc70 pc=0x412fd7
github.com/gammazero/workerpool.(*WorkerPool).Submit(...)
	github.com/gammazero/workerpool@v1.1.3/workerpool.go:109
github.com/towns-protocol/towns/core/node/events.(*StreamCache).submitToPool(0x96c6a3c10dc54fad?, 0xeff9aa8769c08a29?, 0xb1865ae20d?)
	github.com/towns-protocol/towns/core/node/events/stream_reconcile_task.go:53 +0xa7 fp=0xc0244fbcf0 sp=0xc0244fbca0 pc=0x127bc07
github.com/towns-protocol/towns/core/node/events.(*StreamCache).reconciliationTask(0xc000b640f0, 0xc003e50180, {0xad, 0x4f, 0xc5, 0xd, 0xc1, 0xa3, 0xc6, 0x96, ...})
	github.com/towns-protocol/towns/core/node/events/stream_reconcile_task.go:209 +0x667 fp=0xc0244fbf30 sp=0xc0244fbcf0 pc=0x127ca27
github.com/towns-protocol/towns/core/node/events.(*StreamCache).submitReconciliationTask.func2()
	github.com/towns-protocol/towns/core/node/events/stream_reconcile_task.go:118 +0x45 fp=0xc0244fbf90 sp=0xc0244fbf30 pc=0x127c2a5
github.com/gammazero/workerpool.worker(0x0?, 0xc0088837a0, 0xc001d8bc70)
	github.com/gammazero/workerpool@v1.1.3/workerpool.go:237 +0x22 fp=0xc0244fbfb8 sp=0xc0244fbf90 pc=0x1127c02
github.com/gammazero/workerpool.(*WorkerPool).dispatch.gowrap2()
	github.com/gammazero/workerpool@v1.1.3/workerpool.go:197 +0x28 fp=0xc0244fbfe0 sp=0xc0244fbfb8 pc=0x1127b48
runtime.goexit({})
	runtime/asm_amd64.s:1700 +0x1 fp=0xc0244fbfe8 sp=0xc0244fbfe0 pc=0x484aa1
created by github.com/gammazero/workerpool.(*WorkerPool).dispatch in goroutine 502415
	github.com/gammazero/workerpool@v1.1.3/workerpool.go:197 +0x2b3
```