### PR TITLE
chore(contract): remove quotes from URLs and update keys in `.env` fi…

### DIFF
--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -5,8 +5,8 @@ BASE_RPC_URL="${BASE_RPC_URL:-https://mainnet.base.org}"
 BASE_SEPOLIA_RPC_URL="${BASE_SEPOLIA_RPC_URL:-https://sepolia.base.org}"
 BASE_ANVIL_RPC_URL="${BASE_ANVIL_RPC_URL:-http://127.0.0.1:8545}"
 RIVER_ANVIL_RPC_URL="${RIVER_ANVIL_RPC_URL:-http://127.0.0.1:8546}"
-RIVER_RPC_URL="https://mainnet.rpc.towns.com/"
-RIVER_DEVNET_RPC_URL="https://testnet.rpc.towns.com/http"
+RIVER_RPC_URL=https://mainnet.rpc.towns.com/
+RIVER_DEVNET_RPC_URL=https://testnet.rpc.towns.com/http
 
 # PRIVATE_KEY is the private key of the account to use for deployment
 LOCAL_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -24,9 +24,9 @@ BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
 
 # URLs foundry will use to verify contracts
-BASESCAN_URL="https://api.basescan.org/api"
-BASESCAN_SEPOLIA_URL="https://api-sepolia.basescan.org/api"
-BLOCKSCOUT_BASE_URL="https://base.blockscout.com/api"
-BLOCKSCOUT_SEPOLIA_URL="https://base-sepolia.blockscout.com/api"
-RIVERSCAN_DEVNET_URL="https://testnet.explorer.towns.com/api"
-RIVERSCAN_URL="https://explorer.towns.com/api"
+BASESCAN_URL=https://api.basescan.org/api
+BASESCAN_SEPOLIA_URL=https://api-sepolia.basescan.org/api
+BLOCKSCOUT_BASE_URL=https://base.blockscout.com/api
+BLOCKSCOUT_SEPOLIA_URL=https://base-sepolia.blockscout.com/api
+RIVERSCAN_DEVNET_URL=https://testnet.explorer.towns.com/api
+RIVERSCAN_URL=https://explorer.towns.com/api

--- a/packages/contracts/.env.localhost
+++ b/packages/contracts/.env.localhost
@@ -1,5 +1,5 @@
 # RPC_URL is the URL of the Ethereum node to use for deployment
-LOCAL_RPC_URL="http://127.0.0.1:8545"
+LOCAL_RPC_URL=http://127.0.0.1:8545
 BASE_RPC_URL="${BASE_RPC_URL:-https://mainnet.base.org}"
 BASE_ANVIL_RPC_URL="${BASE_ANVIL_RPC_URL:-http://127.0.0.1:8545}"
 RIVER_ANVIL_RPC_URL="${RIVER_ANVIL_RPC_URL:-http://127.0.0.1:8546}"
@@ -19,9 +19,9 @@ BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
 
 # URLs foundry will use to verify contracts
-BASESCAN_URL="https://api.basescan.org/api"
-BASESCAN_SEPOLIA_URL="https://api-sepolia.basescan.org/api"
-BLOCKSCOUT_BASE_URL="https://base.blockscout.com/api"
-BLOCKSCOUT_SEPOLIA_URL="https://base-sepolia.blockscout.com/api"
-RIVERSCAN_DEVNET_URL="https://testnet.explorer.towns.com/api"
-RIVERSCAN_URL="https://explorer.towns.com/api"
+BASESCAN_URL=https://api.basescan.org/api
+BASESCAN_SEPOLIA_URL=https://api-sepolia.basescan.org/api
+BLOCKSCOUT_BASE_URL=https://base.blockscout.com/api
+BLOCKSCOUT_SEPOLIA_URL=https://base-sepolia.blockscout.com/api
+RIVERSCAN_DEVNET_URL=https://testnet.explorer.towns.com/api
+RIVERSCAN_URL=https://explorer.towns.com/api

--- a/packages/contracts/makefile
+++ b/packages/contracts/makefile
@@ -2,7 +2,7 @@
 
 .PHONY: all test clean deploy-base-anvil
 
-all: clean install build
+all: clean build
 
 clean :; forge clean
 
@@ -157,10 +157,10 @@ explicit-verify-any :;
 	@forge verify-contract ${address} ${contract} --verifier ${verifier} --verifier-url ${verifier-url} ${args}
 
 verify-on-blockscout :;
-	@$(MAKE) explicit-verify-any rpc=$(rpc) verifier=blockscout verifier-url=$(blockscout_url) args="$(if $(blockscout_key),--etherscan-api-key $(blockscout_key),)"
+	@$(MAKE) explicit-verify-any verifier=blockscout verifier-url=$(blockscout_url) args="$(if $(blockscout_key),--etherscan-api-key $(blockscout_key),)"
 
 verify-on-etherscan :;
-	@$(MAKE) explicit-verify-any rpc=$(rpc) verifier=etherscan verifier-url=$(etherscan_url) args="--etherscan-api-key $(etherscan_key)"
+	@$(MAKE) explicit-verify-any verifier=etherscan verifier-url=$(etherscan_url) args="--etherscan-api-key $(etherscan_key)"
 
 # ===========================
 # 					Ledger
@@ -212,9 +212,9 @@ deploy-ledger-verify-both :;
 	verifier=etherscan verifier-url=$(etherscan_url) etherscan=$(etherscan_key)
 
 deploy-facet-ledger-verify-both :;
-	@$(MAKE) deploy-facet-ledger rpc=$(rpc) hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS} \
+	@$(MAKE) deploy-facet-ledger rpc=$(rpc) hd_path=$(call format_hd_path,$(HD_PATH)) sender=$(SENDER_ADDRESS) \
 	verifier=blockscout verifier-url=$(blockscout_url) etherscan=$(blockscout_key)
-	@$(MAKE) resume-facet-ledger rpc=$(rpc) hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS} \
+	@$(MAKE) resume-facet-ledger rpc=$(rpc) hd_path=$(call format_hd_path,$(HD_PATH)) sender=$(SENDER_ADDRESS) \
 	verifier=etherscan verifier-url=$(etherscan_url) etherscan=$(etherscan_key)
 
 resume-any-ledger :;
@@ -298,12 +298,12 @@ verify-river-testnet :;
 deploy-ledger-base-sepolia :;
 	@$(MAKE) deploy-ledger-verify-both rpc=base_sepolia hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS} \
 		blockscout_url=${BLOCKSCOUT_SEPOLIA_URL} blockscout_key=${BLOCKSCOUT_SEPOLIA_API_KEY} \
-		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_API_KEY}
+		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_SEPOLIA_API_KEY}
 
 deploy-base-sepolia :;
 	@$(MAKE) deploy-verify-both rpc=base_sepolia private_key=${TESTNET_PRIVATE_KEY} \
 		blockscout_url=${BLOCKSCOUT_SEPOLIA_URL} blockscout_key=${BLOCKSCOUT_SEPOLIA_API_KEY} \
-		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_API_KEY}
+		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_SEPOLIA_API_KEY}
 
 interact-base-sepolia :;
 	@$(MAKE) interact-any rpc=base_sepolia private_key=${TESTNET_PRIVATE_KEY}


### PR DESCRIPTION
…les and Makefile

- Removed redundant quotes around URLs in `.env.localhost` and `.env.example` files.
- Fixed mismatched API keys in Makefile, aligning them with appropriate SEPOLIA values.
- Adjusted Makefile invocations to standardize variable references.
- Simplified the `all` target by removing the `install` step.