### PR TITLE
Fix notifications apps configuration

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -460,6 +460,13 @@ type NotificationsConfig struct {
 	// send notifications to the client but only logs them.
 	// This is intended for development purposes. Defaults to false.
 	Simulate bool
+	// Since viper does not support arrays configurations via env var, 
+	// we can't use the Apps field directly. using two flat configuration 
+	// for towns and sendit apps for now. 
+	// in the future, this configuration (both *App and Apps) will be moved to 
+	// a database, to allow dynamic config without code changes
+	TownsApp *AppNotificationConfig
+	SenditApp *AppNotificationConfig
 	// Apps holds the notification configuration for each app
 	Apps []AppNotificationConfig
 	// APN holds the Apple Push Notification settings (deprecated - use Apps instead)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -460,12 +460,12 @@ type NotificationsConfig struct {
 	// send notifications to the client but only logs them.
 	// This is intended for development purposes. Defaults to false.
 	Simulate bool
-	// Since viper does not support arrays configurations via env var, 
-	// we can't use the Apps field directly. using two flat configuration 
-	// for towns and sendit apps for now. 
-	// in the future, this configuration (both *App and Apps) will be moved to 
+	// Since viper does not support arrays configurations via env var,
+	// we can't use the Apps field directly. using two flat configuration
+	// for towns and sendit apps for now.
+	// in the future, this configuration (both *App and Apps) will be moved to
 	// a database, to allow dynamic config without code changes
-	TownsApp *AppNotificationConfig
+	TownsApp  *AppNotificationConfig
 	SenditApp *AppNotificationConfig
 	// Apps holds the notification configuration for each app
 	Apps []AppNotificationConfig

--- a/core/node/rpc/notifications.go
+++ b/core/node/rpc/notifications.go
@@ -148,6 +148,19 @@ func StartServerInNotificationMode(
 		exitSignal:      make(chan error, 1),
 	}
 
+	// Since viper does not support arrays configurations via env var,
+	// Apps field is not initialized automatically.
+	// As a workaround, we have the TownsApp and SenditApp, and here we copy their values
+	// to the Apps field, so the rest of the code can be apps agnostic.
+	// in the future, this configuration (both *App and Apps) will be moved to
+	// a database, to allow dynamic config without code changes
+	if cfg.Notifications.TownsApp != nil {
+		cfg.Notifications.Apps = append(cfg.Notifications.Apps, *cfg.Notifications.TownsApp)
+	}
+	if cfg.Notifications.SenditApp != nil {
+		cfg.Notifications.Apps = append(cfg.Notifications.Apps, *cfg.Notifications.SenditApp)
+	}
+
 	err := notificationService.startNotificationMode(notifier, opts)
 	if err != nil {
 		notificationService.Close()

--- a/core/node/rpc/notifications.go
+++ b/core/node/rpc/notifications.go
@@ -141,15 +141,8 @@ func StartServerInNotificationMode(
 	ctx = config.CtxWithConfig(ctx, cfg)
 	ctx, ctxCancel := context.WithCancel(ctx)
 
-	notificationService := &Service{
-		serverCtx:       ctx,
-		serverCtxCancel: ctxCancel,
-		config:          cfg,
-		exitSignal:      make(chan error, 1),
-	}
-
 	// Since viper does not support arrays configurations via env var,
-	// Apps field is not initialized automatically.
+	// Apps field cannot be initialized automatically.
 	// As a workaround, we have the TownsApp and SenditApp, and here we copy their values
 	// to the Apps field, so the rest of the code can be apps agnostic.
 	// in the future, this configuration (both *App and Apps) will be moved to
@@ -159,6 +152,13 @@ func StartServerInNotificationMode(
 	}
 	if cfg.Notifications.SenditApp != nil {
 		cfg.Notifications.Apps = append(cfg.Notifications.Apps, *cfg.Notifications.SenditApp)
+	}
+
+	notificationService := &Service{
+		serverCtx:       ctx,
+		serverCtxCancel: ctxCancel,
+		config:          cfg,
+		exitSignal:      make(chan error, 1),
 	}
 
 	err := notificationService.startNotificationMode(notifier, opts)


### PR DESCRIPTION
### Description

Since viper does not support arrays configurations via env var, Apps field cannot be initialized automatically.
As a workaround, we have added the TownsApp and SenditApp fields, and we copy their values to the Apps field, so the rest of the code can stay `apps` agnostic.
in the future, this configuration (both *App and Apps) will be moved to a database, to allow dynamic config without code changes

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
