### PR TITLE
Fix the unsynced queue length metric

### DIFF
--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -428,7 +428,12 @@ func (ssr *syncSessionRunner) Run() {
 
 			// If the batch is nil, it means the messages channel was closed.
 			if batch == nil {
-				ssr.Close(base.RiverError(protocol.Err_BUFFER_FULL, "Sync session runner messages buffer is full, closing sync session runner"))
+				ssr.Close(
+					base.RiverError(
+						protocol.Err_BUFFER_FULL,
+						"Sync session runner messages buffer is full, closing sync session runner",
+					),
+				)
 				return
 			}
 
@@ -702,7 +707,7 @@ func (msr *MultiSyncRunner) Run(
 			case <-rootCtx.Done():
 				return
 			case <-ticker.C:
-				msr.metrics.UnsyncedQueueLength.Set(float64(len(msr.streamsToSync)))
+				msr.metrics.UnsyncedQueueLength.Set(float64(msr.workerPool.WaitingQueueSize()))
 			}
 		}
 	}()


### PR DESCRIPTION
Fix the queue length metric to refer to the size of the worker pool queue, instead of the size of a channel that's emptied by the worker pool, which will probably be close to zero even when many unsynced streams are waiting for sync session assignment.

### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
