### PR TITLE
Client - Re-Encryption bug: When decrypting also update the copy of the event in the local minipool

### DIFF
--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -563,6 +563,11 @@ export class StreamStateView {
         this.membershipContent.onDecryptedContent(eventId, content, emitter)
         this.getContent().onDecryptedContent(eventId, content, emitter)
 
+        const minipoolEvent = this.minipoolEvents.get(eventId)
+        if (minipoolEvent) {
+            minipoolEvent.decryptedContent = content
+        }
+
         const timelineEvent = this.streamsView.timelinesView.streamEventDecrypted(
             this.streamId,
             eventId,


### PR DESCRIPTION
When decrypting also update the copy of the event in the local minipool
If an event gets decrypted before it is confirmed, confirming it could undo the decryption
This has been a bug since i simplified the timeline