### PR TITLE
Ephemeral messages: allow unordered messages in test

### DIFF
--- a/core/node/rpc/stream_test.go
+++ b/core/node/rpc/stream_test.go
@@ -312,13 +312,14 @@ func TestEphemeralMessageInChat(t *testing.T) {
 				return
 			}
 
-			// Check that all 4 ephemeral messages were received
-			for i, expectedMessage := range ephemeralMessages {
-				if syncedMessages[i].message != expectedMessage {
-					collect.Errorf("client %d: expected message %d to be '%s', got '%s'",
-						clientIdx, i, expectedMessage, syncedMessages[i].message)
-				}
+			// Check that all 4 ephemeral messages were received (order doesn't matter)
+			receivedMessageStrings := make([]string, len(syncedMessages))
+			for i, msg := range syncedMessages {
+				receivedMessageStrings[i] = msg.message
 			}
+
+			assert.ElementsMatch(collect, ephemeralMessages, receivedMessageStrings,
+				"client %d: messages don't match", clientIdx)
 		}
 	}, 20*time.Second, 25*time.Millisecond)
 


### PR DESCRIPTION
### Description

messages are only ordered once they make it into a miniblock. Before that they are added to the minipool and there is no guaranteed ordering there.
Fixing the tests so unordered messages are ok
