### PR TITLE
refactor(contract): use storage reference for transaction data handling

### DIFF
--- a/packages/contracts/src/spaces/facets/dispatcher/DispatcherBase.sol
+++ b/packages/contracts/src/spaces/facets/dispatcher/DispatcherBase.sol
@@ -5,20 +5,20 @@ pragma solidity ^0.8.23;
 import {IDispatcherBase} from "./IDispatcher.sol";
 
 // libraries
-import {CustomRevert} from "src/utils/libraries/CustomRevert.sol";
+import {CustomRevert} from "../../../utils/libraries/CustomRevert.sol";
 
 // contracts
 import {DispatcherStorage} from "./DispatcherStorage.sol";
 
 abstract contract DispatcherBase is IDispatcherBase {
-    function _captureData(bytes32 transactionId, bytes memory data) internal {
-        DispatcherStorage.Layout storage ds = DispatcherStorage.layout();
-        ds.transactionData[transactionId] = data;
+    using CustomRevert for bytes4;
+
+    function _deleteTransactionData(bytes32 transactionId) internal {
+        delete DispatcherStorage.transactionDataRef(transactionId).inner;
     }
 
-    function _getCapturedData(bytes32 transactionId) internal view returns (bytes memory) {
-        DispatcherStorage.Layout storage ds = DispatcherStorage.layout();
-        return ds.transactionData[transactionId];
+    function _getCapturedData(bytes32 transactionId) internal view returns (bytes storage) {
+        return DispatcherStorage.transactionDataRef(transactionId).inner;
     }
 
     function _captureValue(bytes32 transactionId) internal {
@@ -43,7 +43,7 @@ abstract contract DispatcherBase is IDispatcherBase {
 
     function _useDispatchNonce(bytes32 keyHash) internal returns (uint256) {
         DispatcherStorage.Layout storage ds = DispatcherStorage.layout();
-        return ds.transactionNonce[keyHash]++;
+        return ++ds.transactionNonce[keyHash];
     }
 
     function _makeDispatchInputSeed(
@@ -69,14 +69,14 @@ abstract contract DispatcherBase is IDispatcherBase {
             _makeDispatchInputSeed(keyHash, sender, _useDispatchNonce(keyHash))
         );
 
+        DispatcherStorage.BytesWrapper storage capturedDataRef = DispatcherStorage
+            .transactionDataRef(transactionId);
         // revert if the transaction already exists
-        if (_getCapturedData(transactionId).length > 0) {
-            CustomRevert.revertWith(Dispatcher__TransactionAlreadyExists.selector);
+        if (capturedDataRef.inner.length > 0) {
+            Dispatcher__TransactionAlreadyExists.selector.revertWith();
         }
 
-        _captureData(transactionId, data);
-        if (msg.value != 0) {
-            _captureValue(transactionId);
-        }
+        capturedDataRef.inner = data;
+        if (msg.value != 0) _captureValue(transactionId);
     }
 }

--- a/packages/contracts/src/spaces/facets/dispatcher/DispatcherStorage.sol
+++ b/packages/contracts/src/spaces/facets/dispatcher/DispatcherStorage.sol
@@ -1,22 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
-
 library DispatcherStorage {
     // keccak256(abi.encode(uint256(keccak256("spaces.facets.dispatcher.storage")) - 1)) &
     // ~bytes32(uint256(0xff))
     bytes32 internal constant STORAGE_SLOT =
         0x34516f6fe09a043d57f1ff579a303a7ae85314751c77b4eb1a55837604a86e00;
-
-    // transactionData {
-    //   bytes data
-    //   uint256 count
-    // }
 
     struct Layout {
         mapping(bytes32 => uint256) transactionNonce;
@@ -25,9 +14,24 @@ library DispatcherStorage {
     }
 
     function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = STORAGE_SLOT;
         assembly {
-            l.slot := slot
+            l.slot := STORAGE_SLOT
+        }
+    }
+
+    /// @dev A reference to a bytes value in storage to allow assignment and deletion
+    struct BytesWrapper {
+        bytes inner;
+    }
+
+    /// @dev Returns the storage reference for the transaction data at the given transaction ID
+    function transactionDataRef(
+        bytes32 transactionId
+    ) internal pure returns (BytesWrapper storage ref) {
+        assembly ("memory-safe") {
+            mstore(0, transactionId)
+            mstore(0x20, add(STORAGE_SLOT, 2)) // transactionData mapping slot
+            ref.slot := keccak256(0, 0x40)
         }
     }
 }

--- a/packages/contracts/src/spaces/facets/dispatcher/IDispatcher.sol
+++ b/packages/contracts/src/spaces/facets/dispatcher/IDispatcher.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
-
 interface IDispatcherBase {
     error Dispatcher__TransactionAlreadyExists();
 }

--- a/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
+++ b/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
@@ -140,7 +140,7 @@ abstract contract MembershipJoin is
     }
 
     function _rejectMembership(bytes32 transactionId, address receiver) internal {
-        _captureData(transactionId, "");
+        _deleteTransactionData(transactionId);
         _refundBalance(transactionId, receiver);
         emit MembershipTokenRejected(receiver);
     }
@@ -149,8 +149,6 @@ abstract contract MembershipJoin is
         // Check if there are any prepaid memberships available
         uint256 prepaidSupply = _getPrepaidSupply();
         if (prepaidSupply > 0) return 0; // If prepaid memberships exist, no payment is required
-
-        if (price == 0) return 0; // If the price is zero, no payment is required
 
         return price;
     }
@@ -373,7 +371,7 @@ abstract contract MembershipJoin is
         if (ownerProceeds != 0) _transferIn(payer, ownerProceeds);
 
         _releaseCapturedValue(transactionId, paymentRequired);
-        _captureData(transactionId, "");
+        _deleteTransactionData(transactionId);
 
         _mintMembershipPoints(receiver, membershipPrice);
     }

--- a/packages/contracts/src/spaces/facets/xchain/SpaceEntitlementGated.sol
+++ b/packages/contracts/src/spaces/facets/xchain/SpaceEntitlementGated.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IMembership} from "../membership/IMembership.sol";
 
 // libraries
 
 // contracts
-import {EntitlementGated} from "src/spaces/facets/gated/EntitlementGated.sol";
-
-import {IMembership} from "src/spaces/facets/membership/IMembership.sol";
-import {MembershipJoin} from "src/spaces/facets/membership/join/MembershipJoin.sol";
+import {EntitlementGated} from "../gated/EntitlementGated.sol";
+import {MembershipJoin} from "../membership/join/MembershipJoin.sol";
 
 /// @title SpaceEntitlementGated
 /// @notice Handles entitlement-gated access to spaces and membership token issuance
@@ -23,11 +22,9 @@ contract SpaceEntitlementGated is MembershipJoin, EntitlementGated {
         bytes32 transactionId,
         NodeVoteStatus result
     ) internal override {
-        bytes memory data = _getCapturedData(transactionId);
+        bytes storage data = _getCapturedData(transactionId);
 
-        if (data.length == 0) {
-            return;
-        }
+        if (data.length == 0) return;
 
         (bytes4 transactionType, , address receiver, ) = abi.decode(
             data,


### PR DESCRIPTION
### Description

Use storage reference in `DispatcherBase` for transaction data handling.

### Changes

- Replaced `transactionData` mapping with `transactionDataRef` for simpler storage referencing using `BytesWrapper`.
- Enhanced code readability by utilizing `.revertWith()` for revert logic.
- Removed redundant empty data captures and optimized `_getCapturedData` for direct storage access.
- Organized and updated import paths for consistency.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
