### PR TITLE
fix: prevent underflow in claim condition loop

### DIFF
--- a/packages/contracts/scripts/interactions/InteractDropFacet.s.sol
+++ b/packages/contracts/scripts/interactions/InteractDropFacet.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {IDropFacet, IDropFacetBase} from "src/airdrop/drop/IDropFacet.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// libraries
+import {DropClaim} from "src/airdrop/drop/DropClaim.sol";
+import {DropGroup} from "src/airdrop/drop/DropGroup.sol";
+
+// contracts
+import {Interaction} from "scripts/common/Interaction.s.sol";
+import {console} from "forge-std/console.sol";
+
+// deployments
+import {DeployRiverAirdrop} from "scripts/deployments/diamonds/DeployRiverAirdrop.s.sol";
+import {DropFacet} from "src/airdrop/drop/DropFacet.sol";
+
+contract InteractDropFacet is Interaction, IDropFacetBase {
+    function __interact(address) internal override {
+        address airdrop = getDeployment("riverAirdrop");
+        address dropFacet = 0x8DB408fD918e80D09Afb895f41480076ba96C74b;
+
+        DropFacet facet = new DropFacet();
+        bytes memory bytecode = address(facet).code;
+        vm.etch(dropFacet, bytecode);
+
+        vm.expectRevert(DropFacet__NoActiveClaimCondition.selector);
+        IDropFacet(airdrop).getActiveClaimConditionId();
+    }
+}

--- a/packages/contracts/src/airdrop/drop/DropBase.sol
+++ b/packages/contracts/src/airdrop/drop/DropBase.sol
@@ -190,7 +190,7 @@ abstract contract DropBase is IDropFacetBase {
             lastConditionId = conditionStartId + conditionCount - 1;
         }
 
