### PR TITLE
Use ModifySync instead of AddStreamToSync and RemoveStreamFromSync

### DIFF
--- a/core/node/rpc/service_norace_test.go
+++ b/core/node/rpc/service_norace_test.go
@@ -503,11 +503,11 @@ func TestUnstableStreams_NoRace(t *testing.T) {
 		}))
 		req.NoError(err, "GetStream")
 
-		_, err = client1.AddStreamToSync(ctx, connect.NewRequest(&protocol.AddStreamToSyncRequest{
-			SyncId:  syncID,
-			SyncPos: getStreamResp.Msg.GetStream().GetNextSyncCookie(),
+		_, err = client1.ModifySync(ctx, connect.NewRequest(&protocol.ModifySyncRequest{
+			SyncId:     syncID,
+			AddStreams: []*protocol.SyncCookie{getStreamResp.Msg.GetStream().GetNextSyncCookie()},
 		}))
-		req.NoError(err, "AddStreamToSync")
+		req.NoError(err, "ModifySync")
 	}
 	mu.Unlock()
 
@@ -554,11 +554,11 @@ func TestUnstableStreams_NoRace(t *testing.T) {
 		}))
 		req.NoError(err, "GetStream")
 
-		_, err = client1.AddStreamToSync(ctx, connect.NewRequest(&protocol.AddStreamToSyncRequest{
-			SyncId:  syncID,
-			SyncPos: getStreamResp.Msg.GetStream().GetNextSyncCookie(),
+		_, err = client1.ModifySync(ctx, connect.NewRequest(&protocol.ModifySyncRequest{
+			SyncId:     syncID,
+			AddStreams: []*protocol.SyncCookie{getStreamResp.Msg.GetStream().GetNextSyncCookie()},
 		}))
-		req.NoError(err, "AddStreamToSync")
+		req.NoError(err, "ModifySync")
 	}
 	mu.Unlock()
 
@@ -624,11 +624,11 @@ func TestUnstableStreams_NoRace(t *testing.T) {
 		}))
 		req.NoError(err, "GetStream")
 
