### PR TITLE
Subgraph alpha configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ go.work.sum
 # Ponder
 packages/subgraph/.ponder
 packages/generated/**/*.bin
+!packages/subgraph/.env.alpha
 
 # Claude local settings
 **/.claude/settings.local.json

--- a/packages/subgraph/.env.alpha
+++ b/packages/subgraph/.env.alpha
@@ -1,0 +1,5 @@
+PONDER_RPC_URL_1=https://base-sepolia.drpc.org
+# block as of 2025-04-02
+PONDER_START_BLOCK=9378183
+PONDER_ENVIRONMENT=alpha
+PONDER_CONFIG=ponder.config.alpha.ts

--- a/packages/subgraph/docker-compose-alpha.yml
+++ b/packages/subgraph/docker-compose-alpha.yml
@@ -20,8 +20,8 @@ services:
 
     subgraph:
         build:
-             context: ../../
-             dockerfile: packages/subgraph/Dockerfile
+            context: ../../
+            dockerfile: packages/subgraph/Dockerfile
         depends_on:
             subgraph-db:
                 condition: service_healthy

--- a/packages/subgraph/docker-compose-alpha.yml
+++ b/packages/subgraph/docker-compose-alpha.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+name: towns
+services:
+    subgraph-db:
+        image: postgres:16.1-alpine
+        restart: always
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U postgres']
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=postgres
+            - POSTGRES_DB=postgres
+        ports:
+            - '5432:5432'
+        volumes:
+            - subgraph-db:/var/lib/postgresql/data
+
+    subgraph:
+        build:
+             context: ../../
+             dockerfile: packages/subgraph/Dockerfile
+        depends_on:
+            subgraph-db:
+                condition: service_healthy
+        env_file:
+            - .env.alpha
+        environment:
+            - NODE_ENV=development
+            - DATABASE_SCHEMA=public
+            - DB_HOST=subgraph-db
+            - DB_PORT=5432
+            - DB_USER=postgres
+            - DB_PASSWORD=postgres
+        ports:
+            - '42069:42069'
+
+volumes:
+    subgraph-db:
+        driver: local

--- a/packages/subgraph/ponder.config.alpha.ts
+++ b/packages/subgraph/ponder.config.alpha.ts
@@ -12,6 +12,8 @@ import {
     spaceDelegationFacetAbi,
     rewardsDistributionV2Abi,
     xChainAbi,
+    swapFacetAbi,
+    swapRouterAbi,
 } from '@towns-protocol/contracts/typings'
 
 // Import our contract address utility
@@ -37,6 +39,11 @@ if (!spaceOwner) {
 const baseRegistry = getContractAddress('baseRegistry')
 if (!baseRegistry) {
     throw new Error('Base registry address not found')
+}
+
+const swapRouter = getContractAddress('swapRouter')
+if (!swapRouter) {
+    throw new Error('Swap router address not found')
 }
 
 const riverAirdrop = getContractAddress('riverAirdrop')
@@ -71,20 +78,14 @@ export default createConfig({
             startBlock,
             chain: 'alpha',
         },
-        RiverAirdrop: {
-            abi: mergeAbis([rewardsDistributionV2Abi]),
-            address: riverAirdrop,
-            startBlock,
-            chain: 'alpha',
-        },
         SpaceFactory: {
-            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi]),
+            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi, swapFacetAbi]),
             address: spaceFactory,
             startBlock,
             chain: 'alpha',
         },
         Space: {
-            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi]),
+            abi: mergeAbis([createSpaceFacetAbi, tokenPausableFacetAbi, swapFacetAbi]),
             address: factory({
                 address: spaceFactory,
                 event: parseAbiItem([
@@ -98,6 +99,18 @@ export default createConfig({
         SpaceOwner: {
             abi: spaceOwnerAbi,
             address: spaceOwner,
+            startBlock,
+            chain: 'alpha',
+        },
+        SwapRouter: {
+            abi: swapRouterAbi,
+            address: swapRouter,
+            startBlock,
+            chain: 'alpha',
+        },
+        RiverAirdrop: {
+            abi: mergeAbis([rewardsDistributionV2Abi]),
+            address: riverAirdrop,
             startBlock,
             chain: 'alpha',
         },


### PR DESCRIPTION
### Description

Setup an alpha environment for subgraph with capabilities to run alpha locally and in CI with docker-compose.

### Changes

- config, env (with public rpc url) supporting alpha subgraph instance.

### Checklist

Tested with docker compose


```
➜  subgraph git:(jt/towns-30674-alpha-subgraph-on) ✗ docker compose -f docker-compose-alpha.yml up --build
➜  subgraph git:(jt/towns-30674-alpha-subgraph-on) ✗ curl http://localhost:42069/status                  
{"alpha":{"id":84532,"block":{"number":17814533,"timestamp":1731397354}}}%                                                                            
➜  subgraph git:(jt/towns-30674-alpha-subgraph-on) ✗ curl http://localhost:42069/ready 
Historical indexing is not complete.% 
```



<img width="1382" height="1026" alt="Screenshot 2025-08-13 at 3 04 22 PM" src="https://github.com/user-attachments/assets/4b4b89ee-fe11-4b54-81ff-d5f60224f389" />

