### PR TITLE
IMembershipShim: change listenForMembershipToken to use getLogs

### DIFF
--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -1606,7 +1606,7 @@ export class SpaceDapp {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
 
-        const issuedListener = space.Membership.listenForMembershipToken(recipient)
+        const startIssuedListener = space.Membership.listenForMembershipToken(recipient)
 
         const blockNumber = await space.provider?.getBlockNumber()
 
@@ -1615,6 +1615,7 @@ export class SpaceDapp {
         const { price } = await this.getJoinSpacePriceDetails(spaceId)
         logger.log('joinSpace getMembershipPrice', Date.now() - getPriceStart)
         const wrapStart = Date.now()
+        const issuedListener = startIssuedListener()
         const result = await wrapTransaction(async () => {
             // Set gas limit instead of using estimateGas
             // As the estimateGas is not reliable for this contract
@@ -1868,24 +1869,6 @@ export class SpaceDapp {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
         return space.Treasury.write(signer).withdraw(recipient)
-    }
-
-    // If the caller doesn't provide an abort controller, listenForMembershipToken will create one
-    public listenForMembershipEvent(
-        spaceId: string,
-        receiver: string,
-        abortController?: AbortController,
-    ): Promise<
-        | { issued: true; tokenId: string; error?: Error | undefined }
-        | { issued: false; tokenId: undefined; error?: Error | undefined }
-    > {
-        const space = this.getSpace(spaceId)
-
-        if (!space) {
-            throw new Error(`Space with spaceId "${spaceId}" is not found.`)
-        }
-
-        return space.Membership.listenForMembershipToken(receiver, abortController)
     }
 
     /**

--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -1606,9 +1606,11 @@ export class SpaceDapp {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
 
-        const startIssuedListener = space.Membership.listenForMembershipToken(recipient)
-
         const blockNumber = await space.provider?.getBlockNumber()
+        const startIssuedListener = space.Membership.listenForMembershipToken({
+            receiver: recipient,
+            startingBlock: blockNumber,
+        })
 
         logger.log('joinSpace before blockNumber', Date.now() - getSpaceStart, blockNumber)
         const getPriceStart = Date.now()

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -47,6 +47,10 @@ export class IMembershipShim extends BaseContractShim<typeof connect> {
 
     // If the caller doesn't provide an abort controller, create one and set a timeout
     // to abort the call after 20 seconds.
+    // exmample:
+    // const startListener = space.Membership.listenForMembershipToken(recipient)
+    // const issuedListener = startListener()
+    // const result = await issuedListener()
     listenForMembershipToken(
         receiver: string,
         providedAbortController?: AbortController,

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -5,8 +5,8 @@ import { IMembershipMetadataShim } from './IMembershipMetadataShim'
 import { MembershipFacet__factory } from '@towns-protocol/generated/dev/typings/factories/MembershipFacet__factory'
 import { IERC721AShim } from '../erc-721/IERC721AShim'
 import { IMulticallShim } from './IMulticallShim'
-import { TransactionOpts } from 'types/ContractTypes'
-const log = dlogger('csb:IMembershipShim')
+import { TransactionOpts } from '../types/ContractTypes'
+const logger = dlogger('csb:IMembershipShim')
 
 const { abi, connect } = MembershipFacet__factory
 
@@ -47,66 +47,117 @@ export class IMembershipShim extends BaseContractShim<typeof connect> {
 
     // If the caller doesn't provide an abort controller, create one and set a timeout
     // to abort the call after 20 seconds.
-    async listenForMembershipToken(
+    listenForMembershipToken(
         receiver: string,
         providedAbortController?: AbortController,
-    ): Promise<{ issued: true; tokenId: string } | { issued: false; tokenId: undefined }> {
-        //
-        const timeoutController = providedAbortController ? undefined : new AbortController()
+    ): () => Promise<{ issued: true; tokenId: string } | { issued: false; tokenId: undefined }> {
+        return async () => {
+            const contract = this.read
+            const provider = contract.provider
+            const iface = contract.interface
 
-        const abortTimeout = providedAbortController
-            ? undefined
-            : setTimeout(() => {
-                  log.error('joinSpace timeout')
-                  timeoutController?.abort()
-              }, 20_000)
+            const issuedFilter =
+                contract.filters['MembershipTokenIssued(address,uint256)'](receiver)
+            const rejectedFilter = contract.filters['MembershipTokenRejected(address)'](receiver)
 
-        const abortController = providedAbortController ?? timeoutController!
-        // TODO: this isn't picking up correct typed function signature, treating as string
-        const issuedFilter = this.read.filters['MembershipTokenIssued(address,uint256)'](
-            receiver,
-        ) as string
-        const rejectedFilter = this.read.filters['MembershipTokenRejected(address)'](
-            receiver,
-        ) as string
+            const abortController = providedAbortController ?? new AbortController()
+            const abortTimeout = providedAbortController
+                ? undefined
+                : setTimeout(() => {
+                      logger.error('joinSpace timeout')
+                      abortController.abort()
+                  }, 20_000)
 
-        return new Promise<
-            { issued: true; tokenId: string } | { issued: false; tokenId: undefined }
-        >((resolve, _reject) => {
-            const cleanup = () => {
-                this.read.off(issuedFilter, issuedListener)
-                this.read.off(rejectedFilter, rejectedListener)
-                abortController.signal.removeEventListener('abort', onAbort)
-                clearTimeout(abortTimeout)
-            }
-            const onAbort = () => {
-                cleanup()
-                resolve({ issued: false, tokenId: undefined })
-            }
-            const issuedListener = (recipient: string, tokenId: BigNumberish) => {
-                if (receiver === recipient) {
-                    log.log('MembershipTokenIssued', { receiver, recipient, tokenId })
-                    cleanup()
-                    resolve({ issued: true, tokenId: BigNumber.from(tokenId).toString() })
-                } else {
-                    // This techincally should never happen, but we should log it
-                    log.log('MembershipTokenIssued mismatch', { receiver, recipient, tokenId })
+            const pollingInterval = 1_000
+            let lastCheckedBlock = await provider.getBlockNumber()
+
+            return new Promise<
+                { issued: true; tokenId: string } | { issued: false; tokenId: undefined }
+            >((resolve) => {
+                let active = true
+
+                const cleanup = () => {
+                    active = false
+                    clearInterval(intervalId)
+                    abortController.signal.removeEventListener('abort', onAbort)
+                    if (abortTimeout) {
+                        clearTimeout(abortTimeout)
+                    }
                 }
-            }
 
-            const rejectedListener = (recipient: string) => {
-                if (receiver === recipient) {
+                const onAbort = () => {
                     cleanup()
                     resolve({ issued: false, tokenId: undefined })
-                } else {
-                    // This techincally should never happen, but we should log it
-                    log.log('MembershipTokenIssued mismatch', { receiver, recipient })
                 }
-            }
 
-            this.read.on(issuedFilter, issuedListener)
-            this.read.on(rejectedFilter, rejectedListener)
-            abortController.signal.addEventListener('abort', onAbort)
-        })
+                abortController.signal.addEventListener('abort', onAbort)
+
+                const intervalId = setInterval(() => {
+                    void (async () => {
+                        if (!active) {
+                            return
+                        }
+
+                        const currentBlock = await provider.getBlockNumber()
+                        if (currentBlock <= lastCheckedBlock) {
+                            return
+                        }
+
+                        try {
+                            // check for both issued and rejected logs
+                            const [issuedLogs, rejectedLogs] = await Promise.all([
+                                provider.getLogs({
+                                    ...issuedFilter,
+                                    fromBlock: lastCheckedBlock + 1,
+                                    toBlock: currentBlock,
+                                }),
+                                provider.getLogs({
+                                    ...rejectedFilter,
+                                    fromBlock: lastCheckedBlock + 1,
+                                    toBlock: currentBlock,
+                                }),
+                            ])
+
+                            for (const log of issuedLogs) {
+                                const parsed = iface.parseLog(log)
+                                const { recipient, tokenId } = parsed.args
+                                if (
+                                    recipient &&
+                                    typeof recipient === 'string' &&
+                                    recipient === receiver
+                                ) {
+                                    logger.log('MembershipTokenIssued', {
+                                        receiver,
+                                        recipient,
+                                        tokenId,
+                                    })
+                                    cleanup()
+                                    resolve({
+                                        issued: true,
+                                        tokenId: BigNumber.from(tokenId).toString(),
+                                    })
+                                    return
+                                }
+                            }
+
+                            for (const log of rejectedLogs) {
+                                const parsed = iface.parseLog(log)
+                                const { recipient } = parsed.args
+                                if (recipient === receiver) {
+                                    logger.log('MembershipTokenRejected', { receiver, recipient })
+                                    cleanup()
+                                    resolve({ issued: false, tokenId: undefined })
+                                    return
+                                }
+                            }
+
+                            lastCheckedBlock = currentBlock
+                        } catch (err) {
+                            logger.error('Log polling error', err)
+                        }
+                    })()
+                }, pollingInterval)
+            })
+        }
     }
 }

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -48,13 +48,19 @@ export class IMembershipShim extends BaseContractShim<typeof connect> {
     // If the caller doesn't provide an abort controller, create one and set a timeout
     // to abort the call after 20 seconds.
     // exmample:
-    // const startListener = space.Membership.listenForMembershipToken(recipient)
-    // const issuedListener = startListener()
-    // const result = await issuedListener()
-    listenForMembershipToken(
-        receiver: string,
-        providedAbortController?: AbortController,
-    ): () => Promise<{ issued: true; tokenId: string } | { issued: false; tokenId: undefined }> {
+    // const startListener = space.Membership.listenForMembershipToken({
+    //     receiver: recipient,
+    //     startingBlock: blockNumber,
+    // })
+    // await txn()
+    // const result = await startListener()
+    listenForMembershipToken(args: {
+        receiver: string
+        startingBlock: number
+        providedAbortController?: AbortController
+    }): () => Promise<{ issued: true; tokenId: string } | { issued: false; tokenId: undefined }> {
+        const { receiver, providedAbortController, startingBlock } = args
+
         return async () => {
             const contract = this.read
             const provider = contract.provider
@@ -73,7 +79,7 @@ export class IMembershipShim extends BaseContractShim<typeof connect> {
                   }, 20_000)
 
             const pollingInterval = 1_000
-            let lastCheckedBlock = await provider.getBlockNumber()
+            let lastCheckedBlock = startingBlock
 
             return new Promise<
                 { issued: true; tokenId: string } | { issued: false; tokenId: undefined }

--- a/packages/web3/src/space/IMembershipShim.ts
+++ b/packages/web3/src/space/IMembershipShim.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, ContractTransaction, ethers, Signer } from 'ethers'
+import { BigNumber, ContractTransaction, ethers, Signer } from 'ethers'
 import { BaseContractShim, OverrideExecution } from '../BaseContractShim'
 import { dlogger } from '@towns-protocol/dlog'
 import { IMembershipMetadataShim } from './IMembershipMetadataShim'


### PR DESCRIPTION
### Description

Our SpaceDapp sets the pollingInterval on the provider to 250ms - which is probably unnecessary, but we can change that in a different PR
```
        if ('pollingInterval' in provider && typeof provider.pollingInterval === 'number') {
            provider.pollingInterval = 250
        }
```
The membership listener was using the ethers/typechain filter listener, which used this pollingInterval, which can result in extraneous rpc requests.

This PR changes that behavior such that:

- it uses getLogs w/ an interval of 1_000 ms to reduce rpc calls
- listenForMembershipToken returns a function. Call the returned function to start polling from the block number saved in the call to listenForMembershipToken (see example comment)

