### PR TITLE
Flaky test: Allow more than one fulfillment message

### DIFF
--- a/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
+++ b/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
@@ -120,9 +120,9 @@ describe('ephemeralEvents', () => {
             ephemeralSolicitations.push(ephemeral ?? false)
         })
 
-        const ephemeralFulfillments: boolean[] = []
-        alice.on('ephemeralKeyFulfillment', (_) => {
-            ephemeralFulfillments.push(true)
+        const ephemeralFulfillments: { userAddress: Uint8Array }[] = []
+        alice.on('ephemeralKeyFulfillment', (event) => {
+            ephemeralFulfillments.push({ userAddress: event.userAddress })
         })
 
         await waitFor(() => {
@@ -139,7 +139,12 @@ describe('ephemeralEvents', () => {
         await expect(chuckEventDecryptedPromise).resolves.not.toThrow()
 
         expect(ephemeralSolicitations).toEqual([true])
-        await waitFor(() => expect(ephemeralFulfillments.length).toEqual(1))
-        expect(ephemeralFulfillments).toEqual([true])
+        
+        // Wait for at least one ephemeral fulfillment
+        await waitFor(() => expect(ephemeralFulfillments.length).toBeGreaterThanOrEqual(1))
+        
+        // Verify all fulfillments are from different clients
+        const uniqueSenders = new Set(ephemeralFulfillments)
+        expect(uniqueSenders.size).toEqual(ephemeralFulfillments.length)
     })
 })

--- a/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
+++ b/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
@@ -139,10 +139,10 @@ describe('ephemeralEvents', () => {
         await expect(chuckEventDecryptedPromise).resolves.not.toThrow()
 
         expect(ephemeralSolicitations).toEqual([true])
-        
+
         // Wait for at least one ephemeral fulfillment
         await waitFor(() => expect(ephemeralFulfillments.length).toBeGreaterThanOrEqual(1))
-        
+
         // Verify all fulfillments are from different clients
         const uniqueSenders = new Set(ephemeralFulfillments)
         expect(uniqueSenders.size).toEqual(ephemeralFulfillments.length)

--- a/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
+++ b/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
@@ -5,7 +5,7 @@
 import { createEventDecryptedPromise, makeTestClient, waitFor } from '../testUtils'
 import { Client } from '../../client'
 import { make_MemberPayload_KeyFulfillment, make_MemberPayload_KeySolicitation } from '../../types'
-import { hexToBytes } from 'ethereum-cryptography/utils'
+import { hexToBytes, bytesToHex } from 'ethereum-cryptography/utils'
 import { MembershipOp } from '@towns-protocol/proto'
 
 // Scaffold for ephemeral events tests
@@ -120,9 +120,9 @@ describe('ephemeralEvents', () => {
             ephemeralSolicitations.push(ephemeral ?? false)
         })
 
-        const ephemeralFulfillments: { userAddress: Uint8Array }[] = []
+        const ephemeralFulfillments: string[] = []
         alice.on('ephemeralKeyFulfillment', (event) => {
-            ephemeralFulfillments.push({ userAddress: event.userAddress })
+            ephemeralFulfillments.push(bytesToHex(event.userAddress))
         })
 
         await waitFor(() => {


### PR DESCRIPTION
### Description

any online client can respond to a key solicitation request, and it's possible to get multiple fulfillments for a single key solicitation message.
Fix the test to allow more than a single fulfillment message