### PR TITLE
include ephemeral solicitations in getKeySolicitations

### DIFF
--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -188,7 +188,17 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
 
     public getKeySolicitations(streamId: string): KeySolicitationContent[] {
         const stream = this.client.stream(streamId)
-        return stream?.view.getMembers().joined.get(this.userId)?.solicitations ?? []
+        const nonEphemeralSolicitations =
+            stream?.view.getMembers().joined.get(this.userId)?.solicitations ?? []
+        const ephemeralSolicitations = (this.ownEphemeralSolicitations.get(streamId) ?? []).map(
+            (s) => ({
+                deviceKey: s.deviceKey,
+                fallbackKey: s.fallbackKey,
+                isNewDevice: s.isNewDevice,
+                sessionIds: Array.from(s.missingSessionIds),
+            }),
+        )
+        return [...nonEphemeralSolicitations, ...ephemeralSolicitations]
     }
 
     /**


### PR DESCRIPTION
It seems like under certain conditions it's possible for clients to over-solicit using ephemeral solicitations.
I believe adding a check like this in `getKeySolicitations` should fix it.