### PR TITLE
potentially fix flaky test

### DIFF
--- a/packages/sdk/src/streamEvents.ts
+++ b/packages/sdk/src/streamEvents.ts
@@ -63,7 +63,7 @@ export type StreamEncryptionEvents = {
         sigBundle: EventSignatureBundle,
     ) => void
     userDeviceKeyMessage: (streamId: string, userId: string, userDevice: UserDevice) => void
-    ephemeralKeyFulfillment: (event: KeyFulfilmentData) => void
+    ephemeralKeyFulfillment: (event: KeyFulfilmentData & { senderUserId: string }) => void
 }
 
 export type SyncedStreamEvents = {

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -378,7 +378,8 @@ export class StreamStateView {
                     userId: userIdFromAddress(fulfillment.userAddress),
                     deviceKey: fulfillment.deviceKey,
                     sessionIds: fulfillment.sessionIds,
-                } satisfies KeyFulfilmentData)
+                    senderUserId: event.creatorUserId,
+                } satisfies KeyFulfilmentData & { senderUserId: string })
                 break
             }
             case undefined:

--- a/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
+++ b/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
@@ -138,7 +138,7 @@ describe('ephemeralEvents', () => {
         await expect(chuck.joinStream(streamId)).resolves.not.toThrow()
         await expect(chuckEventDecryptedPromise).resolves.not.toThrow()
 
-        await waitFor(() => expect(ephemeralSolicitations).toEqual([true]))
+        expect(ephemeralSolicitations).toEqual([true])
 
         // Wait for at least one ephemeral fulfillment
         await waitFor(() => expect(ephemeralFulfillments.length).toBeGreaterThanOrEqual(1))

--- a/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
+++ b/packages/sdk/src/tests/multi_ne/ephemeralEvents.test.ts
@@ -122,7 +122,7 @@ describe('ephemeralEvents', () => {
 
         const ephemeralFulfillments: string[] = []
         alice.on('ephemeralKeyFulfillment', (event) => {
-            ephemeralFulfillments.push(event.userId)
+            ephemeralFulfillments.push(event.senderUserId)
         })
 
         await waitFor(() => {
@@ -138,7 +138,7 @@ describe('ephemeralEvents', () => {
         await expect(chuck.joinStream(streamId)).resolves.not.toThrow()
         await expect(chuckEventDecryptedPromise).resolves.not.toThrow()
 
-        expect(ephemeralSolicitations).toEqual([true])
+        await waitFor(() => expect(ephemeralSolicitations).toEqual([true]))
 
         // Wait for at least one ephemeral fulfillment
         await waitFor(() => expect(ephemeralFulfillments.length).toBeGreaterThanOrEqual(1))


### PR DESCRIPTION
This test is flaky. Maybe I'm missing something but:
- after random timeouts, clients are racing to fulfill a solicitation. in this case there are 3 clients (alice, bob, charlie) with keys syncing the same stream. chuck is soliciting keys.
- sometimes clients will not have had time to pick up that someone else fulfilled the solicitation at the same time, and will also send a fulfillment
- we were using `fulfillment.userId` for checking senders, but that id belongs to the key solicitor. we need to use the `senderUserId` for this approach to work