### PR TITLE
Move metrics ownership to MultiSyncRunner; add sync runner metrics

### DIFF
--- a/core/node/rpc/sync_runner_norace_test.go
+++ b/core/node/rpc/sync_runner_norace_test.go
@@ -258,7 +258,7 @@ func runMultiSyncerTest(t *testing.T, testCfg multiSyncerTestConfig) {
 
 	// Create MultiSyncRunner
 	msr := track_streams.NewMultiSyncRunner(
-		track_streams.NewTrackStreamsSyncMetrics(infra.NewMetricsFactory(nil, "", "")),
+		infra.NewMetricsFactory(nil, "", ""),
 		tt.btc.OnChainConfig,
 		[]nodes.NodeRegistry{nodeRegistry},
 		makeTrackedStreamConstructor(streamEvents),
@@ -520,7 +520,7 @@ func TestMultiSyncerWithNodeFailures(t *testing.T) {
 
 	// Create MultiSyncRunner
 	msr := track_streams.NewMultiSyncRunner(
-		track_streams.NewTrackStreamsSyncMetrics(infra.NewMetricsFactory(nil, "", "")),
+		infra.NewMetricsFactory(nil, "", ""),
 		tt.btc.OnChainConfig,
 		[]nodes.NodeRegistry{nodeRegistry},
 		makeTrackedStreamConstructor(streamEvents),
@@ -752,7 +752,7 @@ func setupColdStreamsTest(t *testing.T) *coldStreamsTestContext {
 
 	// Create MultiSyncRunner
 	msr := track_streams.NewMultiSyncRunner(
-		track_streams.NewTrackStreamsSyncMetrics(infra.NewMetricsFactory(nil, "", "")),
+		infra.NewMetricsFactory(nil, "", ""),
 		tt.btc.OnChainConfig,
 		[]nodes.NodeRegistry{nodeRegistry},
 		makeTrackedStreamConstructor(streamEvents),

--- a/core/node/track_streams/metrics.go
+++ b/core/node/track_streams/metrics.go
@@ -10,7 +10,9 @@ type TrackStreamsSyncMetrics struct {
 	ActiveStreamSyncSessions prometheus.Gauge
 	TotalStreams             *prometheus.GaugeVec
 	TrackedStreams           *prometheus.GaugeVec
+	UnsyncedQueueLength      prometheus.Gauge
 	SyncSessionsInFlight     *prometheus.GaugeVec
+	OpenSyncSessions         *prometheus.GaugeVec
 	SyncUpdate               *prometheus.CounterVec
 	SyncDown                 *prometheus.CounterVec
 	SyncPingInFlight         prometheus.Gauge
@@ -31,6 +33,9 @@ func NewTrackStreamsSyncMetrics(metricsFactory infra.MetricsFactory) *TrackStrea
 			Name: "tracked_streams",
 			Help: "Number of streams to track for notification events",
 		}, []string{"type"}), // type= dm, gdm, space_channel, user_settings
+		UnsyncedQueueLength: metricsFactory.NewGaugeEx(
+			"unsynced_queue_length", "Streams waiting to be located into a sync",
+		),
 		SyncSessionsInFlight: metricsFactory.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "syncs_inflight",
 			Help: "Number of pending sync session requests in flight",
@@ -49,5 +54,9 @@ func NewTrackStreamsSyncMetrics(metricsFactory infra.MetricsFactory) *TrackStrea
 			"Number of streams in each sync session, updated periodically",
 			[]float64{10, 20, 50, 90, 100, 110},
 		),
+		OpenSyncSessions: metricsFactory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "open_sync_sessions",
+			Help: "Number of syncs opened by the MultiSyncRunner",
+		}, []string{"node"}),
 	}
 }

--- a/core/node/track_streams/streams_tracker.go
+++ b/core/node/track_streams/streams_tracker.go
@@ -68,7 +68,6 @@ type StreamsTrackerImpl struct {
 	riverRegistry   *registries.RiverRegistryContract
 	onChainConfig   crypto.OnChainConfiguration
 	listener        StreamEventListener
-	metrics         *TrackStreamsSyncMetrics
 	tracked         *xsync.Map[shared.StreamId, struct{}]
 	multiSyncRunner *MultiSyncRunner
 }
@@ -85,14 +84,13 @@ func (tracker *StreamsTrackerImpl) Init(
 	streamTracking config.StreamTrackingConfig,
 ) error {
 	tracker.ctx = ctx
-	tracker.metrics = NewTrackStreamsSyncMetrics(metricsFactory)
 	tracker.riverRegistry = riverRegistry
 	tracker.onChainConfig = onChainConfig
 	tracker.nodeRegistries = nodeRegistries
 	tracker.listener = listener
 	tracker.filter = filter
 	tracker.multiSyncRunner = NewMultiSyncRunner(
-		tracker.metrics,
+		metricsFactory,
 		onChainConfig,
 		nodeRegistries,
 		filter.NewTrackedStream,


### PR DESCRIPTION
## Summary
- Refactored metrics to be owned by MultiSyncRunner instead of StreamsTracker
- Added two new metrics for better observability:
  - `OpenSyncSessions`: Tracks active sync sessions per target node
  - `UnsyncedQueueLength`: Monitors the pending streams queue length

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `go fmt`