### PR TITLE
feat: add StreamBackwardsReconciliationThreshold on-chain setting

### DIFF
--- a/core/env/local/multi/on_chain.csv
+++ b/core/env/local/multi/on_chain.csv
@@ -21,3 +21,4 @@
 "stream.streamTrimmingMiniblocksToKeep.a5",0,1000
 "stream.enableNewSnapshotFormat",0,1
 "server.enablenode2nodeauth",0,0
+"stream.backwardsReconciliationThreshold",0,50

--- a/core/env/local/multi_ne/on_chain.csv
+++ b/core/env/local/multi_ne/on_chain.csv
@@ -21,3 +21,4 @@
 "stream.streamTrimmingMiniblocksToKeep.a5",0,1000
 "stream.enableNewSnapshotFormat",0,1
 "server.enablenode2nodeauth",0,0
+"stream.backwardsReconciliationThreshold",0,50

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -58,6 +58,10 @@ const (
 	StreamUserSettingStreamTrimmingMiniblocksToKeepConfigKey = "stream.streamTrimmingMiniblocksToKeep.a5"
 	StreamEnableNewSnapshotFormatConfigKey                   = "stream.enableNewSnapshotFormat"
 	ServerEnableNode2NodeAuthConfigKey                       = "server.enablenode2nodeauth"
+	// StreamBackwardsReconciliationThresholdConfigKey is the threshold in miniblocks that determines
+	// whether to use backwards or forward reconciliation. If a stream is behind by more than this
+	// number of miniblocks, backwards reconciliation is used; otherwise forward reconciliation is used.
+	StreamBackwardsReconciliationThresholdConfigKey = "stream.backwardsReconciliationThreshold"
 
 	// StreamDistributionExtraCandidatesCountCountKey is the key for many extra nodes on top of
 	// replication factor must be picked as candidates to place a stream on. From these candidates
@@ -139,14 +143,22 @@ type OnChainSettings struct {
 
 	// StreamSnapshotIntervalInMiniblocks is the interval in miniblocks between snapshots.
 	StreamSnapshotIntervalInMiniblocks uint64 `mapstructure:"stream.snapshotIntervalInMiniblocks"`
+
 	// StreamTrimmingMiniblocksToKeep is the number of miniblocks to keep before the last snapshot.
 	// Defined with the default value and per stream type.
 	StreamTrimmingMiniblocksToKeep StreamTrimmingMiniblocksToKeepSettings `mapstructure:",squash"`
+
 	// StreamDistribution holds settings for the stream distribution algorithm.
 	StreamDistribution StreamDistribution `mapstructure:",squash"`
+
 	// ServerEnableNode2NodeAuth indicates whether node-to-node authentication is enabled.
 	// Options: 1 means enabled, 0 means disabled.
 	ServerEnableNode2NodeAuth uint64 `mapstructure:"server.enablenode2nodeauth"`
+
+	// StreamBackwardsReconciliationThreshold is the threshold in miniblocks that determines
+	// whether to use backwards or forward reconciliation. If a stream is behind by more than this
+	// number of miniblocks, backwards reconciliation is used; otherwise forward reconciliation is used.
+	StreamBackwardsReconciliationThreshold uint64 `mapstructure:"stream.backwardsReconciliationThreshold"`
 }
 
 type XChainSettings struct {
@@ -262,6 +274,8 @@ func DefaultOnChainSettings() *OnChainSettings {
 		},
 
 		ServerEnableNode2NodeAuth: 0,
+
+		StreamBackwardsReconciliationThreshold: 50,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds on-chain configuration setting `StreamBackwardsReconciliationThreshold` to control when backwards vs forward reconciliation is used for stream synchronization.

## Context

This implements the on-chain setting needed for the backwards reconciliation feature. The threshold determines the reconciliation strategy based on how far behind a stream is:
- If behind by more than the threshold → use backwards reconciliation
- If behind by less than or equal to the threshold → use forward reconciliation

## Changes

- Added `StreamBackwardsReconciliationThresholdConfigKey` constant
- Added `StreamBackwardsReconciliationThreshold` field to `OnChainSettings` struct
- Set default value to 50 miniblocks
- Updated local environment CSV configuration files

## Test Plan

- [x] Verified code compiles successfully
- [x] Ran existing on-chain configuration tests
- [x] Setting follows established patterns for on-chain configuration

## Future Work

This setting will be used by the stream reconciliation logic (to be implemented separately) to determine the optimal sync strategy for streams that are behind.