### PR TITLE
Limit number of persisted states in Anvil to 50

### DIFF
--- a/core/justfile
+++ b/core/justfile
@@ -70,6 +70,7 @@ _anvil-start $NAME $PORT $CHAIN_ID:
             --disable-block-gas-limit \
             --disable-code-size-limit \
             --disable-min-priority-fee \
+            --max-persisted-states 50 \
             --gas-price 1 \
             > ./run_files/anvil/${NAME}.log 2>&1 &
         ../scripts/wait-for-port.sh ${PORT} anvil_${NAME}


### PR DESCRIPTION
### Description

Anvil persists unlimited number of state files to disk, eventually using the entire free space.
Using `--max-persisted-states` to limit the number of tmp files.