### PR TITLE
fix(stream-metadata): reduce cache time of `/user/userId/spaces`

### DIFF
--- a/packages/stream-metadata/src/routes/userSpaces.ts
+++ b/packages/stream-metadata/src/routes/userSpaces.ts
@@ -13,8 +13,8 @@ const paramsSchema = z.object({
 })
 
 const CACHE_CONTROL = {
-	200: 'public, max-age=30, s-maxage=3600, stale-while-revalidate=3600',
-	404: 'public, max-age=5, s-maxage=3600',
+	200: 'public, max-age=30, s-maxage=60, stale-while-revalidate=60',
+	404: 'public, max-age=5, s-maxage=60',
 }
 
 export async function fetchUserSpaces(request: FastifyRequest, reply: FastifyReply) {

--- a/packages/stream-metadata/tests/integration/userSpaces.test.ts
+++ b/packages/stream-metadata/tests/integration/userSpaces.test.ts
@@ -164,7 +164,7 @@ describe('integration/stream-metadata/userSpaces', () => {
 		expect(response.status).toBe(200)
 		expect(response.headers['cache-control']).toContain('public')
 		expect(response.headers['cache-control']).toContain('max-age=30')
-		expect(response.headers['cache-control']).toContain('s-maxage=3600')
+		expect(response.headers['cache-control']).toContain('s-maxage=60')
 		log('Cache headers verified:', response.headers['cache-control'])
 	})
 })


### PR DESCRIPTION
Issue: ppl join a new town and this endpoint gets outdated

Since we dont have a way to invalidate the cache, a easy solution is to just reduce the cache time
