### PR TITLE
refactor(contract): tidy imports and enhance dependency handling

### DIFF
--- a/packages/contracts/src/spaces/facets/DependencyLib.sol
+++ b/packages/contracts/src/spaces/facets/DependencyLib.sol
@@ -2,22 +2,24 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IImplementationRegistry} from "src/factory/facets/registry/IImplementationRegistry.sol";
-import {IAppRegistry} from "src/apps/facets/registry/IAppRegistry.sol";
+import {IAppRegistry} from "../../apps/facets/registry/IAppRegistry.sol";
+import {IImplementationRegistry} from "../../factory/facets/registry/IImplementationRegistry.sol";
 
 // libraries
-import {MembershipStorage} from "src/spaces/facets/membership/MembershipStorage.sol";
+import {MembershipStorage} from "./membership/MembershipStorage.sol";
 
 // contracts
 
-///@title DependencyLib
-///@dev Library for resolving contract dependencies via the Implementation Registry. Used for retrieving the latest implementation addresses for named dependencies within a space.
+/// @title DependencyLib
+/// @dev Library for resolving contract dependencies via the Implementation Registry. Used for
+/// retrieving the latest implementation addresses for named dependencies within a space.
 library DependencyLib {
     // Constants for dependency names
     bytes32 internal constant RIVER_AIRDROP = bytes32("RiverAirdrop");
     bytes32 internal constant SPACE_OPERATOR = bytes32("SpaceOperator"); // BaseRegistry
     bytes32 internal constant SPACE_OWNER = bytes32("Space Owner");
     bytes32 internal constant APP_REGISTRY = bytes32("AppRegistry");
+    bytes32 internal constant SWAP_ROUTER = bytes32("SwapRouter");
 
     /// @notice Retrieves the latest implementation address for a given dependency name.
     /// @dev Looks up the dependency in the Implementation Registry associated with the space factory.
@@ -32,22 +34,21 @@ library DependencyLib {
         return registry.getLatestImplementation(dependencyName);
     }
 
-    ///@notice Retrieves the latest implementation addresses for multiple dependency names.
-    ///@dev Batch resolves dependencies using the Implementation Registry associated with the space factory.
-    ///@param ms The MembershipStorage layout containing the spaceFactory address.
-    ///@param deps An array of keccak256 hashes of dependency names to resolve.
-    ///@return An array of addresses corresponding to the latest implementations for each dependency.
+    /// @notice Retrieves the latest implementation addresses for multiple dependency names.
+    /// @dev Batch resolves dependencies using the Implementation Registry associated with the space factory.
+    /// @param ms The MembershipStorage layout containing the spaceFactory address.
+    /// @param deps An array of keccak256 hashes of dependency names to resolve.
+    /// @return dependencies An array of addresses corresponding to the latest implementations for each dependency.
     function getDependencies(
         MembershipStorage.Layout storage ms,
         bytes32[] memory deps
-    ) internal view returns (address[] memory) {
+    ) internal view returns (address[] memory dependencies) {
         uint256 length = deps.length;
-        address[] memory dependencies = new address[](length);
+        dependencies = new address[](length);
         IImplementationRegistry registry = IImplementationRegistry(ms.spaceFactory);
         for (uint256 i; i < length; ++i) {
             dependencies[i] = registry.getLatestImplementation(deps[i]);
         }
-        return dependencies;
     }
 
     /// @notice Retrieves the latest implementation address for the App Registry dependency.

--- a/packages/contracts/src/spaces/facets/Entitled.sol
+++ b/packages/contracts/src/spaces/facets/Entitled.sol
@@ -8,12 +8,12 @@ import {IEntitlementBase} from "../entitlements/IEntitlement.sol";
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {PausableStorage} from "@towns-protocol/diamond/src/facets/pausable/PausableStorage.sol";
+import {ERC721AStorage} from "../../diamond/facets/token/ERC721A/ERC721AStorage.sol";
 import {CustomRevert} from "../../utils/libraries/CustomRevert.sol";
 import {EntitlementsManagerStorage} from "./entitlements/EntitlementsManagerStorage.sol";
 import {MembershipStorage} from "./membership/MembershipStorage.sol";
-import {ERC721AStorage} from "../../diamond/facets/token/ERC721A/ERC721AStorage.sol";
 import {BanningStorage} from "./banning/BanningStorage.sol";
-import {PausableStorage} from "@towns-protocol/diamond/src/facets/pausable/PausableStorage.sol";
 import {AppAccountStorage} from "./account/AppAccountStorage.sol";
 import {DependencyLib} from "./DependencyLib.sol";
 

--- a/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
+++ b/packages/contracts/src/spaces/facets/swap/SwapFacet.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.23;
 // interfaces
 import {ITownsPointsBase} from "../../../airdrop/points/ITownsPoints.sol";
 import {IPlatformRequirements} from "../../../factory/facets/platform/requirements/IPlatformRequirements.sol";
-import {IImplementationRegistry} from "../../../factory/facets/registry/IImplementationRegistry.sol";
 import {ISwapRouter} from "../../../router/ISwapRouter.sol";
 import {ISwapFacet} from "./ISwapFacet.sol";
 
@@ -12,6 +11,7 @@ import {ISwapFacet} from "./ISwapFacet.sol";
 import {BasisPoints} from "../../../utils/libraries/BasisPoints.sol";
 import {CurrencyTransfer} from "../../../utils/libraries/CurrencyTransfer.sol";
 import {CustomRevert} from "../../../utils/libraries/CustomRevert.sol";
+import {DependencyLib} from "../DependencyLib.sol";
 import {MembershipStorage} from "../membership/MembershipStorage.sol";
 import {SwapFacetStorage} from "./SwapFacetStorage.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
@@ -31,9 +31,6 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
 
     /// @notice Maximum fee in basis points (2%)
     uint16 internal constant MAX_FEE_BPS = 200;
-
-    /// @dev The implementation ID for the SwapRouter
-    bytes32 internal constant SWAP_ROUTER_DIAMOND = bytes32("SwapRouter");
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                       ADMIN FUNCTIONS                      */
@@ -143,10 +140,7 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
 
     /// @inheritdoc ISwapFacet
     function getSwapRouter() public view returns (address) {
-        return
-            IImplementationRegistry(_getSpaceFactory()).getLatestImplementation(
-                SWAP_ROUTER_DIAMOND
-            );
+        return DependencyLib.getDependency(MembershipStorage.layout(), DependencyLib.SWAP_ROUTER);
     }
 
     /// @inheritdoc ISwapFacet
@@ -244,12 +238,8 @@ contract SwapFacet is ISwapFacet, ReentrancyGuardTransient, Entitled, PointsBase
         }
     }
 
-    function _getSpaceFactory() internal view returns (address) {
-        return MembershipStorage.layout().spaceFactory;
-    }
-
     function _getPlatformRequirements() internal view returns (IPlatformRequirements) {
-        return IPlatformRequirements(_getSpaceFactory());
+        return IPlatformRequirements(MembershipStorage.layout().spaceFactory);
     }
 
     /// @notice Gets the balance of a token for this contract


### PR DESCRIPTION
- Reorganized import paths across files for consistency and readability.
- Added `SWAP_ROUTER` constant in `DependencyLib` and refactored `SwapFacet.getSwapRouter` to utilize it.
- Removed redundant constants like `SWAP_ROUTER_DIAMOND` and `_getSpaceFactory` from `SwapFacet`.
- Improved `getDependencies` logic by updating returned naming for clarity.
- General cleanup and formatting updates across files.