### PR TITLE
fix(contract): prevent point farming in `executeSwapWithPermit`

### DIFF
--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -101,7 +101,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         );
 
         // post-swap processing (points minting and events)
-        _afterSwap(params, amountOut, protocolFee, poster);
+        _afterSwap(params, amountOut, protocolFee, poster, msg.sender);
 
         // handle refunds of unconsumed input tokens
         _handleRefunds(params.tokenIn, tokenInBalanceBefore);
@@ -134,7 +134,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         );
 
         // post-swap processing (points minting and events)
-        _afterSwap(params, amountOut, protocolFee, poster);
+        _afterSwap(params, amountOut, protocolFee, poster, permit.owner);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -177,11 +177,13 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
     /// @param amountOut The amount of output tokens received
     /// @param protocolFee The protocol fee collected for points calculation
     /// @param poster The swap poster address
+    /// @param payer The address that should receive the points
     function _afterSwap(
         ExactInputParams calldata params,
         uint256 amountOut,
         uint256 protocolFee,
-        address poster
+        address poster,
+        address payer
     ) internal {
         // mint points based on the protocol fee if ETH is involved
         if (
@@ -194,7 +196,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
                 ITownsPointsBase.Action.Swap,
                 abi.encode(protocolFee)
             );
-            _mintPoints(airdropDiamond, msg.sender, points);
+            _mintPoints(airdropDiamond, payer, points);
         }
 
         emit SwapExecuted(

--- a/packages/contracts/test/spaces/swap/SwapFacet.t.sol
+++ b/packages/contracts/test/spaces/swap/SwapFacet.t.sol
@@ -822,10 +822,11 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
 
     function test_executeSwapWithPermit(
         uint256 privateKey,
+        address caller,
         address recipient,
         uint256 amountIn,
         uint256 amountOut
-    ) external givenMembership(user) {
+    ) external givenMembership(caller) {
         vm.assume(recipient != address(0) && recipient != POSTER && recipient != feeRecipient);
 
         privateKey = boundPrivateKey(privateKey);
@@ -876,7 +877,7 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
             POSTER
         );
 
-        vm.prank(user);
+        vm.prank(caller);
         uint256 actualAmountOut = swapFacet.executeSwapWithPermit(
             params,
             routerParams,
@@ -896,16 +897,29 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
             POSTER_BPS
         );
 
+        // verify no points were minted (ERC20-to-ERC20 swap, no ETH involved)
+        assertEq(
+            riverAirdrop.balanceOf(owner),
+            0,
+            "No points should be minted to permit owner in ERC20-to-ERC20 swap"
+        );
+        assertEq(
+            riverAirdrop.balanceOf(caller),
+            0,
+            "No points should be minted to caller in ERC20-to-ERC20 swap"
+        );
+
         // verify no leftover tokens in SwapFacet
         assertEq(token0.balanceOf(everyoneSpace), 0, "No token0 should remain in SwapFacet");
     }
 
     function test_executeSwapWithPermit_swapTokenToEth(
         uint256 privateKey,
+        address caller,
         address recipient,
         uint256 amountIn,
         uint256 amountOut
-    ) external givenMembership(user) assumeEOA(recipient) {
+    ) external givenMembership(caller) assumeEOA(recipient) {
         vm.assume(recipient != POSTER && recipient != feeRecipient);
         vm.assume(recipient.balance == 0);
 
@@ -954,8 +968,9 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
         uint256 protocolFee = BasisPoints.calculate(amountOut, PROTOCOL_BPS);
         uint256 expectedPoints = _getPoints(protocolFee);
 
+        // owner is the permit signer who should get points
         vm.expectEmit(address(riverAirdrop));
-        emit IERC20.Transfer(address(0), user, expectedPoints); // user is the one calling the function
+        emit IERC20.Transfer(address(0), owner, expectedPoints);
 
         vm.expectEmit(everyoneSpace);
         emit SwapExecuted(
@@ -967,7 +982,7 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
             POSTER
         );
 
-        vm.prank(user);
+        vm.prank(caller);
         swapFacet.executeSwapWithPermit(params, routerParams, permitParams, POSTER);
 
         _verifySwapResults(
@@ -981,12 +996,17 @@ contract SwapFacetTest is BaseSetup, SwapTestBase, ISwapFacetBase, IOwnableBase,
             POSTER_BPS
         );
 
-        // verify points were minted correctly to the caller (user)
+        // verify points were minted correctly to the permit owner (owner)
         assertEq(
-            riverAirdrop.balanceOf(user),
+            riverAirdrop.balanceOf(owner),
             expectedPoints,
-            "ETH output swap should mint correct points to caller"
+            "ETH output swap should mint correct points to permit owner"
         );
+
+        // verify caller did not receive extra points (when caller != owner)
+        if (caller != owner) {
+            assertEq(riverAirdrop.balanceOf(caller), 0, "Caller should not receive points");
+        }
 
         // verify no leftover tokens in SwapFacet
         assertEq(token0.balanceOf(everyoneSpace), 0, "No token0 should remain in SwapFacet");


### PR DESCRIPTION
### Description

Fixes a medium-severity audit finding where any member could submit another member's swap using `executeSwapWithPermit` and receive the airdrop points intended for the permit signer. This created an incentive for users to monitor and front-run others' swaps to farm points.

The fix ensures points are always minted to the permit owner (`permit.owner`) instead of the transaction submitter (`msg.sender`) in permit-based swaps, while maintaining backward compatibility for regular swaps.

### Changes

- Modified `_afterSwap` function to accept a `payer` parameter instead of hardcoding `msg.sender`
- Updated `executeSwap` to pass `msg.sender` as payer (maintains existing behavior)
- Updated `executeSwapWithPermit` to pass `permit.owner` as payer (fixes the vulnerability)
- Enhanced `test_executeSwapWithPermit_swapTokenToEth` with fuzzed `caller` parameter to verify points go to permit owner
- Enhanced `test_executeSwapWithPermit` with fuzzed `caller` parameter to verify no points are minted in ERC20-to-ERC20 swaps
- Added comprehensive assertions to prevent regression of the point farming vulnerability

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable  
- [x] Changes adhere to the repository's contribution guidelines