### PR TITLE
refactor(contract): standardize storage handling with `StoragePointer`

### DIFF
--- a/packages/contracts/src/spaces/facets/dispatcher/DispatcherStorage.sol
+++ b/packages/contracts/src/spaces/facets/dispatcher/DispatcherStorage.sol
@@ -1,22 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
-
 library DispatcherStorage {
     // keccak256(abi.encode(uint256(keccak256("spaces.facets.dispatcher.storage")) - 1)) &
     // ~bytes32(uint256(0xff))
     bytes32 internal constant STORAGE_SLOT =
         0x34516f6fe09a043d57f1ff579a303a7ae85314751c77b4eb1a55837604a86e00;
-
-    // transactionData {
-    //   bytes data
-    //   uint256 count
-    // }
 
     struct Layout {
         mapping(bytes32 => uint256) transactionNonce;
@@ -25,9 +14,8 @@ library DispatcherStorage {
     }
 
     function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = STORAGE_SLOT;
         assembly {
-            l.slot := slot
+            l.slot := STORAGE_SLOT
         }
     }
 }

--- a/packages/contracts/src/spaces/facets/dispatcher/IDispatcher.sol
+++ b/packages/contracts/src/spaces/facets/dispatcher/IDispatcher.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
-
 interface IDispatcherBase {
     error Dispatcher__TransactionAlreadyExists();
 }

--- a/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
+++ b/packages/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
@@ -140,7 +140,7 @@ abstract contract MembershipJoin is
     }
 
     function _rejectMembership(bytes32 transactionId, address receiver) internal {
-        _captureData(transactionId, "");
+        _deleteCapturedData(transactionId);
         _refundBalance(transactionId, receiver);
         emit MembershipTokenRejected(receiver);
     }
@@ -149,8 +149,6 @@ abstract contract MembershipJoin is
         // Check if there are any prepaid memberships available
         uint256 prepaidSupply = _getPrepaidSupply();
         if (prepaidSupply > 0) return 0; // If prepaid memberships exist, no payment is required
-
-        if (price == 0) return 0; // If the price is zero, no payment is required
 
         return price;
     }
@@ -373,7 +371,7 @@ abstract contract MembershipJoin is
         if (ownerProceeds != 0) _transferIn(payer, ownerProceeds);
 
         _releaseCapturedValue(transactionId, paymentRequired);
-        _captureData(transactionId, "");
+        _deleteCapturedData(transactionId);
 
         _mintMembershipPoints(receiver, membershipPrice);
     }

--- a/packages/contracts/src/spaces/facets/xchain/SpaceEntitlementGated.sol
+++ b/packages/contracts/src/spaces/facets/xchain/SpaceEntitlementGated.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IMembership} from "../membership/IMembership.sol";
 
 // libraries
 
 // contracts
-import {EntitlementGated} from "src/spaces/facets/gated/EntitlementGated.sol";
-
-import {IMembership} from "src/spaces/facets/membership/IMembership.sol";
-import {MembershipJoin} from "src/spaces/facets/membership/join/MembershipJoin.sol";
+import {EntitlementGated} from "../gated/EntitlementGated.sol";
+import {MembershipJoin} from "../membership/join/MembershipJoin.sol";
 
 /// @title SpaceEntitlementGated
 /// @notice Handles entitlement-gated access to spaces and membership token issuance
@@ -23,11 +22,9 @@ contract SpaceEntitlementGated is MembershipJoin, EntitlementGated {
         bytes32 transactionId,
         NodeVoteStatus result
     ) internal override {
-        bytes memory data = _getCapturedData(transactionId);
+        bytes storage data = _getCapturedData(transactionId);
 
-        if (data.length == 0) {
-            return;
-        }
+        if (data.length == 0) return;
 
         (bytes4 transactionType, , address receiver, ) = abi.decode(
             data,


### PR DESCRIPTION
### Description

Standardize storage manipulation across the codebase by introducing and utilizing the `StoragePointer` library for efficient direct storage access. This refactoring improves code clarity, reusability, and performance by eliminating custom wrapper types and redundant operations.

### Changes

- Introduced `StoragePointer` library import from `@towns-protocol/diamond` package
- Replaced custom `BytesWrapper` struct with `StoragePointer.Bytes` for improved clarity and reusability  
- Refactored `StringSet.sol` to use `StoragePointer.String` and `StoragePointer.Uint256` instead of custom wrapper types
- Updated `DispatcherBase.sol` transaction data handling:
  - Added `_deleteCapturedData()` method for efficient storage cleanup
  - Changed `_getCapturedData()` to return `bytes storage` reference instead of memory copy
  - Optimized transaction registration with direct storage manipulation
- Simplified `DispatcherStorage.sol` by removing unnecessary comments and assembly optimization
- Updated import paths to use relative imports for better maintainability
- Eliminated redundant operations and assembly code where `StoragePointer` provides cleaner alternatives

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines