### PR TITLE
Stop using optional in addEvent calls

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -161,7 +161,6 @@ describe('Bot', { sequential: true }, () => {
         )
         const addResult = await botClient.uploadDeviceKeys()
         expect(addResult).toBeDefined()
-        expect(addResult.error).toBeUndefined()
 
         const exportedDevice = await botClient.cryptoBackend?.exportDevice()
         expect(exportedDevice).toBeDefined()

--- a/packages/sdk/src/client-v2.ts
+++ b/packages/sdk/src/client-v2.ts
@@ -246,12 +246,11 @@ export const createTownsClient = async (
                             miniblockHash,
                         )
                         const eventId = bin_toHexString(event.hash)
-                        const { error } = await rpc.addEvent({
+                        await rpc.addEvent({
                             streamId: streamIdAsBytes(streamId),
                             event,
-                            optional: false,
                         })
-                        return { miniblockHash, eventId, error }
+                        return { miniblockHash, eventId }
                     } catch {
                         return undefined
                     }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -29,7 +29,6 @@ import {
     ChannelMessage_Post_Attachment,
     MemberPayload_Nft,
     CreateStreamRequest,
-    AddEventResponse_Error,
     ChunkedMedia,
     UserBio,
     Tags,
@@ -2651,11 +2650,10 @@ export class Client
             method?: string
             localId?: string
             cleartext?: Uint8Array
-            optional?: boolean
             tags?: PlainMessage<Tags>
             ephemeral?: boolean
         } = {},
-    ): Promise<{ eventId: string; error?: AddEventResponse_Error }> {
+    ): Promise<{ eventId: string }> {
         // TODO: filter this.logged payload for PII reasons
         this.logCall(
             'await makeEventAndAddToStream',
@@ -2663,7 +2661,6 @@ export class Client
             streamId,
             payload,
             options.localId,
-            options.optional,
         )
         assert(this.userStreamId !== undefined, 'userStreamId must be set')
 
@@ -2680,19 +2677,18 @@ export class Client
             isDefined(prevMiniblockNum),
             'no prev miniblock num for stream ' + streamIdAsString(streamId),
         )
-        const { eventId, error } = await this.makeEventWithHashAndAddToStream(
+        const { eventId } = await this.makeEventWithHashAndAddToStream(
             streamId,
             payload,
             prevHash,
             prevMiniblockNum,
-            options.optional,
             options.localId,
             options.cleartext,
             options.tags,
             undefined, // retryCount
             options.ephemeral,
         )
-        return { eventId, error }
+        return { eventId }
     }
 
     async makeEventWithHashAndAddToStream(
@@ -2700,13 +2696,12 @@ export class Client
         payload: PlainMessage<StreamEvent>['payload'],
         prevMiniblockHash: Uint8Array,
         prevMiniblockNum: bigint,
-        optional?: boolean,
         localId?: string,
         cleartext?: Uint8Array,
         tags?: PlainMessage<Tags>,
         retryCount?: number,
         ephemeral?: boolean,
-    ): Promise<{ prevMiniblockHash: Uint8Array; eventId: string; error?: AddEventResponse_Error }> {
+    ): Promise<{ prevMiniblockHash: Uint8Array; eventId: string }> {
         const streamIdStr = streamIdAsString(streamId)
         check(isDefined(streamIdStr) && streamIdStr !== '', 'streamId must be defined')
         const event = await makeEvent(
@@ -2731,16 +2726,15 @@ export class Client
         }
 
         try {
-            const { error } = await this.rpcClient.addEvent({
+            await this.rpcClient.addEvent({
                 streamId: streamIdAsBytes(streamId),
                 event,
-                optional,
             })
             if (localId) {
                 const stream = this.streams.get(streamId)
                 stream?.updateLocalEvent(localId, eventId, 'sent')
             }
-            return { prevMiniblockHash, eventId, error }
+            return { prevMiniblockHash, eventId }
         } catch (err) {
             // custom retry logic for addEvent
             // if we send up a stale prevMiniblockHash, the server will return a BAD_PREV_MINIBLOCK_HASH
@@ -2754,7 +2748,6 @@ export class Client
                     payload,
                     prevMiniblockHash,
                     prevMiniblockNum,
-                    optional,
                     isDefined(localId) ? eventId : undefined,
                     cleartext,
                     tags,

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -13,11 +13,7 @@ import {
     KeySolicitationItem,
 } from './decryptionExtensions'
 
-import {
-    AddEventResponse_Error,
-    EncryptedData,
-    UserInboxPayload_GroupEncryptionSessions,
-} from '@towns-protocol/proto'
+import { EncryptedData, UserInboxPayload_GroupEncryptionSessions } from '@towns-protocol/proto'
 import { make_MemberPayload_KeyFulfillment, make_MemberPayload_KeySolicitation } from './types'
 
 import { Client } from './client'
@@ -372,18 +368,21 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         deviceKey,
         sessionIds,
         ephemeral = false,
-    }: KeyFulfilmentData & { ephemeral?: boolean }): Promise<{ error?: AddEventResponse_Error }> {
+    }: KeyFulfilmentData & { ephemeral?: boolean }): Promise<{ error?: unknown }> {
         const fulfillment = make_MemberPayload_KeyFulfillment({
             userAddress: userAddress,
             deviceKey: deviceKey,
             sessionIds: sessionIds,
         })
 
-        const { error } = await this.client.makeEventAndAddToStream(streamId, fulfillment, {
-            optional: true,
-            ephemeral,
-        })
-        return { error }
+        try {
+            await this.client.makeEventAndAddToStream(streamId, fulfillment, {
+                ephemeral,
+            })
+        } catch (err) {
+            return { error: err }
+        }
+        return {}
     }
 
     public async uploadDeviceKeys(): Promise<void> {

--- a/packages/sdk/src/tests/multi/botEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/botEntitlements.test.ts
@@ -134,8 +134,7 @@ describe('bot entitlements tests', () => {
         })
 
         // This should succeed because the bot has READ permission via app entitlements
-        const { error } = await bot.makeEventAndAddToStream(restrictedChannelId!, payload)
-        expect(error).toBeUndefined()
+        await bot.makeEventAndAddToStream(restrictedChannelId!, payload)
 
         // Cleanup
         await bot.stopSync()

--- a/packages/sdk/src/tests/multi/channelSpaceSettings.test.ts
+++ b/packages/sdk/src/tests/multi/channelSpaceSettings.test.ts
@@ -171,12 +171,7 @@ describe('channelSpaceSettingsTests', () => {
         })
 
         // Set channel1 to autojoin=true
-        const { eventId, error: error3 } = await bob.updateChannelAutojoin(
-            spaceId,
-            channel1Id!,
-            true,
-        )
-        expect(error3).toBeUndefined()
+        const { eventId } = await bob.updateChannelAutojoin(spaceId, channel1Id!, true)
         expect(eventId).toBeDefined()
 
         // Validate autojoin event was emitted for channel1
@@ -314,12 +309,11 @@ describe('channelSpaceSettingsTests', () => {
         })
 
         // Set channel1 to hideUserJoinLeaveEvents=true
-        const { eventId, error: error2 } = await bob.updateChannelHideUserJoinLeaveEvents(
+        const { eventId } = await bob.updateChannelHideUserJoinLeaveEvents(
             spaceId,
             defaultChannelId,
             true,
         )
-        expect(error2).toBeUndefined()
         expect(eventId).toBeDefined()
 
         // Validate updateHideUserJoinLeaveEvent event was emitted for channel1

--- a/packages/sdk/src/tests/multi/sync-agent/syncAgents.test.ts
+++ b/packages/sdk/src/tests/multi/sync-agent/syncAgents.test.ts
@@ -146,7 +146,6 @@ describe('syncAgents.test.ts', () => {
         // bob can pin
         const result = await channel.pin(event.eventId)
         expect(result).toBeDefined()
-        expect(result.error).toBeUndefined()
         await waitFor(() =>
             expect(
                 bob.riverConnection.client?.streams.get(channelId)?.view.membershipContent.pins
@@ -156,7 +155,6 @@ describe('syncAgents.test.ts', () => {
         // bob can unpin
         const result2 = await channel.unpin(event.eventId)
         expect(result2).toBeDefined()
-        expect(result2.error).toBeUndefined()
 
         // alice can't pin yet, she doesn't have permissions
         const aliceChannel = alice.spaces.getSpace(spaceId).getChannel(channelId)
@@ -186,7 +184,6 @@ describe('syncAgents.test.ts', () => {
         // alice can pin
         const result3 = await aliceChannel.pin(event.eventId)
         expect(result3).toBeDefined()
-        expect(result3.error).toBeUndefined()
     })
 
     test('dm', async () => {

--- a/packages/sdk/src/tests/unit/decryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/unit/decryptionExtensions.test.ts
@@ -14,7 +14,6 @@ import {
     makeSessionKeys,
 } from '../../decryptionExtensions'
 import {
-    AddEventResponse_Error,
     EncryptedData,
     SessionKeysSchema,
     UserInboxPayload_GroupEncryptionSessions,
@@ -402,9 +401,7 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
         return Promise.resolve()
     }
 
-    public sendKeyFulfillment(
-        args: KeyFulfilmentData,
-    ): Promise<{ error?: AddEventResponse_Error }> {
+    public sendKeyFulfillment(args: KeyFulfilmentData): Promise<{ error?: unknown }> {
         log('sendKeyFulfillment', args)
         return Promise.resolve({})
     }
@@ -541,9 +538,7 @@ class MockGroupEncryptionClient
         return Promise.resolve()
     }
 
-    public sendKeyFulfillment(
-        _args: KeyFulfilmentData,
-    ): Promise<{ error?: AddEventResponse_Error }> {
+    public sendKeyFulfillment(_args: KeyFulfilmentData): Promise<{ error?: unknown }> {
         return Promise.resolve({})
     }
 


### PR DESCRIPTION
I did this. It was dumb.
1. it hides real errors
2. it doesn’t retry retry-able errors
3. it was dumb, sorry, i will remove it from the node as well