### PR TITLE
Stop using shared syncer in the stress tests

### DIFF
--- a/packages/sdk/src/sync-agent/syncAgent.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.ts
@@ -39,6 +39,7 @@ export interface SyncAgentConfig {
     onTokenExpired?: () => void
     unpackEnvelopeOpts?: UnpackEnvelopeOpts
     logId?: string
+    useSharedSyncer?: boolean
 }
 
 export class SyncAgent {
@@ -93,7 +94,7 @@ export class SyncAgent {
                 unpackEnvelopeOpts: config.unpackEnvelopeOpts,
                 logId: config.logId,
                 streamOpts: {
-                    useSharedSyncer: true,
+                    useSharedSyncer: config.useSharedSyncer ?? true,
                 },
             },
             rpcRetryParams: config.retryParams,

--- a/packages/stress/src/utils/stressClient.ts
+++ b/packages/stress/src/utils/stressClient.ts
@@ -85,6 +85,7 @@ export async function makeStressClient(
             pickleKey: sha256(botPrivateKey),
         },
         logId,
+        useSharedSyncer: false,
     })
     logger.info('makeStressClient: agent created')
     await agent.start()


### PR DESCRIPTION
for now