### PR TITLE
refactor: extract RemoteProvider interface for cleaner testing

### DIFF
--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -25,37 +25,6 @@ const (
 	MiniblockLeaderBlockInterval = 10
 )
 
-// RemoteMiniblockProvider abstracts communications required for coordinated miniblock production.
-type RemoteMiniblockProvider interface {
-	// GetMbProposal requests miniblock proposal from the given node for the given stream.
-	// The node must participate in the stream.
-	GetMbProposal(
-		ctx context.Context,
-		node common.Address,
-		request *ProposeMiniblockRequest,
-	) (*ProposeMiniblockResponse, error)
-
-	// SaveMbCandidate sends the given mb to the given node and node must save it.
-	SaveMbCandidate(
-		ctx context.Context,
-		node common.Address,
-		streamId StreamId,
-		candidate *MiniblockInfo,
-	) error
-
-	// GetMbs returns a range of miniblocks from the given stream from the given node.
-	//
-	// Note: it is possible that the returned miniblocks range is limited when the requested miniblock
-	// range is too large. Range it limited to chain config setting `stream.getMiniblocksMaxPageSize`.
-	GetMbs(
-		ctx context.Context,
-		node common.Address,
-		streamId StreamId,
-		fromInclusive int64,
-		toExclusive int64,
-	) ([]*MiniblockInfo, error)
-}
-
 type TestMiniblockProducer interface {
 	// TestMakeMiniblock is a debug function that creates a miniblock proposal, stores it in the registry, and applies it to the stream.
 	// It is intended to be called manually from the test code.
@@ -385,7 +354,8 @@ func (p *miniblockProducer) submitProposalBatch(ctx context.Context, proposals [
 	}
 
 	for _, job := range proposals {
-		if job.replicated || len(job.reconcileNodes) > 0 || job.candidate.Ref.Num%freq == 0 || job.candidate.Ref.Num == 1 {
+		if job.replicated || len(job.reconcileNodes) > 0 || job.candidate.Ref.Num%freq == 0 ||
+			job.candidate.Ref.Num == 1 {
 			filteredProposals = append(filteredProposals, job)
 		} else {
 			success = append(success, job.stream.streamId)

--- a/core/node/events/remote_provider.go
+++ b/core/node/events/remote_provider.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/utils/rpcinterface"
 )
 
 // RemoteProvider abstracts communications required for miniblock production and stream reconciliation
@@ -45,7 +46,7 @@ type RemoteProvider interface {
 		ctx context.Context,
 		node common.Address,
 		req *GetMiniblocksByIdsRequest,
-	) (RpcStream[GetMiniblockResponse], error)
+	) (rpcinterface.ServerStreamForClient[GetMiniblockResponse], error)
 
 	// GetLastMiniblockHash returns the last miniblock hash and number for the given stream.
 	GetLastMiniblockHash(
@@ -53,11 +54,4 @@ type RemoteProvider interface {
 		node common.Address,
 		streamId StreamId,
 	) (*MiniblockRef, error)
-}
-
-type RpcStream[T any] interface {
-	Close() error
-	Err() error
-	Msg() *T
-	Receive() bool
 }

--- a/core/node/events/remote_provider.go
+++ b/core/node/events/remote_provider.go
@@ -1,0 +1,63 @@
+package events
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	. "github.com/towns-protocol/towns/core/node/protocol"
+	. "github.com/towns-protocol/towns/core/node/shared"
+)
+
+// RemoteProvider abstracts communications required for miniblock production and stream reconciliation
+// to make testing of various scenarios easier.
+type RemoteProvider interface {
+	// GetMbProposal requests miniblock proposal from the given node for the given stream.
+	// The node must participate in the stream.
+	GetMbProposal(
+		ctx context.Context,
+		node common.Address,
+		request *ProposeMiniblockRequest,
+	) (*ProposeMiniblockResponse, error)
+
+	// SaveMbCandidate sends the given mb to the given node and node must save it.
+	SaveMbCandidate(
+		ctx context.Context,
+		node common.Address,
+		streamId StreamId,
+		candidate *MiniblockInfo,
+	) error
+
+	// GetMbs returns a range of miniblocks from the given stream from the given node.
+	//
+	// Note: it is possible that the returned miniblocks range is limited when the requested miniblock
+	// range is too large. Range it limited to chain config setting `stream.getMiniblocksMaxPageSize`.
+	GetMbs(
+		ctx context.Context,
+		node common.Address,
+		streamId StreamId,
+		fromInclusive int64,
+		toExclusive int64,
+	) ([]*MiniblockInfo, error)
+
+	// GetMiniblocksByIds returns miniblocks by their ids.
+	GetMiniblocksByIds(
+		ctx context.Context,
+		node common.Address,
+		req *GetMiniblocksByIdsRequest,
+	) (RpcStream[GetMiniblockResponse], error)
+
+	// GetLastMiniblockHash returns the last miniblock hash and number for the given stream.
+	GetLastMiniblockHash(
+		ctx context.Context,
+		node common.Address,
+		streamId StreamId,
+	) (*MiniblockRef, error)
+}
+
+type RpcStream[T any] interface {
+	Close() error
+	Err() error
+	Msg() *T
+	Receive() bool
+}

--- a/core/node/events/remoteprovider/remote_provider_impl.go
+++ b/core/node/events/remoteprovider/remote_provider_impl.go
@@ -1,4 +1,4 @@
-package rpc
+package remoteprovider
 
 import (
 	"context"
@@ -7,13 +7,24 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	. "github.com/towns-protocol/towns/core/node/events"
+	. "github.com/towns-protocol/towns/core/node/nodes"
 	. "github.com/towns-protocol/towns/core/node/protocol"
+	. "github.com/towns-protocol/towns/core/node/rpc/headers"
 	. "github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/utils/rpcinterface"
 )
 
-var _ RemoteProvider = (*Service)(nil)
+type remoteProviderImpl struct {
+	nodeRegistry NodeRegistry
+}
 
-func (s *Service) GetMbProposal(
+var _ RemoteProvider = (*remoteProviderImpl)(nil)
+
+func NewRemoteProvider(nodeRegistry NodeRegistry) *remoteProviderImpl {
+	return &remoteProviderImpl{nodeRegistry: nodeRegistry}
+}
+
+func (s *remoteProviderImpl) GetMbProposal(
 	ctx context.Context,
 	node common.Address,
 	request *ProposeMiniblockRequest,
@@ -34,7 +45,7 @@ func (s *Service) GetMbProposal(
 	return resp.Msg, nil
 }
 
-func (s *Service) SaveMbCandidate(
+func (s *remoteProviderImpl) SaveMbCandidate(
 	ctx context.Context,
 	node common.Address,
 	streamId StreamId,
@@ -58,7 +69,7 @@ func (s *Service) SaveMbCandidate(
 }
 
 // GetMbs returns a range of miniblocks from the given stream.
-func (s *Service) GetMbs(
+func (s *remoteProviderImpl) GetMbs(
 	ctx context.Context,
 	node common.Address,
 	streamId StreamId,
@@ -91,4 +102,43 @@ func (s *Service) GetMbs(
 	}
 
 	return mbs, nil
+}
+
+func (s *remoteProviderImpl) GetMiniblocksByIds(
+	ctx context.Context,
+	node common.Address,
+	req *GetMiniblocksByIdsRequest,
+) (rpcinterface.ServerStreamForClient[GetMiniblockResponse], error) {
+	remote, err := s.nodeRegistry.GetNodeToNodeClientForAddress(node)
+	if err != nil {
+		return nil, err
+	}
+
+	return remote.GetMiniblocksByIds(ctx, connect.NewRequest(req))
+}
+
+func (s *remoteProviderImpl) GetLastMiniblockHash(
+	ctx context.Context,
+	node common.Address,
+	streamId StreamId,
+) (*MiniblockRef, error) {
+	remote, err := s.nodeRegistry.GetStreamServiceClientForAddress(node)
+	if err != nil {
+		return nil, err
+	}
+
+	req := connect.NewRequest(&GetLastMiniblockHashRequest{
+		StreamId: streamId[:],
+	})
+	req.Header().Set(RiverNoForwardHeader, RiverHeaderTrueValue)
+
+	resp, err := remote.GetLastMiniblockHash(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MiniblockRef{
+		Hash: common.BytesToHash(resp.Msg.Hash),
+		Num:  resp.Msg.MiniblockNum,
+	}, nil
 }

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -20,7 +20,6 @@ import (
 	"github.com/towns-protocol/towns/core/node/crypto"
 	"github.com/towns-protocol/towns/core/node/infra"
 	"github.com/towns-protocol/towns/core/node/logging"
-	. "github.com/towns-protocol/towns/core/node/nodes"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/registries"
 	. "github.com/towns-protocol/towns/core/node/shared"
@@ -44,9 +43,8 @@ type StreamCacheParams struct {
 	AppliedBlockNum         crypto.BlockNumber
 	ChainMonitor            crypto.ChainMonitor // TODO: delete and use RiverChain.ChainMonitor
 	Metrics                 infra.MetricsFactory
-	RemoteMiniblockProvider RemoteMiniblockProvider
+	RemoteMiniblockProvider RemoteProvider
 	Scrubber                Scrubber
-	NodeRegistry            NodeRegistry
 	Tracer                  trace.Tracer
 	disableCallbacks        bool // for test purposes
 	streamCache             *StreamCache

--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -5,8 +5,6 @@ import (
 	"slices"
 	"time"
 
-	"connectrpc.com/connect"
-
 	"github.com/towns-protocol/towns/core/contracts/river"
 	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/crypto"
@@ -159,20 +157,14 @@ func (s *StreamCache) normalizeEphemeralStream(
 		remotes, _ := stream.GetRemotesAndIsLocal()
 		currentStickyPeer := stream.GetStickyPeer()
 		for range len(remotes) {
-			stub, err := s.params.NodeRegistry.GetNodeToNodeClientForAddress(currentStickyPeer)
-			if err != nil {
-				logging.FromCtx(ctx).
-					Errorw("Failed to get node to node client", "error", err, "streamId", stream.streamId)
-				currentStickyPeer = stream.AdvanceStickyPeer(currentStickyPeer)
-				continue
-			}
-
-			resp, err := stub.GetMiniblocksByIds(ctx, connect.NewRequest[GetMiniblocksByIdsRequest](
+			resp, err := s.params.RemoteMiniblockProvider.GetMiniblocksByIds(
+				ctx,
+				currentStickyPeer,
 				&GetMiniblocksByIdsRequest{
 					StreamId:     stream.streamId[:],
 					MiniblockIds: missingMbs,
 				},
-			))
+			)
 			if err != nil {
 				logging.FromCtx(ctx).
 					Errorw("Failed to get miniblocks from sticky peer", "error", err, "streamId", stream.streamId)

--- a/core/node/events/util_test.go
+++ b/core/node/events/util_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/storage"
 	"github.com/towns-protocol/towns/core/node/testutils"
 	"github.com/towns-protocol/towns/core/node/testutils/testrpcstream"
+	"github.com/towns-protocol/towns/core/node/utils/rpcinterface"
 )
 
 type cacheTestContext struct {
@@ -391,7 +392,7 @@ func (ctc *cacheTestContext) GetMiniblocksByIds(
 	ctx context.Context,
 	node common.Address,
 	req *GetMiniblocksByIdsRequest,
-) (RpcStream[GetMiniblockResponse], error) {
+) (rpcinterface.ServerStreamForClient[GetMiniblockResponse], error) {
 	inst, ok := ctc.instancesByAddr[node]
 	if !ok {
 		return nil, RiverError(Err_INTERNAL, "TEST: cacheTestContext::GetMiniblocksByIds node not found", "node", node)

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/nodes"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/registries"
+	. "github.com/towns-protocol/towns/core/node/rpc/headers"
 	"github.com/towns-protocol/towns/core/node/scrub"
 	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/storage"

--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -13,16 +13,9 @@ import (
 	. "github.com/towns-protocol/towns/core/node/nodes"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
+	. "github.com/towns-protocol/towns/core/node/rpc/headers"
 	"github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/utils"
-)
-
-const (
-	RiverNoForwardHeader     = "X-River-No-Forward" // Must be set to "true" to disable forwarding
-	RiverHeaderTrueValue     = "true"
-	RiverFromNodeHeader      = "X-River-From-Node"
-	RiverToNodeHeader        = "X-River-To-Node"
-	RiverAllowNoQuorumHeader = "X-River-Allow-No-Quorum" // Must be set to "true" to allow getting data if local node is not in quorum
 )
 
 func checkNoForward[T any](req *connect.Request[T], baseErr error) error {

--- a/core/node/rpc/get_miniblocks_test.go
+++ b/core/node/rpc/get_miniblocks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/events"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/protocol/protocolconnect"
+	. "github.com/towns-protocol/towns/core/node/rpc/headers"
 	"github.com/towns-protocol/towns/core/node/testutils/testfmt"
 )
 

--- a/core/node/rpc/headers/rpc_headers.go
+++ b/core/node/rpc/headers/rpc_headers.go
@@ -1,0 +1,9 @@
+package headers
+
+const (
+	RiverNoForwardHeader     = "X-River-No-Forward" // Must be set to "true" to disable forwarding
+	RiverHeaderTrueValue     = "true"
+	RiverFromNodeHeader      = "X-River-From-Node"
+	RiverToNodeHeader        = "X-River-To-Node"
+	RiverAllowNoQuorumHeader = "X-River-Allow-No-Quorum" // Must be set to "true" to allow getting data if local node is not in quorum
+)

--- a/core/node/rpc/miniblocks.go
+++ b/core/node/rpc/miniblocks.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/towns-protocol/towns/core/node/shared"
 )
 
-var _ RemoteMiniblockProvider = (*Service)(nil)
+var _ RemoteProvider = (*Service)(nil)
 
 func (s *Service) GetMbProposal(
 	ctx context.Context,

--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	"github.com/towns-protocol/towns/core/node/events"
+	"github.com/towns-protocol/towns/core/node/events/remoteprovider"
 	"github.com/towns-protocol/towns/core/node/http_client"
 	"github.com/towns-protocol/towns/core/node/infra"
 	"github.com/towns-protocol/towns/core/node/logging"
@@ -741,8 +742,7 @@ func (s *Service) initCacheAndSync(opts *ServerStartOpts) error {
 		AppliedBlockNum:         s.riverChain.InitialBlockNum,
 		ChainMonitor:            s.riverChain.ChainMonitor,
 		Metrics:                 s.metrics,
-		RemoteMiniblockProvider: s,
-		NodeRegistry:            s.nodeRegistry,
+		RemoteMiniblockProvider: remoteprovider.NewRemoteProvider(s.nodeRegistry),
 		Tracer:                  s.otelTracer,
 	}
 

--- a/core/node/rpc/stream_replacement_test.go
+++ b/core/node/rpc/stream_replacement_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/crypto"
 	"github.com/towns-protocol/towns/core/node/protocol"
+	. "github.com/towns-protocol/towns/core/node/rpc/headers"
 	"github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/testutils/testfmt"
 )

--- a/core/node/testutils/testrpcstream/test_rpc_stream.go
+++ b/core/node/testutils/testrpcstream/test_rpc_stream.go
@@ -3,6 +3,9 @@ package testrpcstream
 import (
 	"errors"
 	"io"
+	"net/http"
+
+	"github.com/towns-protocol/towns/core/node/utils/rpcinterface"
 )
 
 type testRpcStream[T any] struct {
@@ -10,6 +13,8 @@ type testRpcStream[T any] struct {
 	cursor int
 	closed bool
 }
+
+var _ rpcinterface.ServerStreamForClient[struct{}] = (*testRpcStream[struct{}])(nil)
 
 func NewTestRpcStream[T any](data []*T) *testRpcStream[T] {
 	return &testRpcStream[T]{data: data, cursor: -1}
@@ -43,4 +48,12 @@ func (s *testRpcStream[T]) Msg() *T {
 func (s *testRpcStream[T]) Receive() bool {
 	s.cursor++
 	return s.cursor < len(s.data)
+}
+
+func (s *testRpcStream[T]) ResponseHeader() http.Header {
+	return http.Header{}
+}
+
+func (s *testRpcStream[T]) ResponseTrailer() http.Header {
+	return http.Header{}
 }

--- a/core/node/testutils/testrpcstream/test_rpc_stream.go
+++ b/core/node/testutils/testrpcstream/test_rpc_stream.go
@@ -1,0 +1,46 @@
+package testrpcstream
+
+import (
+	"errors"
+	"io"
+)
+
+type testRpcStream[T any] struct {
+	data   []*T
+	cursor int
+	closed bool
+}
+
+func NewTestRpcStream[T any](data []*T) *testRpcStream[T] {
+	return &testRpcStream[T]{data: data, cursor: -1}
+}
+
+func (s *testRpcStream[T]) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *testRpcStream[T]) Err() error {
+	if s.closed {
+		return errors.New("stream closed")
+	}
+	if s.cursor >= len(s.data) {
+		return io.EOF
+	}
+	if s.cursor < 0 {
+		return errors.New("stream not initialized")
+	}
+	return nil
+}
+
+func (s *testRpcStream[T]) Msg() *T {
+	if s.cursor >= 0 && s.cursor < len(s.data) {
+		return s.data[s.cursor]
+	}
+	return nil
+}
+
+func (s *testRpcStream[T]) Receive() bool {
+	s.cursor++
+	return s.cursor < len(s.data)
+}

--- a/core/node/utils/rpcinterface/rpc_streams.go
+++ b/core/node/utils/rpcinterface/rpc_streams.go
@@ -1,0 +1,15 @@
+// Package rpcinterface provides interfaces for RPC streams.
+// connectrpc.com/connect returns streams  as pointers to classes,
+// treating them as interfaces makes testing easier.
+package rpcinterface
+
+import "net/http"
+
+type ServerStreamForClient[Res any] interface {
+	Close() error
+	Err() error
+	Msg() *Res
+	Receive() bool
+	ResponseHeader() http.Header
+	ResponseTrailer() http.Header
+}


### PR DESCRIPTION
## Summary
- Extracted RemoteMiniblockProvider interface to new RemoteProvider interface
- Reorganized RPC interfaces and remote provider implementation
- Improved code organization by separating interfaces from implementations

## Details
This PR refactors the remote node communication interfaces to improve testability:

1. **RemoteProvider Interface**: Moved from miniblock_producer.go to dedicated remote_provider.go file with expanded methods including GetMiniblocksByIds and GetLastMiniblockHash

2. **Code Organization**:
   - Created `utils/rpcinterface` package for RPC stream interfaces
   - Created `events/remoteprovider` package for remote provider implementation
   - Created `rpc/headers` package for RPC header utilities
   - Removed redundant miniblocks.go file

3. **Test Improvements**:
   - Updated test utilities to implement the expanded interface
   - Created testrpcstream package for RPC stream testing utilities
   - Improved test helper functions in util_test.go

This refactoring makes it easier to mock and test various stream synchronization scenarios by providing a unified interface for remote node communications during testing.