### PR TITLE
node: incorrect error handling remote syncer that could lead to nil p…

### DIFF
--- a/core/node/rpc/sync/client/remote.go
+++ b/core/node/rpc/sync/client/remote.go
@@ -82,7 +82,11 @@ func NewRemoteSyncer(
 			"syncOp", responseStream.Msg().SyncOp,
 			"syncId", responseStream.Msg().SyncId)
 		syncStreamCancel()
-		return nil, err
+
+		return nil, RiverError(Err_UNAVAILABLE, "Received unexpected sync stream message").
+			Tags("syncOp", responseStream.Msg().SyncOp,
+				"syncId", responseStream.Msg().SyncId,
+				"remote", remoteAddr)
 	}
 
 	return &remoteSyncer{

--- a/core/node/rpc/sync/legacyclient/remote.go
+++ b/core/node/rpc/sync/legacyclient/remote.go
@@ -84,7 +84,11 @@ func newRemoteSyncer(
 			"syncOp", responseStream.Msg().SyncOp,
 			"syncId", responseStream.Msg().SyncId)
 		syncStreamCancel()
-		return nil, err
+
+		return nil, RiverError(Err_UNAVAILABLE, "Received unexpected sync stream message").
+			Tags("syncOp", responseStream.Msg().SyncOp,
+				"syncId", responseStream.Msg().SyncId,
+				"remote", remoteAddr)
 	}
 
 	return &remoteSyncer{


### PR DESCRIPTION
When instantiating a new remote syncer error handling wasn't done correct. This could lead that the NewSyncer function return `(nil, nil)` instead of `(nil, RiverError)`. This can lead to a nil panic.

An existing `err` was returned that was used in a previous assigned and checked to be nil. But wasn't set when checking in the error condition.