### PR TITLE
fix(contract): resolve incorrect poster fee refund in `SwapFacet`

### DIFF
--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -98,7 +98,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         );
 
         // handle refunds of unconsumed input tokens
-        _handleRefunds(params.tokenIn, tokenInBalanceBefore);
+        _handleRefunds(params.tokenIn, tokenInBalanceBefore, poster);
 
         // reset approval for ERC20 tokens
         if (!isNativeToken) params.tokenIn.safeApprove(swapRouter, 0);
@@ -210,14 +210,20 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
     /// @notice Handles refunds of unconsumed input tokens back to the caller
     /// @param tokenIn The input token address
     /// @param tokenInBalanceBefore The balance before receiving tokens from user
-    function _handleRefunds(address tokenIn, uint256 tokenInBalanceBefore) internal {
+    /// @param poster The poster address for this swap
+    function _handleRefunds(
+        address tokenIn,
+        uint256 tokenInBalanceBefore,
+        address poster
+    ) internal {
         uint256 currentBalance = _getBalance(tokenIn);
 
         // calculate base refund amount
         uint256 refundAmount = FixedPointMathLib.zeroFloorSub(currentBalance, tokenInBalanceBefore);
 
         // for ETH, subtract poster fee if it was collected to space
-        if (tokenIn == CurrencyTransfer.NATIVE_TOKEN && !_isForwardPosterFee()) {
+        // this happens when poster is the space itself (regardless of forwardPosterFee setting)
+        if (tokenIn == CurrencyTransfer.NATIVE_TOKEN && poster == address(this)) {
             // get the poster fee that was collected to space
             (, uint16 posterBps, ) = getSwapFees();
             uint256 posterFee = BasisPoints.calculate(msg.value, posterBps);


### PR DESCRIPTION
### Description

Fixes L-2 audit finding where poster fees were incorrectly refunded when `forwardPosterFee=true` but `poster=address(this)`. When a space acts as its own poster, fees should remain with the space regardless of the `forwardPosterFee` setting.

### Changes

- Modified `_handleRefunds` function to accept `poster` parameter
- Simplified refund logic to check `poster == address(this)` instead of complex boolean condition
- Enhanced test coverage with `forwardPosterFee` fuzzing to cover both edge cases
- Optimized test assertions by removing redundant intermediate calculations
- Fixed edge case in fee manipulation attack test

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable  
- [x] Changes adhere to the repository's contribution guidelines