### PR TITLE
Update the decryption extensions queue again

### DIFF
--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -109,12 +109,6 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             sigBundle: EventSignatureBundle,
         ) => this.enqueueInitKeySolicitations(streamId, eventHashStr, members, sigBundle)
 
-        const onStreamInitialized = (streamId: string) => {
-            if (isUserInboxStreamId(streamId)) {
-                this.enqueueNewMessageDownload()
-            }
-        }
-
         const onStreamSyncActive = (active: boolean) => {
             this.log.info('onStreamSyncActive', active)
             if (!active) {
@@ -133,7 +127,6 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         client.on('updatedKeySolicitation', onKeySolicitation)
         client.on('initKeySolicitations', onInitKeySolicitations)
         client.on('streamNewUserJoined', onMembershipChange)
-        client.on('streamInitialized', onStreamInitialized)
         client.on('streamSyncActive', onStreamSyncActive)
         client.on('ephemeralKeyFulfillment', onEphemeralKeyFulfillment)
 
@@ -145,7 +138,6 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
             client.off('updatedKeySolicitation', onKeySolicitation)
             client.off('initKeySolicitations', onInitKeySolicitations)
             client.off('streamNewUserJoined', onMembershipChange)
-            client.off('streamInitialized', onStreamInitialized)
             client.off('streamSyncActive', onStreamSyncActive)
             client.off('ephemeralKeyFulfillment', onEphemeralKeyFulfillment)
         }

--- a/packages/sdk/src/decryptionExtensions.ts
+++ b/packages/sdk/src/decryptionExtensions.ts
@@ -618,7 +618,9 @@ export abstract class BaseDecryptionExtensions {
             this.streamQueues.isEmpty()
         ) {
             this.log.debug('no more work to do, setting status to done')
-            this.setStatus(DecryptionStatus.done)
+            if (this.allQueueRunners.every((x) => !x.inProgress)) {
+                this.setStatus(DecryptionStatus.done)
+            }
             return
         }
 

--- a/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Client } from '../../client'
-import { dlog } from '@towns-protocol/dlog'
+import { dlog, shortenHexString } from '@towns-protocol/dlog'
 import { isDefined } from '../../check'
 import { TestClientOpts, makeTestClient, makeUniqueSpaceStreamId, waitFor } from '../testUtils'
 import { Stream } from '../../stream'
@@ -44,12 +44,14 @@ describe('ClientDecryptionExtensions', () => {
     }
 
     const waitForMessages = async (client: Client, streamId: string, bodys: string[]) => {
-        log('waitForMessages', client.userId, streamId, bodys)
+        log('waitForMessages:', client.userId, client.logId, streamId, bodys)
         const stream = await client.waitForStream(streamId)
+        log('waitForMessages stream:', client.userId, client.logId, streamId, stream.view.timeline)
+
         return waitFor(
             () => {
                 const messages = getDecryptedChannelMessages(stream)
-                expect(messages).toEqual(bodys)
+                expect(messages, `messages for ${client.logId}`).toEqual(bodys)
             },
             { timeoutMS: 15000 },
         )
@@ -137,8 +139,6 @@ describe('ClientDecryptionExtensions', () => {
             context: alice1.signerContext,
             deviceId: 'alice2',
         })
-
-        await expect(alice2_restarted.waitForStream(streamId)).resolves.not.toThrow()
 
         // she should have the keys because bob2 should share with existing members
         await expect(

--- a/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/multi_ne/clientDecryptionExtensions.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Client } from '../../client'
-import { dlog, shortenHexString } from '@towns-protocol/dlog'
+import { dlog } from '@towns-protocol/dlog'
 import { isDefined } from '../../check'
 import { TestClientOpts, makeTestClient, makeUniqueSpaceStreamId, waitFor } from '../testUtils'
 import { Stream } from '../../stream'


### PR DESCRIPTION


1. don’t double enqueue the user inbox messages task
2. don’t wait for the user inbox stream to sync before decrypting
3. sort own and ephemeral solicitations and make sure that we only respond to solicitations if the stream is up to date