### PR TITLE
refactor: consolidate miniblock data structures

### DIFF
--- a/core/node/events/miniblock_info.go
+++ b/core/node/events/miniblock_info.go
@@ -318,7 +318,7 @@ func (b *MiniblockInfo) lastEvent() *ParsedEvent {
 }
 
 // AsStorageMb returns a storage miniblock with the data from the MiniblockInfo.
-func (b *MiniblockInfo) AsStorageMb() (*storage.WriteMiniblockData, error) {
+func (b *MiniblockInfo) AsStorageMb() (*storage.MiniblockDescriptor, error) {
 	serializedMb, err := proto.Marshal(b.Proto)
 	if err != nil {
 		return nil, AsRiverError(err, Err_INTERNAL).
@@ -341,7 +341,7 @@ func (b *MiniblockInfo) AsStorageMb() (*storage.WriteMiniblockData, error) {
 		serializedSn = make([]byte, 0)
 	}
 
-	return &storage.WriteMiniblockData{
+	return &storage.MiniblockDescriptor{
 		Number:   b.Ref.Num,
 		Hash:     b.Ref.Hash,
 		Snapshot: serializedSn,

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -254,7 +254,7 @@ func (s *Stream) importMiniblocksLocked(
 	miniblocks []*MiniblockInfo,
 ) error {
 	firstMbNum := miniblocks[0].Ref.Num
-	blocksToWriteToStorage := make([]*storage.WriteMiniblockData, len(miniblocks))
+	blocksToWriteToStorage := make([]*storage.MiniblockDescriptor, len(miniblocks))
 	for i, miniblock := range miniblocks {
 		if miniblock.Ref.Num != firstMbNum+int64(i) {
 			return RiverError(Err_INTERNAL, "miniblock numbers are not sequential").Func("importMiniblocks")
@@ -363,9 +363,9 @@ func (s *Stream) applyMiniblockImplLocked(
 		return err
 	}
 
-	var storageMb *storage.WriteMiniblockData
+	var storageMb *storage.MiniblockDescriptor
 	if miniblock != nil {
-		storageMb = &storage.WriteMiniblockData{
+		storageMb = &storage.MiniblockDescriptor{
 			Number:   info.Ref.Num,
 			Hash:     info.Ref.Hash,
 			Snapshot: miniblock.Snapshot,
@@ -380,7 +380,7 @@ func (s *Stream) applyMiniblockImplLocked(
 	err = s.params.Storage.WriteMiniblocks(
 		ctx,
 		s.streamId,
-		[]*storage.WriteMiniblockData{storageMb},
+		[]*storage.MiniblockDescriptor{storageMb},
 		newSV.minipool.generation,
 		newMinipool,
 		prevSV.minipool.generation,
@@ -496,7 +496,7 @@ func (s *Stream) initFromGenesisLocked(
 	err := s.params.Storage.CreateStreamStorage(
 		ctx,
 		s.streamId,
-		&storage.WriteMiniblockData{Data: genesisBytes},
+		&storage.MiniblockDescriptor{Data: genesisBytes},
 	)
 	if err != nil {
 		return err

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -513,7 +513,7 @@ func (s *StreamCache) readGenesisAndCreateLocalStream(
 	err = s.params.Storage.CreateStreamStorage(
 		ctx,
 		streamId,
-		&storage.WriteMiniblockData{Data: mb},
+		&storage.MiniblockDescriptor{Data: mb},
 	)
 	if err != nil {
 		if IsRiverErrorCode(err, Err_ALREADY_EXISTS) {

--- a/core/node/events/stream_ephemeral_test.go
+++ b/core/node/events/stream_ephemeral_test.go
@@ -71,7 +71,7 @@ func Test_StreamCache_normalizeEphemeralStream(t *testing.T) {
 			})
 			tc.require.NoError(err)
 
-			err = leaderInstance.params.Storage.WriteEphemeralMiniblock(ctx, streamId, &storage.WriteMiniblockData{
+			err = leaderInstance.params.Storage.WriteEphemeralMiniblock(ctx, streamId, &storage.MiniblockDescriptor{
 				Number: mbRef.Num + 1,
 				Hash:   common.BytesToHash(header.Hash),
 				Data:   mbBytes,
@@ -132,7 +132,7 @@ func Test_StreamCache_normalizeEphemeralStream(t *testing.T) {
 			})
 			tc.require.NoError(err)
 
-			err = leaderInstance.params.Storage.WriteEphemeralMiniblock(ctx, streamId, &storage.WriteMiniblockData{
+			err = leaderInstance.params.Storage.WriteEphemeralMiniblock(ctx, streamId, &storage.MiniblockDescriptor{
 				Number: mbRef.Num + 1,
 				Hash:   common.BytesToHash(header.Hash),
 				Data:   mbBytes,

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -707,7 +707,7 @@ func (a *Archiver) ArchiveStream(ctx context.Context, stream *ArchiveStream) (er
 
 		// Validate miniblocks are sequential.
 		// TODO: validate miniblock signatures.
-		var serialized []*storage.WriteMiniblockData
+		var serialized []*storage.MiniblockDescriptor
 		for i, mb := range resp.Msg.Miniblocks {
 			// Parse header
 			info, err := events.NewMiniblockInfoFromProto(

--- a/core/node/rpc/create_media_stream.go
+++ b/core/node/rpc/create_media_stream.go
@@ -227,7 +227,7 @@ func (s *Service) createReplicatedMediaStream(
 	// Create ephemeral stream within the local node
 	if isLocal {
 		sender.AddTask(func(ctx context.Context) error {
-			return s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.WriteMiniblockData{Data: mbBytes})
+			return s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.MiniblockDescriptor{Data: mbBytes})
 		})
 	}
 

--- a/core/node/rpc/miniblock_scrub_test.go
+++ b/core/node/rpc/miniblock_scrub_test.go
@@ -247,12 +247,12 @@ func writeStreamBackToStore(
 	require.NotNil(mb2)
 
 	// Re-write the stream with corrupt block 1
-	require.NoError(store.CreateStreamStorage(ctx, streamId, &storage.WriteMiniblockData{Data: blocks[0].Data}))
+	require.NoError(store.CreateStreamStorage(ctx, streamId, &storage.MiniblockDescriptor{Data: blocks[0].Data}))
 	require.NoError(
 		store.WriteMiniblocks(
 			ctx,
 			streamId,
-			[]*storage.WriteMiniblockData{
+			[]*storage.MiniblockDescriptor{
 				{
 					Number:   1,
 					Hash:     mb1.Ref.Hash,

--- a/core/node/rpc/node2node_ephemeral.go
+++ b/core/node/rpc/node2node_ephemeral.go
@@ -55,7 +55,7 @@ func (s *Service) allocateEphemeralStream(ctx context.Context, req *AllocateEphe
 		}
 	}
 
-	if err = s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.WriteMiniblockData{
+	if err = s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.MiniblockDescriptor{
 		Data:     mbBytes,
 		Snapshot: snBytes,
 	}); err != nil {

--- a/core/node/rpc/replicated_add.go
+++ b/core/node/rpc/replicated_add.go
@@ -208,7 +208,7 @@ func (s *Service) replicatedAddMediaEventImpl(
 			return err
 		}
 
-		if err = s.storage.WriteEphemeralMiniblock(ctx, streamId, &storage.WriteMiniblockData{
+		if err = s.storage.WriteEphemeralMiniblock(ctx, streamId, &storage.MiniblockDescriptor{
 			Number: cc.MiniblockNum,
 			Hash:   common.BytesToHash(ephemeralMb.Header.Hash),
 			Data:   mbBytes,

--- a/core/node/storage/pg_ephemeral_store.go
+++ b/core/node/storage/pg_ephemeral_store.go
@@ -53,7 +53,7 @@ func (s *PostgresStreamStore) lockEphemeralStream(
 func (s *PostgresStreamStore) CreateEphemeralStreamStorage(
 	ctx context.Context,
 	streamId StreamId,
-	genesisMiniblock *WriteMiniblockData,
+	genesisMiniblock *MiniblockDescriptor,
 ) error {
 	return s.txRunner(
 		ctx,
@@ -71,7 +71,7 @@ func (s *PostgresStreamStore) createEphemeralStreamStorageTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	genesisMiniblock *WriteMiniblockData,
+	genesisMiniblock *MiniblockDescriptor,
 ) error {
 	sql := s.sqlForStream(
 		`
@@ -149,7 +149,7 @@ func (s *PostgresStreamStore) readEphemeralMiniblockNumsTx(
 func (s *PostgresStreamStore) WriteEphemeralMiniblock(
 	ctx context.Context,
 	streamId StreamId,
-	miniblock *WriteMiniblockData,
+	miniblock *MiniblockDescriptor,
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -175,7 +175,7 @@ func (s *PostgresStreamStore) writeEphemeralMiniblockTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	miniblock *WriteMiniblockData,
+	miniblock *MiniblockDescriptor,
 ) error {
 	// Query to insert a new ephemeral miniblock
 	query := s.sqlForStream("INSERT INTO {{miniblocks}} (stream_id, seq_num, blockdata, snapshot) VALUES ($1, $2, $3, $4);", streamId)

--- a/core/node/storage/pg_snapshot_trimmer_test.go
+++ b/core/node/storage/pg_snapshot_trimmer_test.go
@@ -24,7 +24,7 @@ func TestSnapshotsTrimmer(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
-	genesisMb := &WriteMiniblockData{Data: []byte("genesisMiniblock"), Snapshot: []byte("genesisSnapshot")}
+	genesisMb := &MiniblockDescriptor{Data: []byte("genesisMiniblock"), Snapshot: []byte("genesisSnapshot")}
 	err := pgStreamStore.CreateStreamStorage(ctx, streamId, genesisMb)
 	require.NoError(err)
 
@@ -32,9 +32,9 @@ func TestSnapshotsTrimmer(t *testing.T) {
 	testEnvelopes = append(testEnvelopes, []byte("event2"))
 
 	// Generate 500 miniblocks with snapshot on each 10th miniblock
-	mbs := make([]*WriteMiniblockData, 500)
+	mbs := make([]*MiniblockDescriptor, 500)
 	for i := 1; i <= 500; i++ {
-		mb := &WriteMiniblockData{
+		mb := &MiniblockDescriptor{
 			Number: int64(i),
 			Hash:   common.BytesToHash([]byte("block_hash" + strconv.Itoa(i))),
 			Data:   []byte("block" + strconv.Itoa(i)),

--- a/core/node/storage/pg_storage_archive_test.go
+++ b/core/node/storage/pg_storage_archive_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/towns-protocol/towns/core/node/testutils"
 )
 
-func mbDataForNumb(n int64, sn bool) *WriteMiniblockData {
+func mbDataForNumb(n int64, sn bool) *MiniblockDescriptor {
 	var snapshot []byte
 	if sn {
 		snapshot = []byte(fmt.Sprintf("snapshot-%d", n))
 	}
-	return &WriteMiniblockData{
+	return &MiniblockDescriptor{
 		Data:     []byte(fmt.Sprintf("data-%d", n)),
 		Snapshot: snapshot,
 	}
@@ -47,7 +47,7 @@ func TestArchive(t *testing.T) {
 	require.NoError(err)
 	require.Equal(int64(-1), bn)
 
-	data := []*WriteMiniblockData{
+	data := []*MiniblockDescriptor{
 		mbDataForNumb(0, true),
 		mbDataForNumb(1, false),
 		mbDataForNumb(2, false),
@@ -68,7 +68,7 @@ func TestArchive(t *testing.T) {
 		{Number: 2, Data: data[2].Data, Snapshot: data[2].Snapshot},
 	}, readMBs)
 
-	data2 := []*WriteMiniblockData{
+	data2 := []*MiniblockDescriptor{
 		mbDataForNumb(3, false),
 		mbDataForNumb(4, false),
 		mbDataForNumb(5, false),

--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -510,7 +510,7 @@ func (s *PostgresStreamStore) lockStream(
 func (s *PostgresStreamStore) CreateStreamStorage(
 	ctx context.Context,
 	streamId StreamId,
-	genesisMiniblock *WriteMiniblockData,
+	genesisMiniblock *MiniblockDescriptor,
 ) error {
 	if len(genesisMiniblock.Data) == 0 {
 		return RiverError(
@@ -552,7 +552,7 @@ func (s *PostgresStreamStore) createStreamStorageTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	genesisMiniblock *WriteMiniblockData,
+	genesisMiniblock *MiniblockDescriptor,
 ) error {
 	sql := s.sqlForStream(
 		`
@@ -575,7 +575,7 @@ func (s *PostgresStreamStore) maybeOverwriteCorruptGenesisMiniblockTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	genesisMiniblock *WriteMiniblockData,
+	genesisMiniblock *MiniblockDescriptor,
 ) error {
 	okErr := RiverError(Err_ALREADY_EXISTS, "OK: Stream not corrupt")
 	snapshotMiniblock, err := s.lockStream(ctx, tx, streamId, true)
@@ -705,7 +705,7 @@ func (s *PostgresStreamStore) WriteArchiveMiniblocks(
 	ctx context.Context,
 	streamId StreamId,
 	startMiniblockNum int64,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 ) error {
 	return s.txRunner(
 		ctx,
@@ -726,7 +726,7 @@ func (s *PostgresStreamStore) writeArchiveMiniblocksTx(
 	tx pgx.Tx,
 	streamId StreamId,
 	startMiniblockNum int64,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 ) error {
 	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
@@ -1033,7 +1033,7 @@ func (s *PostgresStreamStore) writeEventTx(
 func (s *PostgresStreamStore) WritePrecedingMiniblocks(
 	ctx context.Context,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 ) error {
 	if len(miniblocks) == 0 {
 		return RiverError(
@@ -1072,7 +1072,7 @@ func (s *PostgresStreamStore) writePrecedingMiniblocksTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 ) error {
 	// Lock the stream for update
 	_, err := s.lockStream(ctx, tx, streamId, true)
@@ -1131,7 +1131,7 @@ func (s *PostgresStreamStore) writePrecedingMiniblocksTx(
 	}
 
 	// Prepare miniblocks to insert (skip existing ones)
-	var toInsert []*WriteMiniblockData
+	var toInsert []*MiniblockDescriptor
 	for _, mb := range miniblocks {
 		if !existingNums[mb.Number] {
 			toInsert = append(toInsert, mb)
@@ -1428,7 +1428,7 @@ func (s *PostgresStreamStore) readMiniblocksByIdsTx(
 func (s *PostgresStreamStore) WriteMiniblockCandidate(
 	ctx context.Context,
 	streamId StreamId,
-	miniblock *WriteMiniblockData,
+	miniblock *MiniblockDescriptor,
 ) error {
 	if len(miniblock.Data) == 0 {
 		return RiverError(
@@ -1462,7 +1462,7 @@ func (s *PostgresStreamStore) writeMiniblockCandidateTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	miniblock *WriteMiniblockData,
+	miniblock *MiniblockDescriptor,
 ) error {
 	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
@@ -1624,7 +1624,7 @@ func (s *PostgresStreamStore) getMiniblockCandidateCountTx(
 func (s *PostgresStreamStore) WriteMiniblocks(
 	ctx context.Context,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 	newMinipoolGeneration int64,
 	newMinipoolEnvelopes [][]byte,
 	prevMinipoolGeneration int64,
@@ -1688,7 +1688,7 @@ func (s *PostgresStreamStore) writeMiniblocksTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 	newMinipoolGeneration int64,
 	newMinipoolEnvelopes [][]byte,
 	prevMinipoolGeneration int64,
@@ -2639,7 +2639,7 @@ func parseAndCheckHasLegacySnapshot(data []byte) bool {
 func (s *PostgresStreamStore) ReinitializeStreamStorage(
 	ctx context.Context,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 	lastSnapshotMiniblockNum int64,
 	updateExisting bool,
 ) error {
@@ -2707,7 +2707,7 @@ func (s *PostgresStreamStore) reinitializeStreamStorageTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
-	miniblocks []*WriteMiniblockData,
+	miniblocks []*MiniblockDescriptor,
 	lastSnapshotMiniblockNum int64,
 	updateExisting bool,
 ) error {
@@ -2835,7 +2835,7 @@ func (s *PostgresStreamStore) reinitializeStreamStorageTx(
 		}
 
 		// Filter miniblocks to only include those that don't exist
-		miniblocksToInsert := make([]*WriteMiniblockData, 0, len(miniblocks))
+		miniblocksToInsert := make([]*MiniblockDescriptor, 0, len(miniblocks))
 		for _, mb := range miniblocks {
 			if !existingMbs[mb.Number] {
 				miniblocksToInsert = append(miniblocksToInsert, mb)

--- a/core/node/storage/pg_stream_store_gaps_test.go
+++ b/core/node/storage/pg_stream_store_gaps_test.go
@@ -36,7 +36,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err := store.CreateStreamStorage(
 			ctx,
 			streamId,
-			&WriteMiniblockData{
+			&MiniblockDescriptor{
 				Number:   0,
 				Hash:     common.HexToHash("0x01"),
 				Data:     []byte("genesis"),
@@ -50,7 +50,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 			err := store.WriteMiniblocks(
 				ctx,
 				streamId,
-				[]*WriteMiniblockData{{
+				[]*MiniblockDescriptor{{
 					Number:   i,
 					Hash:     common.HexToHash(string(rune('0' + i))),
 					Data:     []byte("miniblock"),
@@ -90,7 +90,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err := store.ReinitializeStreamStorage(
 			ctx,
 			streamIdGaps,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{Number: 5, Hash: common.HexToHash("0x05"), Data: []byte("miniblock5"), Snapshot: nil},
 				{Number: 6, Hash: common.HexToHash("0x06"), Data: []byte("miniblock6"), Snapshot: nil},
 				{Number: 7, Hash: common.HexToHash("0x07"), Data: []byte("miniblock7"), Snapshot: []byte("snapshot7")},
@@ -107,7 +107,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err = store.WritePrecedingMiniblocks(
 			ctx,
 			streamIdGaps,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{Number: 0, Hash: common.HexToHash("0x00"), Data: []byte("genesis"), Snapshot: []byte("snapshot0")},
 				{Number: 1, Hash: common.HexToHash("0x01"), Data: []byte("miniblock1"), Snapshot: nil},
 				{Number: 2, Hash: common.HexToHash("0x02"), Data: []byte("miniblock2"), Snapshot: nil},
@@ -137,7 +137,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err = store.ReinitializeStreamStorage(
 			ctx,
 			streamIdGaps,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{
 					Number:   15,
 					Hash:     common.HexToHash("0x15"),
@@ -170,7 +170,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err := store.ReinitializeStreamStorage(
 			ctx,
 			streamIdNonZero,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{
 					Number:   100,
 					Hash:     common.HexToHash("0x100"),
@@ -209,7 +209,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err := store.ReinitializeStreamStorage(
 			ctx,
 			streamIdLarge,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{
 					Number:   1000,
 					Hash:     common.HexToHash("0x1000"),
@@ -228,7 +228,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err = store.ReinitializeStreamStorage(
 			ctx,
 			streamIdLarge,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{
 					Number:   2000,
 					Hash:     common.HexToHash("0x2000"),
@@ -245,7 +245,7 @@ func TestGetMiniblockNumberRanges(t *testing.T) {
 		err = store.WritePrecedingMiniblocks(
 			ctx,
 			streamIdLarge,
-			[]*WriteMiniblockData{
+			[]*MiniblockDescriptor{
 				{Number: 0, Hash: common.HexToHash("0x00"), Data: []byte("genesis"), Snapshot: []byte("snapshot0")},
 			},
 		)
@@ -285,7 +285,7 @@ func TestGetMiniblockNumberRangesWithPrecedingMiniblocks(t *testing.T) {
 	err := store.ReinitializeStreamStorage(
 		ctx,
 		streamId,
-		[]*WriteMiniblockData{
+		[]*MiniblockDescriptor{
 			{Number: 10, Hash: common.HexToHash("0x10"), Data: []byte("miniblock10"), Snapshot: []byte("snapshot10")},
 			{Number: 11, Hash: common.HexToHash("0x11"), Data: []byte("miniblock11"), Snapshot: nil},
 			{Number: 12, Hash: common.HexToHash("0x12"), Data: []byte("miniblock12"), Snapshot: nil},
@@ -307,7 +307,7 @@ func TestGetMiniblockNumberRangesWithPrecedingMiniblocks(t *testing.T) {
 	err = store.WritePrecedingMiniblocks(
 		ctx,
 		streamId,
-		[]*WriteMiniblockData{
+		[]*MiniblockDescriptor{
 			{Number: 5, Hash: common.HexToHash("0x05"), Data: []byte("miniblock5"), Snapshot: nil},
 			{Number: 6, Hash: common.HexToHash("0x06"), Data: []byte("miniblock6"), Snapshot: nil},
 			{Number: 7, Hash: common.HexToHash("0x07"), Data: []byte("miniblock7"), Snapshot: nil},
@@ -327,7 +327,7 @@ func TestGetMiniblockNumberRangesWithPrecedingMiniblocks(t *testing.T) {
 	err = store.WritePrecedingMiniblocks(
 		ctx,
 		streamId,
-		[]*WriteMiniblockData{
+		[]*MiniblockDescriptor{
 			{Number: 0, Hash: common.HexToHash("0x00"), Data: []byte("genesis"), Snapshot: []byte("snapshot0")},
 			{Number: 1, Hash: common.HexToHash("0x01"), Data: []byte("miniblock1"), Snapshot: nil},
 			{Number: 2, Hash: common.HexToHash("0x02"), Data: []byte("miniblock2"), Snapshot: nil},
@@ -371,9 +371,9 @@ func TestGetMiniblockNumberRangesPerformance(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create initial continuous range 0-999
-	miniblocks := make([]*WriteMiniblockData, 1000)
+	miniblocks := make([]*MiniblockDescriptor, 1000)
 	for i := 0; i < 1000; i++ {
-		miniblocks[i] = &WriteMiniblockData{
+		miniblocks[i] = &MiniblockDescriptor{
 			Number:   int64(i),
 			Hash:     common.HexToHash(string(rune(i % 256))),
 			Data:     []byte("miniblock"),
@@ -395,9 +395,9 @@ func TestGetMiniblockNumberRangesPerformance(t *testing.T) {
 
 	// Add more ranges with gaps: 2000-2999, 4000-4999, etc.
 	for base := int64(2000); base < 10000; base += 2000 {
-		extraBlocks := make([]*WriteMiniblockData, 1000)
+		extraBlocks := make([]*MiniblockDescriptor, 1000)
 		for i := 0; i < 1000; i++ {
-			extraBlocks[i] = &WriteMiniblockData{
+			extraBlocks[i] = &MiniblockDescriptor{
 				Number:   base + int64(i),
 				Hash:     common.HexToHash(string(rune(i % 256))),
 				Data:     []byte("miniblock"),

--- a/core/node/storage/pg_stream_store_preceding_test.go
+++ b/core/node/storage/pg_stream_store_preceding_test.go
@@ -22,7 +22,7 @@ func TestWritePrecedingMiniblocks_BasicBackfill(t *testing.T) {
 
 	// Create a stream first
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -37,7 +37,7 @@ func TestWritePrecedingMiniblocks_BasicBackfill(t *testing.T) {
 
 	// Now add blocks with gaps using ReinitializeStreamStorage with updateExisting=true
 	// This will add blocks 5-6, leaving gaps 1-4
-	additionalMiniblocks := []*WriteMiniblockData{
+	additionalMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   5,
 			Hash:     common.BytesToHash([]byte("block5")),
@@ -57,7 +57,7 @@ func TestWritePrecedingMiniblocks_BasicBackfill(t *testing.T) {
 	require.NoError(err)
 
 	// Prepare miniblocks to backfill gaps
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.BytesToHash([]byte("block1")),
@@ -112,7 +112,7 @@ func TestWritePrecedingMiniblocks_PartialOverlap(t *testing.T) {
 	
 	// The test actually can't create real gaps with ReinitializeStreamStorage
 	// So we'll create continuous blocks and test the overlap behavior
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -155,7 +155,7 @@ func TestWritePrecedingMiniblocks_PartialOverlap(t *testing.T) {
 	require.NoError(err)
 
 	// Prepare overlapping backfill (includes existing block 2)
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.BytesToHash([]byte("block1")),
@@ -205,7 +205,7 @@ func TestWritePrecedingMiniblocks_StreamNotFound(t *testing.T) {
 	ctx := params.ctx
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.BytesToHash([]byte("block1")),
@@ -230,7 +230,7 @@ func TestWritePrecedingMiniblocks_InvalidRange(t *testing.T) {
 
 	// Use the same approach as BasicBackfill test which works
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -255,7 +255,7 @@ func TestWritePrecedingMiniblocks_InvalidRange(t *testing.T) {
 	require.NoError(err)
 
 	// Try to backfill with block >= last block (should fail validation)
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   2, // Equal to last block
 			Hash:     common.BytesToHash([]byte("block2_new")),
@@ -279,7 +279,7 @@ func TestWritePrecedingMiniblocks_NonContinuous(t *testing.T) {
 
 	// Create a stream with initial block
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -292,7 +292,7 @@ func TestWritePrecedingMiniblocks_NonContinuous(t *testing.T) {
 	require.NoError(err)
 	
 	// Add block 10 with gap using updateExisting
-	additionalMiniblocks := []*WriteMiniblockData{
+	additionalMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   10,
 			Hash:     common.BytesToHash([]byte("block10")),
@@ -305,7 +305,7 @@ func TestWritePrecedingMiniblocks_NonContinuous(t *testing.T) {
 	require.NoError(err)
 
 	// Try to backfill with non-continuous blocks
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.BytesToHash([]byte("block1")),
@@ -335,7 +335,7 @@ func TestWritePrecedingMiniblocks_EmptyList(t *testing.T) {
 
 	// Create a stream
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -348,7 +348,7 @@ func TestWritePrecedingMiniblocks_EmptyList(t *testing.T) {
 	require.NoError(err)
 
 	// Empty list should return error
-	err = store.WritePrecedingMiniblocks(ctx, streamId, []*WriteMiniblockData{})
+	err = store.WritePrecedingMiniblocks(ctx, streamId, []*MiniblockDescriptor{})
 	require.Error(err)
 	require.True(IsRiverErrorCode(err, Err_INVALID_ARGUMENT))
 	require.Contains(err.Error(), "miniblocks cannot be empty")
@@ -364,7 +364,7 @@ func TestWritePrecedingMiniblocks_AllExisting(t *testing.T) {
 
 	// Create a stream with continuous blocks
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis")),
@@ -389,7 +389,7 @@ func TestWritePrecedingMiniblocks_AllExisting(t *testing.T) {
 	require.NoError(err)
 
 	// Try to backfill existing blocks (they should be skipped)
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte("genesis_new")),
@@ -428,9 +428,9 @@ func TestWritePrecedingMiniblocks_LargeBackfill(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	
 	// First create blocks 0-600
-	initialMiniblocks := make([]*WriteMiniblockData, 601)
+	initialMiniblocks := make([]*MiniblockDescriptor, 601)
 	for i := 0; i <= 600; i++ {
-		initialMiniblocks[i] = &WriteMiniblockData{
+		initialMiniblocks[i] = &MiniblockDescriptor{
 			Number:   int64(i),
 			Hash:     common.BytesToHash([]byte{byte(i % 256)}),
 			Data:     []byte{byte(i % 256)},
@@ -445,9 +445,9 @@ func TestWritePrecedingMiniblocks_LargeBackfill(t *testing.T) {
 	require.NoError(err)
 	
 	// Now add block 1000 to create a gap
-	additionalMiniblocks := make([]*WriteMiniblockData, 400)
+	additionalMiniblocks := make([]*MiniblockDescriptor, 400)
 	for i := 0; i < 400; i++ {
-		additionalMiniblocks[i] = &WriteMiniblockData{
+		additionalMiniblocks[i] = &MiniblockDescriptor{
 			Number:   int64(i + 601),
 			Hash:     common.BytesToHash([]byte{byte((i + 601) % 256)}),
 			Data:     []byte{byte((i + 601) % 256)},
@@ -462,9 +462,9 @@ func TestWritePrecedingMiniblocks_LargeBackfill(t *testing.T) {
 	require.NoError(err)
 
 	// Create large backfill
-	backfillBlocks := make([]*WriteMiniblockData, 500)
+	backfillBlocks := make([]*MiniblockDescriptor, 500)
 	for i := 0; i < 500; i++ {
-		backfillBlocks[i] = &WriteMiniblockData{
+		backfillBlocks[i] = &MiniblockDescriptor{
 			Number:   int64(i + 100), // 100-599
 			Hash:     common.BytesToHash([]byte{byte(i)}),
 			Data:     []byte{byte(i)},
@@ -497,9 +497,9 @@ func TestWritePrecedingMiniblocks_ConcurrentBackfill(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	
 	// Create blocks 0-10
-	miniblocks := make([]*WriteMiniblockData, 11)
+	miniblocks := make([]*MiniblockDescriptor, 11)
 	for i := 0; i <= 10; i++ {
-		miniblocks[i] = &WriteMiniblockData{
+		miniblocks[i] = &MiniblockDescriptor{
 			Number:   int64(i),
 			Hash:     common.BytesToHash([]byte{byte(i)}),
 			Data:     []byte{byte(i)},
@@ -514,7 +514,7 @@ func TestWritePrecedingMiniblocks_ConcurrentBackfill(t *testing.T) {
 	require.NoError(err)
 
 	// Prepare two overlapping backfills
-	backfill1 := []*WriteMiniblockData{
+	backfill1 := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.BytesToHash([]byte("block1")),
@@ -529,7 +529,7 @@ func TestWritePrecedingMiniblocks_ConcurrentBackfill(t *testing.T) {
 		},
 	}
 
-	backfill2 := []*WriteMiniblockData{
+	backfill2 := []*MiniblockDescriptor{
 		{
 			Number:   2,
 			Hash:     common.BytesToHash([]byte("block2_alt")),
@@ -577,7 +577,7 @@ func TestWritePrecedingMiniblocks_ValidationBeforeWrite(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	
 	// First create 0-2
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.BytesToHash([]byte{0}),
@@ -602,7 +602,7 @@ func TestWritePrecedingMiniblocks_ValidationBeforeWrite(t *testing.T) {
 	require.NoError(err)
 	
 	// Then add 3-5 to create continuous blocks
-	additionalMiniblocks := []*WriteMiniblockData{
+	additionalMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   3,
 			Hash:     common.BytesToHash([]byte{3}),
@@ -627,7 +627,7 @@ func TestWritePrecedingMiniblocks_ValidationBeforeWrite(t *testing.T) {
 	require.NoError(err)
 
 	// Mix of valid and invalid blocks (block 5 exists, block 6 > last)
-	backfillBlocks := []*WriteMiniblockData{
+	backfillBlocks := []*MiniblockDescriptor{
 		{
 			Number:   3,
 			Hash:     common.BytesToHash([]byte("block3")),

--- a/core/node/storage/pg_stream_store_reinitialize_test.go
+++ b/core/node/storage/pg_stream_store_reinitialize_test.go
@@ -24,7 +24,7 @@ func TestReinitializeStreamStorage_CreateNew(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Prepare miniblocks
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{
 			Number:   0,
 			Hash:     common.HexToHash("0x01"),
@@ -81,7 +81,7 @@ func TestReinitializeStreamStorage_UpdateExisting(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create initial stream
-	genesisMb := &WriteMiniblockData{
+	genesisMb := &MiniblockDescriptor{
 		Number:   0,
 		Hash:     common.HexToHash("0x01"),
 		Data:     []byte("genesis miniblock"),
@@ -92,12 +92,12 @@ func TestReinitializeStreamStorage_UpdateExisting(t *testing.T) {
 
 	// Write a miniblock to extend the stream
 	err = store.WriteMiniblocks(ctx, streamId, 
-		[]*WriteMiniblockData{{Number: 1, Data: []byte("miniblock 1")}},
+		[]*MiniblockDescriptor{{Number: 1, Data: []byte("miniblock 1")}},
 		2, [][]byte{}, 1, 0)
 	require.NoError(err)
 
 	// Add miniblock candidates
-	candidate := &WriteMiniblockData{
+	candidate := &MiniblockDescriptor{
 		Number: 2,
 		Hash:   common.HexToHash("0xc1"),
 		Data:   []byte("candidate 2"),
@@ -106,7 +106,7 @@ func TestReinitializeStreamStorage_UpdateExisting(t *testing.T) {
 	require.NoError(err)
 
 	// Prepare new miniblocks for reinitialization (extending the stream)
-	newMiniblocks := []*WriteMiniblockData{
+	newMiniblocks := []*MiniblockDescriptor{
 		{
 			Number:   1,
 			Hash:     common.HexToHash("0x02"),
@@ -174,19 +174,19 @@ func TestReinitializeStreamStorage_ValidationErrors(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		miniblocks               []*WriteMiniblockData
+		miniblocks               []*MiniblockDescriptor
 		lastSnapshotMiniblockNum int64
 		expectedError            string
 	}{
 		{
 			name:                     "empty miniblocks",
-			miniblocks:               []*WriteMiniblockData{},
+			miniblocks:               []*MiniblockDescriptor{},
 			lastSnapshotMiniblockNum: 0,
 			expectedError:            "miniblocks cannot be empty",
 		},
 		{
 			name: "invalid snapshot number below range",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 5, Data: []byte("mb5")},
 				{Number: 6, Data: []byte("mb6")},
 			},
@@ -195,7 +195,7 @@ func TestReinitializeStreamStorage_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "non-continuous miniblock numbers",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 2, Data: []byte("mb2")}, // Skipped 1
 			},
@@ -204,7 +204,7 @@ func TestReinitializeStreamStorage_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "empty miniblock data",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte{}}, // Empty data
 			},
@@ -213,7 +213,7 @@ func TestReinitializeStreamStorage_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "invalid snapshot miniblock number - negative",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte("mb1")},
 			},
@@ -222,7 +222,7 @@ func TestReinitializeStreamStorage_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "invalid snapshot miniblock number - too high",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte("mb1")},
 			},
@@ -250,7 +250,7 @@ func TestReinitializeStreamStorage_UpdateValidation(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create stream with initial miniblocks
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("genesis"), Snapshot: []byte("snapshot")},
 		{Number: 1, Data: []byte("miniblock 1")},
 		{Number: 2, Data: []byte("miniblock 2")},
@@ -259,7 +259,7 @@ func TestReinitializeStreamStorage_UpdateValidation(t *testing.T) {
 	require.NoError(err)
 
 	// Try to update with miniblocks not exceeding existing
-	newMiniblocks := []*WriteMiniblockData{
+	newMiniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("new genesis"), Snapshot: []byte("new snapshot")},
 		{Number: 1, Data: []byte("new miniblock 1")},
 		// Last miniblock is 1, but existing has up to 2
@@ -279,7 +279,7 @@ func TestReinitializeStreamStorage_ExistenceChecks(t *testing.T) {
 	existingStreamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	nonExistingStreamId := testutils.FakeStreamId(STREAM_SPACE_BIN)
 
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("genesis"), Snapshot: []byte("snapshot")},
 	}
 
@@ -324,7 +324,7 @@ func TestReinitializeStreamStorage_CandidateCleanup(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create initial stream
-	genesisMb := &WriteMiniblockData{
+	genesisMb := &MiniblockDescriptor{
 		Number:   0,
 		Hash:     common.HexToHash("0x01"),
 		Data:     []byte("genesis miniblock"),
@@ -334,7 +334,7 @@ func TestReinitializeStreamStorage_CandidateCleanup(t *testing.T) {
 	require.NoError(err)
 
 	// Add multiple miniblock candidates
-	candidates := []*WriteMiniblockData{
+	candidates := []*MiniblockDescriptor{
 		{Number: 1, Hash: common.HexToHash("0xc1"), Data: []byte("candidate 1")},
 		{Number: 2, Hash: common.HexToHash("0xc2"), Data: []byte("candidate 2")},
 		{Number: 3, Hash: common.HexToHash("0xc3"), Data: []byte("candidate 3")},
@@ -354,7 +354,7 @@ func TestReinitializeStreamStorage_CandidateCleanup(t *testing.T) {
 	require.Equal(3, candidateCount)
 
 	// Reinitialize stream - must extend beyond existing miniblock 0
-	newMiniblocks := []*WriteMiniblockData{
+	newMiniblocks := []*MiniblockDescriptor{
 		{Number: 1, Data: []byte("new miniblock 1"), Snapshot: []byte("snapshot 1")},
 		{Number: 2, Data: []byte("new miniblock 2")},
 	}
@@ -385,7 +385,7 @@ func TestReinitializeStreamStorage_TransactionRollback(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create initial stream
-	genesisMb := &WriteMiniblockData{
+	genesisMb := &MiniblockDescriptor{
 		Number:   0,
 		Hash:     common.HexToHash("0x01"),
 		Data:     []byte("genesis miniblock"),
@@ -405,7 +405,7 @@ func TestReinitializeStreamStorage_TransactionRollback(t *testing.T) {
 	require.NoError(err)
 
 	// Prepare miniblocks that will cause an error (duplicate miniblock number)
-	badMiniblocks := []*WriteMiniblockData{
+	badMiniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("new mb0"), Snapshot: []byte("snapshot")},
 		{Number: 1, Data: []byte("new mb1")},
 		{Number: 1, Data: []byte("duplicate")}, // This will cause an error
@@ -436,9 +436,9 @@ func TestReinitializeStreamStorage_LargeDataSet(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create 100+ miniblocks
-	miniblocks := make([]*WriteMiniblockData, 150)
+	miniblocks := make([]*MiniblockDescriptor, 150)
 	for i := 0; i < 150; i++ {
-		miniblocks[i] = &WriteMiniblockData{
+		miniblocks[i] = &MiniblockDescriptor{
 			Number: int64(i),
 			Hash:   common.BytesToHash([]byte(fmt.Sprintf("hash%d", i))),
 			Data:   []byte(fmt.Sprintf("miniblock data %d", i)),
@@ -474,14 +474,14 @@ func TestReinitializeStreamStorage_SnapshotHandling(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		miniblocks               []*WriteMiniblockData
+		miniblocks               []*MiniblockDescriptor
 		lastSnapshotMiniblockNum int64
 		expectedSnapshot         int
 		expectedMiniblockCount   int
 	}{
 		{
 			name: "snapshot at genesis",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0"), Snapshot: []byte("snapshot0")},
 				{Number: 1, Data: []byte("mb1")},
 				{Number: 2, Data: []byte("mb2")},
@@ -492,7 +492,7 @@ func TestReinitializeStreamStorage_SnapshotHandling(t *testing.T) {
 		},
 		{
 			name: "snapshot in middle",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte("mb1"), Snapshot: []byte("snapshot1")},
 				{Number: 2, Data: []byte("mb2")},
@@ -504,7 +504,7 @@ func TestReinitializeStreamStorage_SnapshotHandling(t *testing.T) {
 		},
 		{
 			name: "snapshot at end",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte("mb1")},
 				{Number: 2, Data: []byte("mb2"), Snapshot: []byte("snapshot2")},
@@ -568,9 +568,9 @@ func TestReinitializeStreamStorage_MinipoolGeneration(t *testing.T) {
 			streamTypes := []byte{STREAM_CHANNEL_BIN, STREAM_SPACE_BIN, STREAM_DM_CHANNEL_BIN}
 			streamId := testutils.FakeStreamId(streamTypes[i%len(streamTypes)])
 
-			miniblocks := make([]*WriteMiniblockData, tt.miniblockCount)
+			miniblocks := make([]*MiniblockDescriptor, tt.miniblockCount)
 			for j := 0; j < tt.miniblockCount; j++ {
-				miniblocks[j] = &WriteMiniblockData{
+				miniblocks[j] = &MiniblockDescriptor{
 					Number: int64(j),
 					Data:   []byte(fmt.Sprintf("miniblock %d", j)),
 				}
@@ -597,7 +597,7 @@ func TestReinitializeStreamStorage_NonZeroStart(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Test miniblocks starting from non-zero
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{Number: 10, Data: []byte("mb10"), Snapshot: []byte("snapshot10")},
 		{Number: 11, Data: []byte("mb11")},
 		{Number: 12, Data: []byte("mb12")},
@@ -634,7 +634,7 @@ func TestReinitializeStreamStorage_OverlappingUpdate(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Create initial stream with miniblocks 0-3
-	initialMiniblocks := []*WriteMiniblockData{
+	initialMiniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("original mb0"), Snapshot: []byte("snapshot0")},
 		{Number: 1, Data: []byte("original mb1")},
 		{Number: 2, Data: []byte("original mb2")},
@@ -644,7 +644,7 @@ func TestReinitializeStreamStorage_OverlappingUpdate(t *testing.T) {
 	require.NoError(err)
 
 	// Update with overlapping range (2-5), existing 2-3 should remain unchanged
-	updateMiniblocks := []*WriteMiniblockData{
+	updateMiniblocks := []*MiniblockDescriptor{
 		{Number: 2, Data: []byte("new mb2 - should be ignored")},
 		{Number: 3, Data: []byte("new mb3 - should be ignored")},
 		{Number: 4, Data: []byte("new mb4")},
@@ -698,7 +698,7 @@ func TestReinitializeStreamStorage_StreamWithoutMiniblocks(t *testing.T) {
 	require.NoError(err)
 
 	// Try to update the stream - should detect the invariant violation
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{Number: 0, Data: []byte("mb0"), Snapshot: []byte("snapshot0")},
 		{Number: 1, Data: []byte("mb1")},
 	}
@@ -716,13 +716,13 @@ func TestReinitializeStreamStorage_SnapshotValidation(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		miniblocks               []*WriteMiniblockData
+		miniblocks               []*MiniblockDescriptor
 		lastSnapshotMiniblockNum int64
 		expectedError            string
 	}{
 		{
 			name: "snapshot position has no snapshot",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0"), Snapshot: []byte("snapshot0")},
 				{Number: 1, Data: []byte("mb1")}, // No snapshot
 				{Number: 2, Data: []byte("mb2")},
@@ -732,7 +732,7 @@ func TestReinitializeStreamStorage_SnapshotValidation(t *testing.T) {
 		},
 		{
 			name: "snapshot position has empty snapshot",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0"), Snapshot: []byte("snapshot0")},
 				{Number: 1, Data: []byte("mb1"), Snapshot: []byte{}}, // Empty snapshot
 				{Number: 2, Data: []byte("mb2")},
@@ -742,7 +742,7 @@ func TestReinitializeStreamStorage_SnapshotValidation(t *testing.T) {
 		},
 		{
 			name: "valid snapshot position",
-			miniblocks: []*WriteMiniblockData{
+			miniblocks: []*MiniblockDescriptor{
 				{Number: 0, Data: []byte("mb0")},
 				{Number: 1, Data: []byte("mb1"), Snapshot: []byte("snapshot1")},
 				{Number: 2, Data: []byte("mb2")},
@@ -778,7 +778,7 @@ func TestReinitializeStreamStorage_IntegerOverflow(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 
 	// Test with miniblock number at MaxInt64
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{Number: math.MaxInt64 - 1, Data: []byte("mb"), Snapshot: []byte("snapshot")},
 		{Number: math.MaxInt64, Data: []byte("mb at max")},
 	}

--- a/core/node/storage/pg_stream_store_write_miniblocks_test.go
+++ b/core/node/storage/pg_stream_store_write_miniblocks_test.go
@@ -21,17 +21,17 @@ func TestWriteMiniblocks_ValidationErrors(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Test: No miniblocks to write
-	err = store.WriteMiniblocks(ctx, streamId, []*WriteMiniblockData{}, 1, [][]byte{}, 0, 0)
+	err = store.WriteMiniblocks(ctx, streamId, []*MiniblockDescriptor{}, 1, [][]byte{}, 0, 0)
 	require.Error(err)
 	require.True(IsRiverErrorCode(err, Err_INTERNAL))
 	require.Contains(err.Error(), "No miniblocks to write")
 
 	// Test: Previous minipool generation mismatch
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 2, // Should be 1
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -42,7 +42,7 @@ func TestWriteMiniblocks_ValidationErrors(t *testing.T) {
 	require.Contains(err.Error(), "Previous minipool generation mismatch")
 
 	// Test: New minipool generation mismatch
-	miniblocks = []*WriteMiniblockData{{
+	miniblocks = []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -53,7 +53,7 @@ func TestWriteMiniblocks_ValidationErrors(t *testing.T) {
 	require.Contains(err.Error(), "New minipool generation mismatch")
 
 	// Test: Non-consecutive miniblock numbers
-	miniblocks = []*WriteMiniblockData{
+	miniblocks = []*MiniblockDescriptor{
 		{
 			Number: 1,
 			Hash:   common.BytesToHash([]byte("hash1")),
@@ -71,7 +71,7 @@ func TestWriteMiniblocks_ValidationErrors(t *testing.T) {
 	require.Contains(err.Error(), "Miniblock number are not consecutive")
 
 	// Test: Empty miniblock data
-	miniblocks = []*WriteMiniblockData{{
+	miniblocks = []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte{}, // Empty data
@@ -91,7 +91,7 @@ func TestWriteMiniblocks_SuccessfulWrite(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Add some events to the initial minipool
@@ -101,7 +101,7 @@ func TestWriteMiniblocks_SuccessfulWrite(t *testing.T) {
 	require.NoError(err)
 
 	// Write first set of miniblocks
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number:   1,
 		Hash:     common.BytesToHash([]byte("hash1")),
 		Data:     []byte("block1"),
@@ -147,14 +147,14 @@ func TestWriteMiniblocks_MultipleMiniblocksWithSnapshot(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{
 		Data:     genesisMiniblock,
 		Snapshot: []byte("genesis_snapshot"),
 	})
 	require.NoError(err)
 
 	// Write multiple miniblocks, with a snapshot in the middle
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{
 			Number: 1,
 			Hash:   common.BytesToHash([]byte("hash1")),
@@ -202,12 +202,12 @@ func TestWriteMiniblocks_CandidateCleanup(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Write some miniblock candidates
 	for i := 1; i <= 5; i++ {
-		err = store.WriteMiniblockCandidate(ctx, streamId, &WriteMiniblockData{
+		err = store.WriteMiniblockCandidate(ctx, streamId, &MiniblockDescriptor{
 			Number: int64(i),
 			Hash:   common.BytesToHash([]byte{byte(i)}),
 			Data:   []byte("candidate"),
@@ -221,7 +221,7 @@ func TestWriteMiniblocks_CandidateCleanup(t *testing.T) {
 	require.Equal(1, count)
 
 	// Write miniblocks up to block 3
-	miniblocks := []*WriteMiniblockData{
+	miniblocks := []*MiniblockDescriptor{
 		{
 			Number: 1,
 			Hash:   common.BytesToHash([]byte("hash1")),
@@ -271,7 +271,7 @@ func TestWriteMiniblocks_TransactionConsistency(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Add events to current minipool
@@ -280,7 +280,7 @@ func TestWriteMiniblocks_TransactionConsistency(t *testing.T) {
 
 	// Corrupt the database to make write fail partway through
 	// We'll delete the stream after locking it, which should cause the write to fail
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -311,7 +311,7 @@ func TestWriteMiniblocks_StreamNotFound(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	
 	// Try to write miniblocks to non-existent stream
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -331,7 +331,7 @@ func TestWriteMiniblocks_CorruptedMinipool(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Add events to minipool
@@ -352,7 +352,7 @@ func TestWriteMiniblocks_CorruptedMinipool(t *testing.T) {
 	require.NoError(err)
 
 	// Try to write miniblocks - should fail due to inconsistent minipool
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -372,11 +372,11 @@ func TestWriteMiniblocks_LastMiniblockValidation(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Write first miniblock
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -385,7 +385,7 @@ func TestWriteMiniblocks_LastMiniblockValidation(t *testing.T) {
 	require.NoError(err)
 
 	// Try to write with wrong prevMinipoolGeneration
-	miniblocks = []*WriteMiniblockData{{
+	miniblocks = []*MiniblockDescriptor{{
 		Number: 2,
 		Hash:   common.BytesToHash([]byte("hash2")),
 		Data:   []byte("block2"),
@@ -408,11 +408,11 @@ func TestWriteMiniblocks_EmptyMinipool(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Write miniblocks with empty new minipool
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),
@@ -440,7 +440,7 @@ func TestWriteMiniblocks_LargeMinipool(t *testing.T) {
 
 	streamId := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
 	genesisMiniblock := []byte("genesisMiniblock")
-	err := store.CreateStreamStorage(ctx, streamId, &WriteMiniblockData{Data: genesisMiniblock})
+	err := store.CreateStreamStorage(ctx, streamId, &MiniblockDescriptor{Data: genesisMiniblock})
 	require.NoError(err)
 
 	// Create a large minipool
@@ -451,7 +451,7 @@ func TestWriteMiniblocks_LargeMinipool(t *testing.T) {
 	}
 
 	// Write miniblocks with another large minipool
-	miniblocks := []*WriteMiniblockData{{
+	miniblocks := []*MiniblockDescriptor{{
 		Number: 1,
 		Hash:   common.BytesToHash([]byte("hash1")),
 		Data:   []byte("block1"),

--- a/core/node/storage/pg_stream_trimmer_test.go
+++ b/core/node/storage/pg_stream_trimmer_test.go
@@ -23,7 +23,7 @@ func TestStreamTrimmer(t *testing.T) {
 	streamId := testutils.FakeStreamId(STREAM_SPACE_BIN)
 	nonTrimmableStreamId := testutils.FakeStreamId(STREAM_MEDIA_BIN)
 
-	genesisMb := &WriteMiniblockData{Data: []byte("genesisMiniblock"), Snapshot: []byte("genesisSnapshot")}
+	genesisMb := &MiniblockDescriptor{Data: []byte("genesisMiniblock"), Snapshot: []byte("genesisSnapshot")}
 
 	err := pgStreamStore.CreateStreamStorage(ctx, streamId, genesisMb)
 	require.NoError(err)
@@ -34,9 +34,9 @@ func TestStreamTrimmer(t *testing.T) {
 	testEnvelopes = append(testEnvelopes, []byte("event2"))
 
 	// Generate 54 miniblocks with snapshot on each 10th miniblock
-	mbs := make([]*WriteMiniblockData, 54)
+	mbs := make([]*MiniblockDescriptor, 54)
 	for i := 1; i <= 54; i++ {
-		mb := &WriteMiniblockData{
+		mb := &MiniblockDescriptor{
 			Number: int64(i),
 			Hash:   common.BytesToHash([]byte("block_hash" + strconv.Itoa(i))),
 			Data:   []byte("block" + strconv.Itoa(i)),
@@ -104,7 +104,7 @@ func TestStreamTrimmer(t *testing.T) {
 	}, time.Second*5, 100*time.Millisecond)
 
 	// Write a new miniblock with a snapshot and check if the stream is trimmed correctly
-	newMb := &WriteMiniblockData{
+	newMb := &MiniblockDescriptor{
 		Number:   55,
 		Hash:     common.BytesToHash([]byte("block_hash" + strconv.Itoa(55))),
 		Data:     []byte("block" + strconv.Itoa(55)),
@@ -113,7 +113,7 @@ func TestStreamTrimmer(t *testing.T) {
 	err = pgStreamStore.WriteMiniblocks(
 		ctx,
 		streamId,
-		[]*WriteMiniblockData{newMb},
+		[]*MiniblockDescriptor{newMb},
 		newMb.Number+1,
 		testEnvelopes,
 		newMb.Number,

--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -24,17 +24,10 @@ type (
 		MinipoolEnvelopes       [][]byte
 	}
 
-	WriteMiniblockData struct {
-		Number   int64
-		Hash     common.Hash
-		Snapshot []byte
-		Data     []byte
-	}
-
 	MiniblockDescriptor struct {
 		Number   int64
 		Data     []byte
-		Hash     common.Hash // Only set for miniblock candidates
+		Hash     common.Hash // On read only set for miniblock candidates
 		Snapshot []byte
 	}
 
@@ -74,7 +67,7 @@ type (
 		// CreateStreamStorage creates a new stream with the given genesis miniblock at index 0.
 		// Last snapshot minblock index is set to 0.
 		// Minipool is set to generation number 1 (i.e. number of miniblock that is going to be produced next) and is empty.
-		CreateStreamStorage(ctx context.Context, streamId StreamId, genesisMiniblock *WriteMiniblockData) error
+		CreateStreamStorage(ctx context.Context, streamId StreamId, genesisMiniblock *MiniblockDescriptor) error
 
 		// ReinitializeStreamStorage initialized or reinitializes storage for the given stream.
 		//
@@ -94,13 +87,17 @@ type (
 		ReinitializeStreamStorage(
 			ctx context.Context,
 			streamId StreamId,
-			miniblocks []*WriteMiniblockData,
+			miniblocks []*MiniblockDescriptor,
 			lastSnapshotMiniblockNum int64,
 			updateExisting bool,
 		) error
 
 		// CreateEphemeralStreamStorage same as CreateStreamStorage but marks the stream as ephemeral.
-		CreateEphemeralStreamStorage(ctx context.Context, streamId StreamId, genesisMiniblock *WriteMiniblockData) error
+		CreateEphemeralStreamStorage(
+			ctx context.Context,
+			streamId StreamId,
+			genesisMiniblock *MiniblockDescriptor,
+		) error
 
 		// CreateStreamArchiveStorage creates a new archive storage for the given stream.
 		// Unlike regular CreateStreamStorage, only entry in es table and partition table for miniblocks are created.
@@ -156,7 +153,7 @@ type (
 		WriteMiniblockCandidate(
 			ctx context.Context,
 			streamId StreamId,
-			miniblock *WriteMiniblockData,
+			miniblock *MiniblockDescriptor,
 		) error
 
 		ReadMiniblockCandidate(
@@ -184,7 +181,7 @@ type (
 		WriteMiniblocks(
 			ctx context.Context,
 			streamId StreamId,
-			miniblocks []*WriteMiniblockData,
+			miniblocks []*MiniblockDescriptor,
 			newMinipoolGeneration int64,
 			newMinipoolEnvelopes [][]byte,
 			prevMinipoolGeneration int64,
@@ -193,7 +190,7 @@ type (
 
 		// WriteEphemeralMiniblock writes a miniblock as part of ephemeral stream. Skips a bunch of consistency checks.
 		// Stream with the given ID must be ephemeral.
-		WriteEphemeralMiniblock(ctx context.Context, streamId StreamId, miniblock *WriteMiniblockData) error
+		WriteEphemeralMiniblock(ctx context.Context, streamId StreamId, miniblock *MiniblockDescriptor) error
 
 		// GetMaxArchivedMiniblockNumber returns the maximum miniblock number that has been archived for the given stream.
 		// If stream record is created, but no miniblocks are archived, returns -1.
@@ -206,7 +203,7 @@ type (
 			ctx context.Context,
 			streamId StreamId,
 			startMiniblockNum int64,
-			miniblocks []*WriteMiniblockData,
+			miniblocks []*MiniblockDescriptor,
 		) error
 
 		// GetLastMiniblockNumber returns the last miniblock number for the given stream from storage.
@@ -238,7 +235,7 @@ type (
 		WritePrecedingMiniblocks(
 			ctx context.Context,
 			streamId StreamId,
-			miniblocks []*WriteMiniblockData,
+			miniblocks []*MiniblockDescriptor,
 		) error
 
 		// GetMiniblockNumberRanges returns all continuous ranges of miniblock numbers


### PR DESCRIPTION
## Summary
Remove WriteMiniblockData struct and use MiniblockDescriptor for all miniblock storage operations. This simplifies the storage interface by eliminating duplicate data structures.