### PR TITLE
refactor: replace magic number with named constant in miniblock_job.go

### DIFF
--- a/core/node/events/miniblock_job.go
+++ b/core/node/events/miniblock_job.go
@@ -413,7 +413,8 @@ func (j *mbJob) gatherRemoteProposals(
 }
 
 func (j *mbJob) saveCandidate(ctx context.Context) error {
-	timeout := 240 * time.Second // TODO: REPLICATION: FIX: make this timeout configurable
+	const defaultCandidateTimeout = 240 * time.Second // TODO: REPLICATION: FIX: make this timeout configurable
+	timeout := defaultCandidateTimeout
 	qp := NewQuorumPool(
 		ctx,
 		NewQuorumPoolOpts().


### PR DESCRIPTION
### Description

Replace the magic number 240 with a named constant defaultCandidateTimeout for better code readability and maintainability. This change makes the code more self-documenting and easier to modify in the future, while maintaining
the exact same functionality.

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [x] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
