### PR TITLE
Fix two snapshot problems in db

### DIFF
--- a/core/node/events/miniblock.go
+++ b/core/node/events/miniblock.go
@@ -47,7 +47,6 @@ func Make_GenesisMiniblockHeader(parsedEvents []*ParsedEvent) (*MiniblockHeader,
 }
 
 // MakeGenesisMiniblock creates a genesis miniblock with the given events.
-// Returns the miniblock and the snapshot envelope.
 // IMPORTANT: Genesis miniblocks use the legacy format of snapshots.
 func MakeGenesisMiniblock(
 	wallet *crypto.Wallet,

--- a/core/node/rpc/create_media_stream.go
+++ b/core/node/rpc/create_media_stream.go
@@ -227,7 +227,11 @@ func (s *Service) createReplicatedMediaStream(
 	// Create ephemeral stream within the local node
 	if isLocal {
 		sender.AddTask(func(ctx context.Context) error {
-			return s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.MiniblockDescriptor{Data: mbBytes})
+			return s.storage.CreateEphemeralStreamStorage(
+				ctx,
+				streamId,
+				&storage.MiniblockDescriptor{Data: mbBytes, HasLegacySnapshot: true},
+			)
 		})
 	}
 

--- a/core/node/rpc/node2node_ephemeral.go
+++ b/core/node/rpc/node2node_ephemeral.go
@@ -6,13 +6,11 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
-	"google.golang.org/protobuf/proto"
 
 	. "github.com/towns-protocol/towns/core/node/base"
 	. "github.com/towns-protocol/towns/core/node/events"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/shared"
-	"github.com/towns-protocol/towns/core/node/storage"
 	"github.com/towns-protocol/towns/core/node/utils"
 )
 
@@ -37,28 +35,30 @@ func (s *Service) AllocateEphemeralStream(
 	return connect.NewResponse(r), nil
 }
 
-func (s *Service) allocateEphemeralStream(ctx context.Context, req *AllocateEphemeralStreamRequest) (*AllocateEphemeralStreamResponse, error) {
+func (s *Service) allocateEphemeralStream(
+	ctx context.Context,
+	req *AllocateEphemeralStreamRequest,
+) (*AllocateEphemeralStreamResponse, error) {
 	streamId, err := StreamIdFromBytes(req.StreamId)
 	if err != nil {
 		return nil, err
 	}
 
-	mbBytes, err := proto.Marshal(req.Miniblock)
+	mbInfo, err := NewMiniblockInfoFromProto(
+		req.GetMiniblock(),
+		req.GetSnapshot(),
+		NewParsedMiniblockInfoOpts().WithExpectedBlockNumber(0),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	var snBytes []byte
-	if req.Snapshot != nil {
-		if snBytes, err = proto.Marshal(req.Snapshot); err != nil {
-			return nil, err
-		}
+	storageMb, err := mbInfo.AsStorageMb()
+	if err != nil {
+		return nil, err
 	}
 
-	if err = s.storage.CreateEphemeralStreamStorage(ctx, streamId, &storage.MiniblockDescriptor{
-		Data:     mbBytes,
-		Snapshot: snBytes,
-	}); err != nil {
+	if err = s.storage.CreateEphemeralStreamStorage(ctx, streamId, storageMb); err != nil {
 		return nil, err
 	}
 
@@ -90,7 +90,8 @@ func (s *Service) saveEphemeralMiniblock(ctx context.Context, req *SaveEphemeral
 	}
 
 	mbInfo, err := NewMiniblockInfoFromProto(
-		req.GetMiniblock(), req.GetSnapshot(),
+		req.GetMiniblock(),
+		req.GetSnapshot(),
 		NewParsedMiniblockInfoOpts(),
 	)
 	if err != nil {

--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -25,10 +25,30 @@ type (
 	}
 
 	MiniblockDescriptor struct {
-		Number   int64
-		Data     []byte
-		Hash     common.Hash // On read only set for miniblock candidates
+		// Number is the miniblock number within the stream.
+		Number int64
+
+		// Data is the miniblock data.
+		Data []byte
+
+		// Hash is the miniblock hash.
+		// NOTE: On read this field is only set for miniblock candidates.
+		// For regular miniblocks hash is not stored in db as a separate column,
+		// to get hash in this case parse it from the data.
+		Hash common.Hash
+
+		// Snapshot is the miniblock snapshot data.
+		// It's not empty if miniblock has non-legacy snapshot.
 		Snapshot []byte
+
+		// HasLegacySnapshot is true if snapshot is embedded in the Data
+		// and not stored in the Snapshot field.
+		// Legacy snapshots are embedded in the Data.
+		// Legacy snapshots are used in the miniblock 0 and in the
+		// historical data present in the system.
+		// This field is used on write to correctly set last snapshot index in es table.
+		// NOTE:This field is not set on read.
+		HasLegacySnapshot bool
 	}
 
 	EventDescriptor struct {


### PR DESCRIPTION
### Description

1. In prod for some streams last snapshot is set to -1, leading to loading failure. Return 0 in such case.

2. It appears that when legacy data is imported, last snapshot number is not set correctly.
Add HasLegacySnapshot field to MiniblockDescriptor to track legacy snapshots.