### PR TITLE
chore(contract): enable npm publishing for @towns-protocol/contracts package

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -42,12 +42,15 @@
     "solidity-bytes-utils": "^0.8.4"
   },
   "files": [
+    "docs/**/*",
     "src/**/*.sol",
     "scripts/**/*.sol",
-    "./typings/index.ts",
     "README.md"
   ],
   "installConfig": {
     "hoistingLimits": "dependencies"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
### Description

Added configuration to allow the `@towns-protocol/contracts` package to be published to npm nightly. This provides developers access to contract source code, documentation, and deployment information.

### Changes

- Added `publishConfig.access: "public"` to `contracts` package.json to enable npm publishing.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines