### PR TITLE
Fix flake in TestGetMiniblocksWithGapsAcrossReplicas

### DIFF
--- a/core/node/rpc/get_miniblocks_test.go
+++ b/core/node/rpc/get_miniblocks_test.go
@@ -649,8 +649,13 @@ func TestGetMiniblocksWithGapsAcrossReplicas(t *testing.T) {
 		)
 		require.NoError(err)
 		alice.addEvent(spaceId, envelope)
-		spaceLastMb, _ = alice.tryMakeMiniblock(spaceId, false, spaceLastMb.Num)
-		if spaceLastMb != nil && spaceLastMb.Num >= 49 {
+		newSpaceLastMb, err := alice.tryMakeMiniblock(spaceId, false, spaceLastMb.Num)
+		if err != nil || newSpaceLastMb == nil {
+			testfmt.Logf(t, "Failed to make miniblock: %v", err)
+			continue
+		}
+		spaceLastMb = newSpaceLastMb
+		if spaceLastMb.Num >= 49 {
 			break
 		}
 	}


### PR DESCRIPTION
### Description

Correctly handle situation if miniblock was not created on request.