### PR TITLE
Fix the over-enqueueing of tick in decryption extensions

### DIFF
--- a/packages/sdk/src/decryptionExtensions.ts
+++ b/packages/sdk/src/decryptionExtensions.ts
@@ -596,6 +596,9 @@ export abstract class BaseDecryptionExtensions {
     private lastPrintedAt = 0
     private microtaskEnqueued = false
     protected checkStartTicking() {
+        if (this.microtaskEnqueued) {
+            return
+        }
         this.microtaskEnqueued = true
         queueMicrotask(() => {
             this.microtaskEnqueued = false

--- a/packages/sdk/src/decryptionExtensions.ts
+++ b/packages/sdk/src/decryptionExtensions.ts
@@ -594,11 +594,11 @@ export abstract class BaseDecryptionExtensions {
     }
 
     private lastPrintedAt = 0
+    private microtaskEnqueued = false
     protected checkStartTicking() {
-        // tick is safe to call multiple times in the same frame, but we dont' want it
-        // slowing down the rest of the main thread, and we want tick to happen async outside of
-        // any dispatched events (decrypted item shows up, event dispatched, then event is added to timeline, only then should we update it with the decrypted content)
+        this.microtaskEnqueued = true
         queueMicrotask(() => {
+            this.microtaskEnqueued = false
             this.tick()
         })
     }


### PR DESCRIPTION
my comment was dumb, this can get called hunderds of times, tick sorts the stream ids, it’s expensive.