### PR TITLE
Fix/mica whitepaper redirect url

### DIFF
--- a/packages/docs/mint.json
+++ b/packages/docs/mint.json
@@ -212,10 +212,7 @@
       "pages": [
         "white-paper/towns-technical-overview",
         "white-paper/technical-whitepaper",
-        {
-          "name": "MiCA Whitepaper",
-          "url": "https://towns.com/mica-whitepaper"
-        }
+        "white-paper/mica-whitepaper"
       ]
     }
   ],

--- a/packages/docs/mint.json
+++ b/packages/docs/mint.json
@@ -210,12 +210,12 @@
     {
       "group": "White Paper",
       "pages": [
-        "white-paper/towns-technical-overview",
-        "white-paper/technical-whitepaper",
         {
           "name": "MiCA Whitepaper",
           "url": "https://www.towns.com/mica-whitepaper.pdf"
-        }
+        },
+        "white-paper/towns-technical-overview",
+        "white-paper/technical-whitepaper"
       ]
     }
   ],

--- a/packages/docs/mint.json
+++ b/packages/docs/mint.json
@@ -210,12 +210,12 @@
     {
       "group": "White Paper",
       "pages": [
+        "white-paper/towns-technical-overview",
+        "white-paper/technical-whitepaper",
         {
           "name": "MiCA Whitepaper",
-          "url": "https://www.towns.com/mica-whitepaper.pdf"
-        },
-        "white-paper/towns-technical-overview",
-        "white-paper/technical-whitepaper"
+          "url": "https://towns.com/mica-whitepaper"
+        }
       ]
     }
   ],

--- a/packages/docs/white-paper/mica-whitepaper.mdx
+++ b/packages/docs/white-paper/mica-whitepaper.mdx
@@ -1,0 +1,13 @@
+---
+title: "MiCA Whitepaper"
+---
+
+import { useEffect } from "react"
+
+export default function Redirect() {
+  useEffect(() => {
+    window.location.href = "https://www.towns.com/mica-whitepaper.pdf"
+  }, [])
+
+  return <p>Redirecting to MiCA Whitepaper...</p>
+}


### PR DESCRIPTION
### Description

  Fix MiCA Whitepaper navigation link in documentation sidebar by implementing
   a proper Mintlify-compatible redirect solution.

  ### Changes

  - Created `white-paper/mica-whitepaper.mdx` with React redirect component
  that automatically redirects to PDF
  - Updated `mint.json` navigation to use string reference instead of object
  format (Mintlify requirement)
  - Changed redirect target to go directly to
  `https://www.towns.com/mica-whitepaper.pdf`
  - Ensured "MiCA Whitepaper" displays correctly in White Paper navigation
  group

  ### Checklist

  - [x] Tests added where required (N/A - navigation change)
  - [x] Documentation updated where applicable (this IS the documentation
  update)
  - [x] Changes adhere to the repository's contribution guidelines