-        for (uint256 i = lastConditionId; i >= conditionStartId; --i) {
+        for (uint256 i = lastConditionId; i >= conditionStartId; ) {
             DropGroup.ClaimCondition storage condition = _getClaimConditionById(i);
             uint256 endTimestamp = condition.endTimestamp;
             if (
@@ -198,6 +198,14 @@ abstract contract DropBase is IDropFacetBase {
                 (endTimestamp == 0 || block.timestamp < endTimestamp)
             ) {
                 return i;
+            }
+
+            if (i == conditionStartId) {
+                break;
+            }
+
+            unchecked {
+                --i;
             }
         }
 

--- a/packages/contracts/src/airdrop/drop/DropBase.sol
+++ b/packages/contracts/src/airdrop/drop/DropBase.sol
@@ -190,7 +190,11 @@ abstract contract DropBase is IDropFacetBase {
             lastConditionId = conditionStartId + conditionCount - 1;
         }
 
-        for (uint256 i = lastConditionId; i >= conditionStartId; ) {
+        for (uint256 i = lastConditionId + 1; i > conditionStartId; ) {
+            unchecked {
+                --i;
+            }
+
             DropGroup.ClaimCondition storage condition = _getClaimConditionById(i);
             uint256 endTimestamp = condition.endTimestamp;
             if (
@@ -198,14 +202,6 @@ abstract contract DropBase is IDropFacetBase {
                 (endTimestamp == 0 || block.timestamp < endTimestamp)
             ) {
                 return i;
-            }
-
-            if (i == conditionStartId) {
-                break;
-            }
-
-            unchecked {
-                --i;
             }
         }
 

--- a/packages/contracts/test/airdrop/DropFacet.t.sol
+++ b/packages/contracts/test/airdrop/DropFacet.t.sol
@@ -227,19 +227,117 @@ contract DropFacetTest is BaseSetup, IDropFacetBase, IOwnableBase, IRewardsDistr
     // getActiveClaimConditionId
     function test_getActiveClaimConditionId() external givenTokensMinted(TOTAL_TOKEN_AMOUNT * 3) {
         DropGroup.ClaimCondition[] memory conditions = new DropGroup.ClaimCondition[](3);
-        conditions[0] = _createClaimCondition(block.timestamp - 100, root, TOTAL_TOKEN_AMOUNT); // expired
-        conditions[1] = _createClaimCondition(block.timestamp, root, TOTAL_TOKEN_AMOUNT); // active
+        conditions[0] = _createClaimCondition(block.timestamp - 100, root, TOTAL_TOKEN_AMOUNT); // current
+        conditions[1] = _createClaimCondition(block.timestamp, root, TOTAL_TOKEN_AMOUNT); // next
         conditions[2] = _createClaimCondition(block.timestamp + 100, root, TOTAL_TOKEN_AMOUNT); // future
 
         vm.prank(deployer);
         dropFacet.setClaimConditions(conditions);
 
-        uint256 id = dropFacet.getActiveClaimConditionId();
+        uint256 id = dropFacet.getActiveClaimConditionId(); // fetch the boundary condition
         assertEq(id, 1);
 
         vm.warp(block.timestamp + 100);
         id = dropFacet.getActiveClaimConditionId();
         assertEq(id, 2);
+    }
+
+    function test_getActiveClaimConditionId_extended()
+        external
+        givenTokensMinted(TOTAL_TOKEN_AMOUNT * 3)
+    {
+        // Test 1: No claim conditions - should revert without underflow
+        vm.expectRevert(DropFacet__NoActiveClaimCondition.selector);
+        dropFacet.getActiveClaimConditionId();
+
+        // Test 2: Expired conditions - should revert without underflow
+        DropGroup.ClaimCondition[] memory expiredConditions = new DropGroup.ClaimCondition[](2);
+        expiredConditions[0] = _createClaimCondition(
+            block.timestamp - 200,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+        expiredConditions[0].endTimestamp = uint40(block.timestamp - 100); // Expired
+        expiredConditions[1] = _createClaimCondition(
+            block.timestamp - 100,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+        expiredConditions[1].endTimestamp = uint40(block.timestamp - 50); // Also expired
+
+        vm.prank(deployer);
+        dropFacet.setClaimConditions(expiredConditions);
+
+        vm.expectRevert(DropFacet__NoActiveClaimCondition.selector);
+        dropFacet.getActiveClaimConditionId();
+
+        // Test 3: Future conditions - should revert without underflow
+        DropGroup.ClaimCondition[] memory futureConditions = new DropGroup.ClaimCondition[](2);
+        futureConditions[0] = _createClaimCondition(
+            block.timestamp + 100,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+        futureConditions[1] = _createClaimCondition(
+            block.timestamp + 200,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+
+        vm.prank(deployer);
+        dropFacet.setClaimConditions(futureConditions);
+
+        vm.expectRevert(DropFacet__NoActiveClaimCondition.selector);
+        dropFacet.getActiveClaimConditionId();
+
+        // Test 4: Valid active condition - should return correct ID
+        DropGroup.ClaimCondition[] memory validConditions = new DropGroup.ClaimCondition[](3);
+        validConditions[0] = _createClaimCondition(block.timestamp - 100, root, TOTAL_TOKEN_AMOUNT);
+        validConditions[0].endTimestamp = uint40(block.timestamp - 50); // Expired
+        validConditions[1] = _createClaimCondition(block.timestamp - 50, root, TOTAL_TOKEN_AMOUNT); // Active (no end time)
+        validConditions[2] = _createClaimCondition(block.timestamp + 100, root, TOTAL_TOKEN_AMOUNT); // Future
+
+        vm.prank(deployer);
+        dropFacet.setClaimConditions(validConditions);
+
+        uint256 activeConditionId = dropFacet.getActiveClaimConditionId();
+        assertEq(activeConditionId, 1, "Should return the active condition ID");
+
+        // Test 5: Multiple active conditions - should return the latest one
+        DropGroup.ClaimCondition[] memory multipleActiveConditions = new DropGroup.ClaimCondition[](
+            3
+        );
+        multipleActiveConditions[0] = _createClaimCondition(
+            block.timestamp - 100,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+        multipleActiveConditions[1] = _createClaimCondition(
+            block.timestamp - 50,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+        multipleActiveConditions[2] = _createClaimCondition(
+            block.timestamp - 25,
+            root,
+            TOTAL_TOKEN_AMOUNT
+        );
+
+        vm.prank(deployer);
+        dropFacet.setClaimConditions(multipleActiveConditions);
+
+        uint256 latestActiveId = dropFacet.getActiveClaimConditionId();
+        assertEq(latestActiveId, 2, "Should return the latest active condition ID");
+
+        // Test 6: Edge case - single condition at boundary
+        DropGroup.ClaimCondition[] memory boundaryCondition = new DropGroup.ClaimCondition[](1);
+        boundaryCondition[0] = _createClaimCondition(block.timestamp, root, TOTAL_TOKEN_AMOUNT);
+
+        vm.prank(deployer);
+        dropFacet.setClaimConditions(boundaryCondition);
+
+        uint256 boundaryId = dropFacet.getActiveClaimConditionId();
+        assertEq(boundaryId, 0, "Should handle boundary condition correctly");
     }
 
     function test_getActiveClaimConditionId_revertWhen_noActiveClaimCondition() external {


### PR DESCRIPTION
### Description

Fixed a potential underflow vulnerability in the `DropBase` contract's loop and added a script to interact with the `DropFacet` contract.

### Changes

- Fixed a potential underflow vulnerability in the `DropBase` contract by:
  - Modifying the loop decrement pattern to use unchecked math
  - Adding a break condition to safely exit the loop when reaching the start index
- Added a new interaction script `InteractDropFacet.s.sol` that:
  - Creates a test environment for the `DropFacet` contract
  - Includes a test case that verifies the proper reversion when no active claim condition exists

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines