### PR TITLE
Stop scrolling back on all channels by default

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -428,7 +428,6 @@ export class Client
         stream.on('userJoinedStream', (s) => void this.onJoinedStream(s))
         stream.on('userInvitedToStream', (s) => void this.onInvitedToStream(s))
         stream.on('userLeftStream', (s) => void this.onLeftStream(s))
-        this.on('streamInitialized', (s) => void this.onStreamInitialized(s))
         this.on('streamUpToDate', (s) => void this.onStreamUpToDate(s))
 
         const streamIds = Object.entries(stream.view.userContent.streamMemberships).reduce(
@@ -1715,22 +1714,6 @@ export class Client
     private onLeftStream = async (streamId: string): Promise<void> => {
         this.logEvent('onLeftStream', streamId)
         return await this.streams.removeStreamFromSync(streamId)
-    }
-
-    private onStreamInitialized = (streamId: string): void => {
-        const scrollbackUntilContentFound = async () => {
-            const stream = this.streams.get(streamId)
-            if (!stream) {
-                return
-            }
-            while (stream.view.getContent().needsScrollback()) {
-                const scrollback = await this.scrollback(streamId)
-                if (scrollback.terminus) {
-                    break
-                }
-            }
-        }
-        void scrollbackUntilContentFound()
     }
 
     private onStreamUpToDate = (streamId: string): void => {

--- a/packages/sdk/src/streamStateView_AbstractContent.ts
+++ b/packages/sdk/src/streamStateView_AbstractContent.ts
@@ -71,8 +71,4 @@ export abstract class StreamStateView_AbstractContent {
         }
         return streamIdToBytes(streamParentId)
     }
-
-    needsScrollback(): boolean {
-        return false
-    }
 }

--- a/packages/sdk/src/streamStateView_Channel.ts
+++ b/packages/sdk/src/streamStateView_Channel.ts
@@ -10,7 +10,6 @@ import { DecryptedContent } from './encryptedContentTypes'
 export class StreamStateView_Channel extends StreamStateView_AbstractContent {
     readonly streamId: string
     spaceId: string = ''
-    private reachedRenderableContent = false
 
     constructor(streamId: string) {
         super()
@@ -19,10 +18,6 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
 
     getStreamParentId(): string | undefined {
         return this.spaceId
-    }
-
-    needsScrollback(): boolean {
-        return !this.reachedRenderableContent
     }
 
     applySnapshot(
@@ -46,10 +41,6 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
             case 'inception':
                 break
             case 'message':
-                // if we have a refEventId it means we're a reaction or thread message
-                if (!payload.content.value.refEventId) {
-                    this.reachedRenderableContent = true
-                }
                 this.decryptEvent(
                     'channelMessage',
                     event,
@@ -79,9 +70,6 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
             case 'inception':
                 break
             case 'message':
-                if (!payload.content.value.refEventId) {
-                    this.reachedRenderableContent = true
-                }
                 this.decryptEvent(
                     'channelMessage',
                     event,


### PR DESCRIPTION
in the spirit of only sync the channel you’re currently looking at, stop scrolling back on channels in the sdk
we have duplciate scrollback logic in the app
cursory testing doesn’t turn over any problems