### PR TITLE
feat(contract): add no points check to drop facet

### DIFF
--- a/packages/contracts/src/airdrop/drop/DropFacet.sol
+++ b/packages/contracts/src/airdrop/drop/DropFacet.sol
@@ -75,7 +75,7 @@ contract DropFacet is IDropFacet, DropBase, OwnableBase, PausableBase, Facet {
 
         TownsPointsStorage.Layout storage points = TownsPointsStorage.layout();
         points.inner.burn(req.account, req.points);
-        emit IERC20.Transfer(req.account, address(0), amount);
+        emit IERC20.Transfer(req.account, address(0), req.points);
 
         drop.condition.currency.safeTransfer(req.recipient, amount);
 
@@ -104,7 +104,7 @@ contract DropFacet is IDropFacet, DropBase, OwnableBase, PausableBase, Facet {
 
         TownsPointsStorage.Layout storage points = TownsPointsStorage.layout();
         points.inner.burn(req.account, req.points);
-        emit IERC20.Transfer(req.account, address(0), amount);
+        emit IERC20.Transfer(req.account, address(0), req.points);
 
         _approveClaimToken(drop.condition.currency, amount);
 

--- a/packages/contracts/src/airdrop/drop/DropFacet.sol
+++ b/packages/contracts/src/airdrop/drop/DropFacet.sol
@@ -73,9 +73,7 @@ contract DropFacet is IDropFacet, DropBase, OwnableBase, PausableBase, Facet {
 
         drop.claim(req.account, amount);
 
-        TownsPointsStorage.Layout storage points = TownsPointsStorage.layout();
-        points.inner.burn(req.account, req.points);
-        emit IERC20.Transfer(req.account, address(0), req.points);
+        _burnPoints(req.account, req.points);
 
         drop.condition.currency.safeTransfer(req.recipient, amount);
 
@@ -102,10 +100,7 @@ contract DropFacet is IDropFacet, DropBase, OwnableBase, PausableBase, Facet {
 
         drop.claim(req.account, amount);
 
-        TownsPointsStorage.Layout storage points = TownsPointsStorage.layout();
-        points.inner.burn(req.account, req.points);
-        emit IERC20.Transfer(req.account, address(0), req.points);
-
+        _burnPoints(req.account, req.points);
         _approveClaimToken(drop.condition.currency, amount);
 
         uint256 depositId = IRewardsDistribution(DropStorage.getLayout().rewardsDistribution)
@@ -166,5 +161,16 @@ contract DropFacet is IDropFacet, DropBase, OwnableBase, PausableBase, Facet {
         uint256 conditionId
     ) external view returns (uint256) {
         return _getSupplyClaimedByWallet(conditionId, account).depositId;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        INTERNAL FUNCTIONS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _burnPoints(address from, uint256 amount) internal {
+        if (amount == 0) return;
+        TownsPointsStorage.Layout storage points = TownsPointsStorage.layout();
+        points.inner.burn(from, amount);
+        emit IERC20.Transfer(from, address(0), amount);
     }
 }

--- a/packages/contracts/test/airdrop/DropFacet.t.sol
+++ b/packages/contracts/test/airdrop/DropFacet.t.sol
@@ -72,6 +72,8 @@ contract DropFacetTest is
     uint256 internal bobKey;
     address internal alice;
     uint256 internal aliceKey;
+    address internal charlie;
+    uint256 internal charlieKey;
 
     address internal NOTIFIER = makeAddr("NOTIFIER");
     uint256 internal rewardDuration;
@@ -82,6 +84,7 @@ contract DropFacetTest is
 
         (bob, bobKey) = makeAddrAndKey("bob");
         (alice, aliceKey) = makeAddrAndKey("alice");
+        (charlie, charlieKey) = makeAddrAndKey("charlie");
 
         // Initialize the Drop facet
         dropFacet = DropFacet(riverAirdrop);
@@ -427,7 +430,7 @@ contract DropFacetTest is
                 : claimData[i].claimer;
             claimers[i] = claimData[i].claimer;
             claimAmounts[i] = claimData[i].amount == 0 ? 1 : claimData[i].amount;
-            claimPoints[i] = claimData[i].points == 0 ? 1 : claimData[i].points;
+            claimPoints[i] = claimData[i].points;
             claimData[i].amount = uint16(claimAmounts[i]);
             claimData[i].points = uint16(claimPoints[i]);
 
@@ -506,6 +509,17 @@ contract DropFacetTest is
         uint256 expectedAmount = _calculateExpectedAmount(bob);
         assertEq(towns.balanceOf(bob), expectedAmount);
         assertEq(pointsFacet.balanceOf(bob), 10);
+    }
+
+    function test_claimWithNoPoints()
+        external
+        givenTokensMinted(TOTAL_TOKEN_AMOUNT)
+        givenClaimConditionSet(5000)
+        givenWalletHasClaimedWithPenalty(charlie, charlie)
+    {
+        uint256 expectedAmount = _calculateExpectedAmount(charlie);
+        assertEq(towns.balanceOf(charlie), expectedAmount);
+        assertEq(pointsFacet.balanceOf(charlie), 0);
     }
 
     function test_revertWhen_merkleRootNotSet() external givenTokensMinted(TOTAL_TOKEN_AMOUNT) {
@@ -1648,9 +1662,13 @@ contract DropFacetTest is
         accounts.push(alice);
         amounts.push(200);
         points.push(20);
+        accounts.push(charlie);
+        amounts.push(300);
+        points.push(0);
 
         treeIndex[bob] = 0;
         treeIndex[alice] = 1;
+        treeIndex[charlie] = 2;
         (root, tree) = merkleTree.constructTree(accounts, amounts, points);
     }
 


### PR DESCRIPTION
- Introduced a new address and key in the DropFacetTest contract.
- Added a test case for account claim with no points, verifying expected balance outcomes.
- Updated claim logic to remove unnecessary default values for claim points.
- Enhanced the Merkle tree construction to include new data for claims.
- Separate burn points logic to internal function
