### PR TITLE
Fix some of the caching logic around banning users

### DIFF
--- a/packages/web3/src/cache/SimpleCache.ts
+++ b/packages/web3/src/cache/SimpleCache.ts
@@ -10,10 +10,10 @@ export class SimpleCache<K extends Keyable, V> {
      * @param maxSize Optional maximum number of entries in the cache.
      */
     constructor(args: { ttlSeconds?: number; maxSize?: number } = {}) {
-        const ttlSeconds = args.ttlSeconds !== undefined ? args.ttlSeconds * 1000 : Infinity
+        const ttlMilliseconds = args.ttlSeconds !== undefined ? args.ttlSeconds * 1000 : Infinity
         const maxSize = args.maxSize ?? 10_000
         this.cache = new TTLCache({
-            ttl: ttlSeconds,
+            ttl: ttlMilliseconds,
             max: maxSize,
         })
     }
@@ -38,13 +38,19 @@ export class SimpleCache<K extends Keyable, V> {
      * Executes a function to fetch a value if it's not in the cache,
      * stores the result, and returns it.
      */
-    async executeUsingCache(key: K, fetchFn: (key: K) => Promise<V>): Promise<V> {
+    async executeUsingCache(
+        key: K,
+        fetchFn: (key: K) => Promise<V>,
+        opts?: { skipCache?: boolean },
+    ): Promise<V> {
         const cacheKey = key.toKey()
 
         // 1. Check main cache
-        const cachedValue = this.cache.get(cacheKey)
-        if (cachedValue !== undefined) {
-            return cachedValue
+        if (opts?.skipCache !== true) {
+            const cachedValue = this.cache.get(cacheKey)
+            if (cachedValue !== undefined) {
+                return cachedValue
+            }
         }
 
         // 2. Check for pending fetch

--- a/packages/web3/src/space-dapp/SpaceDapp.ts
+++ b/packages/web3/src/space-dapp/SpaceDapp.ts
@@ -321,19 +321,41 @@ export class SpaceDapp {
         this.isBannedTokenCache.remove(new IsTokenBanned(spaceId, tokenId))
     }
 
-    public async walletAddressIsBanned(spaceId: string, walletAddress: string): Promise<boolean> {
+    public async updateCacheAfterBanOrUnBanWallet(spaceId: string, walletAddress: string) {
+        const space = this.getSpace(spaceId)
+        if (!space) {
+            throw new Error(`Space with spaceId "${spaceId}" is not found.`)
+        }
+        const tokenId = await space.ERC721AQueryable.read
+            .tokensOfOwner(walletAddress)
+            .then((tokens) => tokens[0])
+        if (!tokenId) {
+            logger.log(
+                `updateCacheAfterBanOrUnBanWallet: Token ID not found for wallet address ${walletAddress} in space ${spaceId}`,
+            )
+            return
+        }
+        this.updateCacheAfterBanOrUnBan(spaceId, tokenId)
+    }
+
+    public async walletAddressIsBanned(
+        spaceId: string,
+        walletAddress: string,
+        opts?: { skipCache?: boolean },
+    ): Promise<boolean> {
         const space = this.getSpace(spaceId)
         if (!space) {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
 
-        const token = await space.ERC721AQueryable.read
+        const tokenId = await space.ERC721AQueryable.read
             .tokensOfOwner(walletAddress)
             .then((tokens) => tokens[0])
 
         const isBanned = await this.isBannedTokenCache.executeUsingCache(
-            new IsTokenBanned(spaceId, token),
+            new IsTokenBanned(spaceId, tokenId),
             async (request) => space.Banning.read.isBanned(request.tokenId),
+            opts,
         )
         return isBanned
     }


### PR DESCRIPTION
- when bans happen in harmony they go through user ops, and the cache wasn’t being reset
- when a user is just banned, they will still have not-banned in the cache, add api option to skip the cache for the current user