### PR TITLE
ci: add Go code formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,44 @@ jobs:
                     exit 1
                   fi
 
+            - name: Check Go Formatting
+              if: ${{ !cancelled() && steps.setup_success.outcome == 'success' }}
+              working-directory: core
+              run: |
+                  # Install formatting tools if not present
+                  if ! command -v gofumpt >/dev/null 2>&1; then
+                    go install mvdan.cc/gofumpt@latest
+                  fi
+                  if ! command -v golines >/dev/null 2>&1; then
+                    go install github.com/segmentio/golines@latest
+                  fi
+                  if ! command -v goimports >/dev/null 2>&1; then
+                    go install golang.org/x/tools/cmd/goimports@latest
+                  fi
+                  
+                  # Check if any files need formatting
+                  echo "Checking Go code formatting..."
+                  
+                  # Capture output and exit code
+                  set +e
+                  OUTPUT=$(./fmt.sh -l 2>&1)
+                  EXIT_CODE=$?
+                  set -e
+                  
+                  if [ $EXIT_CODE -ne 0 ]; then
+                    echo "❌ Go files are not properly formatted!"
+                    echo ""
+                    if [ -n "$OUTPUT" ]; then
+                      echo "The following files need formatting:"
+                      echo "$OUTPUT"
+                      echo ""
+                    fi
+                    echo "Please run './fmt.sh' in the core directory and commit the changes."
+                    exit 1
+                  fi
+                  
+                  echo "✅ All Go files are properly formatted."
+
             - name: Generate react-sdk docs
               if: ${{ !cancelled() && steps.setup_success.outcome == 'success' }}
               working-directory: packages/react-sdk


### PR DESCRIPTION
## Summary
- Add a new CI step that checks Go code formatting using the fmt.sh script
- The step runs after linting and will fail if any Go files are not properly formatted
- This ensures consistent code style across the Go codebase

## Test plan
- This PR should fail CI if there are unformatted Go files in the core directory
- Once all Go files are properly formatted (by running ./fmt.sh in the core directory), CI should pass

🤖 Generated with [Claude Code](https://claude.ai/code)