### PR TITLE
DO NOT MERGE feat: add debug stream filtering for notification service

### DIFF
--- a/core/node/notifications/debug_streams/debug_streams.go
+++ b/core/node/notifications/debug_streams/debug_streams.go
@@ -1,0 +1,36 @@
+package debug_streams
+
+import (
+	"github.com/towns-protocol/towns/core/node/shared"
+)
+
+var debugStreamIds = []string{
+	"1037f792728f5dd4049dd25442e7ed3f1a38a827d10000000000000000000000",
+	"10ccd22c91939d9d6f9bf9ce7f3ad23c8e87a111260000000000000000000000",
+}
+
+var debugStreamMap map[shared.StreamId]bool
+
+func init() {
+	debugStreamMap = make(map[shared.StreamId]bool, len(debugStreamIds))
+
+	for _, streamIdStr := range debugStreamIds {
+		streamId, err := shared.StreamIdFromString(streamIdStr)
+		if err == nil {
+			debugStreamMap[streamId] = true
+		}
+	}
+}
+
+// IsDebugStream checks if the given stream id is in the debug list. If a space stream
+// is in the debug list and this stream is a stream in that space, it will also be
+// considered a debug stream. We use this to enable conditional logging for network debugging,
+// but only for the notifications service.
+func IsDebugStream(streamId shared.StreamId) bool {
+	if _, ok := debugStreamMap[streamId]; ok {
+		return ok
+	}
+
+	_, ok := debugStreamMap[streamId.SpaceID()]
+	return ok
+}

--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/events"
 	"github.com/towns-protocol/towns/core/node/logging"
 	"github.com/towns-protocol/towns/core/node/nodes"
+	"github.com/towns-protocol/towns/core/node/notifications/debug_streams"
 	"github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/rpc/sync/client"
 	"github.com/towns-protocol/towns/core/node/rpc/sync/dynmsgbuf"
@@ -229,6 +230,20 @@ func (ssr *syncSessionRunner) applyUpdateToStream(
 			// Send notifications for all events in all blocks.
 			for _, event := range block.GetEvents() {
 				if parsedEvent, err := events.ParseEvent(event); err == nil {
+					if debug_streams.IsDebugStream(streamId) {
+						log.Infow(
+							"Saw stream event in stream tracker; forwarding (applyBlocks)",
+							"stream",
+							streamId,
+							"eventHash",
+							event.Hash,
+							"eventMiniblockRef",
+							parsedEvent.MiniblockRef,
+							"remote",
+							ssr.node,
+						)
+					}
+
 					if err := trackedView.SendEventNotification(ssr.syncCtx, parsedEvent); err != nil {
 						log.Errorw(
 							"Error sending event notification",
@@ -251,6 +266,19 @@ func (ssr *syncSessionRunner) applyUpdateToStream(
 		// will be silently skipped because they are already a part of the minipool.
 		if record.applyHistoricalContent.Enabled {
 			if parsedEvent, err := events.ParseEvent(event); err == nil {
+				if debug_streams.IsDebugStream(streamId) {
+					log.Infow(
+						"Saw stream event in stream tracker; forwarding",
+						"stream",
+						streamId,
+						"eventHash",
+						event.Hash,
+						"eventMiniblockRef",
+						parsedEvent.MiniblockRef,
+						"remote",
+						ssr.node,
+					)
+				}
 				if err := record.trackedView.SendEventNotification(ssr.syncCtx, parsedEvent); err != nil {
 					log.Errorw(
 						"Error sending notification for historical event",


### PR DESCRIPTION
- Create debug_streams package with O(1) lookup for monitored stream IDs
- Add debug logging in multi_sync_runner for tracked debug streams
- Support checking both direct stream IDs and parent space IDs

### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
