### PR TITLE
fix: correct caller information in zap logger wrapper

### DIFF
--- a/core/node/logging/log.go
+++ b/core/node/logging/log.go
@@ -112,9 +112,9 @@ func Init(
 		}
 
 		if len(defaultCores) > 1 {
-			defaultLogger := zap.New(zapcore.NewTee(defaultCores...))
-			miniblockLogger := zap.New(zapcore.NewTee(miniblockCores...))
-			rpcLogger := zap.New(zapcore.NewTee(rpcCores...))
+			defaultLogger := zap.New(zapcore.NewTee(defaultCores...), zap.AddCaller(), zap.AddCallerSkip(1))
+			miniblockLogger := zap.New(zapcore.NewTee(miniblockCores...), zap.AddCaller(), zap.AddCallerSkip(1))
+			rpcLogger := zap.New(zapcore.NewTee(rpcCores...), zap.AddCaller(), zap.AddCallerSkip(1))
 
 			zap.ReplaceGlobals(defaultLogger)
 
@@ -126,9 +126,9 @@ func Init(
 			}
 
 		} else if len(defaultCores) == 1 {
-			defaultLogger := zap.New(defaultCores[0])
-			miniblockLogger := zap.New(miniblockCores[0])
-			rpcLogger := zap.New(rpcCores[0])
+			defaultLogger := zap.New(defaultCores[0], zap.AddCaller(), zap.AddCallerSkip(1))
+			miniblockLogger := zap.New(miniblockCores[0], zap.AddCaller(), zap.AddCallerSkip(1))
+			rpcLogger := zap.New(rpcCores[0], zap.AddCaller(), zap.AddCallerSkip(1))
 
 			zap.ReplaceGlobals(defaultLogger)
 
@@ -174,7 +174,7 @@ func LoggerWithWriter(level zapcore.Level, writer zapcore.WriteSyncer) *Log {
 	encoder := NewJSONEncoder(DefaultZapEncoderConfig())
 
 	core := zapcore.NewCore(encoder, writer, level)
-	logger := zap.New(core, zap.AddCaller())
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
 
 	sugar := logger.Sugar()
 


### PR DESCRIPTION
## Summary
- Added `zap.AddCallerSkip(1)` to all logger creation points in the logging wrapper
- This ensures logs show the actual calling function instead of the wrapper method
- Fixes incorrect function names in logs (e.g., now shows `worker.Start` instead of `logging.(*Log).Info`)

## Test plan
- [x] Created and ran a test program to verify the fix works correctly
- [x] Logs now display the correct calling function names
- [x] All existing logging functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)