-		_, err = client1.AddStreamToSync(ctx, connect.NewRequest(&protocol.AddStreamToSyncRequest{
-			SyncId:  syncID,
-			SyncPos: getStreamResp.Msg.GetStream().GetNextSyncCookie(),
+		_, err = client1.ModifySync(ctx, connect.NewRequest(&protocol.ModifySyncRequest{
+			SyncId:     syncID,
+			AddStreams: []*protocol.SyncCookie{getStreamResp.Msg.GetStream().GetNextSyncCookie()},
 		}))
-		req.NoError(err, "AddStreamToSync")
+		req.NoError(err, "ModifySync")
 	}
 
 	sendMessagesAndReceive(100, wallets, channels, req, client0, ctx, messages, func(streamID StreamId) bool {

--- a/core/node/rpc/service_norace_test.go
+++ b/core/node/rpc/service_norace_test.go
@@ -523,11 +523,11 @@ func TestUnstableStreams_NoRace(t *testing.T) {
 	rand.Shuffle(len(channels), func(i, j int) { channels[i], channels[j] = channels[j], channels[i] })
 	for i, syncCookie := range channels {
 		streamID, _ := StreamIdFromBytes(syncCookie.GetStreamId())
-		_, err = client1.RemoveStreamFromSync(ctx, connect.NewRequest(&protocol.RemoveStreamFromSyncRequest{
-			SyncId:   syncID,
-			StreamId: streamID[:],
+		_, err = client1.ModifySync(ctx, connect.NewRequest(&protocol.ModifySyncRequest{
+			SyncId:        syncID,
+			RemoveStreams: [][]byte{streamID[:]},
 		}))
-		req.NoError(err, "RemoveStreamFromSync")
+		req.NoError(err, "ModifySync")
 
 		unsubbedStreams[streamID] = struct{}{}
 

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -874,16 +874,16 @@ func testAddStreamsToSync(tester *serviceTester) {
 	)
 	require.Nilf(err, "error calling AddEvent: %v", err)
 	// bob adds alice's stream to sync
-	_, err = bobClient.AddStreamToSync(
+	_, err = bobClient.ModifySync(
 		ctx,
 		connect.NewRequest(
-			&protocol.AddStreamToSyncRequest{
-				SyncId:  syncId,
-				SyncPos: channel1,
+			&protocol.ModifySyncRequest{
+				SyncId:     syncId,
+				AddStreams: []*protocol.SyncCookie{channel1},
 			},
 		),
 	)
-	require.NoError(err, "error calling AddStreamsToSync")
+	require.NoError(err, "error calling ModifySync")
 	// wait for the sync
 	syncRes.Receive()
 	msg := syncRes.Msg()
@@ -966,17 +966,17 @@ func testRemoveStreamsFromSync(tester *serviceTester) {
 	require.Nilf(err, "error calling AddEvent: %v", err)
 
 	// bob adds alice's stream to sync
-	resp, err := bobClient.AddStreamToSync(
+	resp, err := bobClient.ModifySync(
 		ctx,
 		connect.NewRequest(
-			&protocol.AddStreamToSyncRequest{
-				SyncId:  syncId,
-				SyncPos: channel1,
+			&protocol.ModifySyncRequest{
+				SyncId:     syncId,
+				AddStreams: []*protocol.SyncCookie{channel1},
 			},
 		),
 	)
-	require.NoError(err, "AddStreamsToSync")
-	log.Infow("AddStreamToSync", "resp", resp)
+	require.NoError(err, "ModifySync")
+	log.Infow("ModifySync", "resp", resp)
 	// When AddEvent is called, node calls streamImpl.notifyToSubscribers() twice
 	// for different events. 	See hnt-3683 for explanation. First event is for
 	// the externally added event (by AddEvent). Second event is the miniblock
@@ -1349,34 +1349,6 @@ func TestModifySyncWithWrongCookie(t *testing.T) {
 	tt.require.NoError(err)
 	tt.require.Len(resp.Msg.GetAdds(), 0)
 	tt.require.Len(resp.Msg.GetRemovals(), 0)
-}
-
-func TestAddStreamToSyncWithWrongCookie(t *testing.T) {
-	tt := newServiceTester(t, serviceTesterOpts{numNodes: 2, start: true})
-
-	alice := tt.newTestClient(0, testClientOpts{enableSync: true})
-	_ = alice.createUserStreamGetCookie()
-	spaceId, _ := alice.createSpace()
-	channelId, _, cookie := alice.createChannel(spaceId)
-
-	alice.say(channelId, "hello from Alice")
-
-	alice.startSync()
-
-	// Replace node address in the cookie with the address of the other node
-	if common.BytesToAddress(cookie.NodeAddress) == tt.nodes[0].address {
-		cookie.NodeAddress = tt.nodes[1].address.Bytes()
-	} else {
-		cookie.NodeAddress = tt.nodes[0].address.Bytes()
-	}
-
-	testfmt.Print(t, "AddStreamToSync with wrong node address in cookie")
-	_, err := alice.client.AddStreamToSync(alice.ctx, connect.NewRequest(&protocol.AddStreamToSyncRequest{
-		SyncId:  alice.SyncID(),
-		SyncPos: cookie,
-	}))
-	tt.require.NoError(err)
-	testfmt.Print(t, "AddStreamToSync with wrong node address in cookie done")
 }
 
 func TestStartSyncWithWrongCookie(t *testing.T) {

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -1005,12 +1005,12 @@ OuterLoop:
 	Act
 	*/
 	// bob removes alice's stream to sync
-	removeRes, err := bobClient.RemoveStreamFromSync(
+	removeRes, err := bobClient.ModifySync(
 		ctx,
 		connect.NewRequest(
-			&protocol.RemoveStreamFromSyncRequest{
-				SyncId:   syncId,
-				StreamId: channelId[:],
+			&protocol.ModifySyncRequest{
+				SyncId:        syncId,
+				RemoveStreams: [][]byte{channelId[:]},
 			},
 		),
 	)
@@ -1073,8 +1073,8 @@ func TestSingleAndMulti(t *testing.T) {
 		{"testMethods", testMethods},
 		{"testRiverDeviceId", testRiverDeviceId},
 		{"testSyncStreams", testSyncStreams},
-		{"testAddStreamsToSync", testAddStreamsToSync},
-		{"testRemoveStreamsFromSync", testRemoveStreamsFromSync},
+		{"testModifySyncAdd", testAddStreamsToSync},
+		{"testModifySyncRemove", testRemoveStreamsFromSync},
 	}
 
 	t.Run("single", func(t *testing.T) {

--- a/packages/sdk/src/tests/multi_ne/streamRpcClient.test.ts
+++ b/packages/sdk/src/tests/multi_ne/streamRpcClient.test.ts
@@ -415,9 +415,9 @@ describe('streamRpcClient', () => {
         })
         expect(messageCount).toEqual(1)
 
-        await alice.addStreamToSync({
+        await alice.modifySync({
             syncId,
-            syncPos: channel.stream.nextSyncCookie!,
+            addStreams: [channel.stream.nextSyncCookie!],
         })
 
         // Bob posts another message

--- a/packages/sdk/src/tests/multi_ne/streamRpcClientSync.test.ts
+++ b/packages/sdk/src/tests/multi_ne/streamRpcClientSync.test.ts
@@ -139,7 +139,7 @@ describe('streamRpcClient using v2 sync', () => {
         expect(syncId).toBeDefined()
     })
 
-    test('addStreamToSyncGetsEvents', async () => {
+    test('modifySyncGetsEvents', async () => {
         /** Arrange */
         const alice = await makeTestRpcClient()
         const alicesUserId = userIdFromAddress(alicesContext.creatorAddress)
@@ -252,9 +252,9 @@ describe('streamRpcClient using v2 sync', () => {
         })
         // bob adds alice's channel to his syncStreams
         const bobsChannelStream = await bob.getStream({ streamId: channelId }, { timeoutMs: -1 })
-        await bob.addStreamToSync({
+        await bob.modifySync({
             syncId: syncId!,
-            syncPos: bobsChannelStream.stream!.nextSyncCookie!,
+            addStreams: [bobsChannelStream.stream!.nextSyncCookie!],
         })
         // alice posts a message
         event = await makeEvent(


### PR DESCRIPTION
Start using ModifySync in tests instead of AddStreamToSync and RemoveStreamFromSync operations