### PR TITLE
Add validation for miniblock index range in getMiniblocksImpl function.

### DIFF
--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -304,6 +304,19 @@ func (s *Service) getMiniblocksImpl(
 	ctx context.Context,
 	req *connect.Request[GetMiniblocksRequest],
 ) (*connect.Response[GetMiniblocksResponse], error) {
+	if req.Msg.FromInclusive < 0 || req.Msg.ToExclusive <= req.Msg.FromInclusive {
+		return nil, RiverError(
+			Err_INVALID_ARGUMENT,
+			"Index can't be negative, and there should be at least one miniblock in the requestedrange",
+			"fromInclusive",
+			req.Msg.FromInclusive,
+			"toExclusive",
+			req.Msg.ToExclusive,
+			"streamId",
+			req.Msg.StreamId,
+		)
+	}
+
 	streamId, err := shared.StreamIdFromBytes(req.Msg.StreamId)
 	if err != nil {
 		return nil, err

--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -307,7 +307,7 @@ func (s *Service) getMiniblocksImpl(
 	if req.Msg.FromInclusive < 0 || req.Msg.ToExclusive <= req.Msg.FromInclusive {
 		return nil, RiverError(
 			Err_INVALID_ARGUMENT,
-			"Index can't be negative, and there should be at least one miniblock in the requestedrange",
+			"Index can't be negative, and there should be at least one miniblock in the requested range",
 			"fromInclusive",
 			req.Msg.FromInclusive,
 			"toExclusive",

--- a/core/node/rpc/service_norace_test.go
+++ b/core/node/rpc/service_norace_test.go
@@ -68,7 +68,7 @@ func TestGetMiniblocksRangeLimit_NoRace(t *testing.T) {
 		ToExclusive:   5,
 	}))
 	tt.require.Nil(resp)
-	tt.require.ErrorContains(err, "invalid range")
+	tt.require.ErrorContains(err, "INVALID_ARGUMENT")
 
 	tt.require.Eventually(func() bool {
 		// Requesting a list of miniblocks with the limit > max limit and expect to return "limit" miniblocks.


### PR DESCRIPTION
### Description

Miniblock index can't be negative, and there should be at least one miniblock in the requested range