### PR TITLE
Update “sync timed out” error to “sync stalled”

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -852,7 +852,7 @@ export class SyncedStreamsLoop {
                                                 syncStartedAt: this.syncStartedAt,
                                                 duration,
                                             },
-                                            `sync timed out after ${duration}ms`,
+                                            `sync has stalled after ${duration}ms`,
                                         )
                                         this.clientEmitter.emit('streamSyncTimedOut', {
                                             duration,


### PR DESCRIPTION
since the sync hasn’t failed, it will pick back up