### PR TITLE
refactor(contract): use `abi.encodeCall` and update deploy logic

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -53,4 +53,8 @@ quote_style = "double"
 wrap_comments = true
 sort_imports = true
 
+[lint]
+severity = ["high", "med", "low", "gas"]
+exclude_lints = ["asm-keccak256", "erc20-unchecked-transfer", "incorrect-shift"]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/contracts/scripts/deployments/utils/DeployTownsBase.s.sol
+++ b/packages/contracts/scripts/deployments/utils/DeployTownsBase.s.sol
@@ -11,7 +11,6 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 import {Deployer} from "scripts/common/Deployer.s.sol";
 import {Towns} from "src/tokens/towns/base/Towns.sol";
 import {TownsDeployer} from "src/tokens/towns/base/TownsDeployer.sol";
-import {TownsDeployer} from "src/tokens/towns/base/TownsDeployer.sol";
 import {MockTowns} from "test/mocks/MockTowns.sol";
 import {MockTownsDeployer} from "test/mocks/MockTownsDeployer.sol";
 
@@ -24,21 +23,23 @@ contract DeployTownsBase is Deployer {
         return "utils/towns";
     }
 
-    function __deploy(address deployer) internal override returns (address) {
+    function __deploy(address deployer) internal override returns (address proxy) {
         (implSalt, proxySalt) = _getSalts();
 
         address vault = _getVault(deployer);
-        address proxy = _proxyAddress(_implAddress(implSalt), proxySalt, l1Token, vault);
+        proxy = _proxyAddress(_implAddress(implSalt), proxySalt, l1Token, vault);
 
-        vm.startBroadcast(deployer);
-        if (isAnvil()) {
-            new MockTownsDeployer(l1Token, vault, implSalt, proxySalt);
+        if (!isTesting()) {
+            vm.broadcast(deployer);
+            if (isAnvil()) {
+                new MockTownsDeployer(l1Token, vault, implSalt, proxySalt);
+            } else {
+                new TownsDeployer(l1Token, vault, implSalt, proxySalt);
+            }
         } else {
-            new TownsDeployer(l1Token, vault, implSalt, proxySalt);
+            vm.prank(deployer);
+            new MockTownsDeployer(l1Token, vault, implSalt, proxySalt);
         }
-        vm.stopBroadcast();
-
-        return proxy;
     }
 
     function _implAddress(bytes32 salt) internal view returns (address impl) {
@@ -55,12 +56,9 @@ contract DeployTownsBase is Deployer {
         address remoteToken,
         address owner
     ) internal pure returns (address proxy) {
-        bytes memory byteCode = abi.encodePacked(
+        bytes memory byteCode = bytes.concat(
             type(ERC1967Proxy).creationCode,
-            abi.encode(
-                impl,
-                abi.encodePacked(Towns.initialize.selector, abi.encode(remoteToken, owner))
-            )
+            abi.encode(impl, abi.encodeCall(Towns.initialize, (remoteToken, owner)))
         );
 
         proxy = Create2Utils.computeCreate2Address(salt, byteCode);

--- a/packages/contracts/scripts/interactions/InteractBaseAlpha.s.sol
+++ b/packages/contracts/scripts/interactions/InteractBaseAlpha.s.sol
@@ -22,7 +22,6 @@ contract InteractBaseAlpha is AlphaHelper {
     DeployRiverAirdrop deployRiverAirdrop = new DeployRiverAirdrop();
 
     function __interact(address deployer) internal override {
-        vm.setEnv("OVERRIDE_DEPLOYMENTS", "1");
         address space = getDeployment("space");
         address spaceOwner = getDeployment("spaceOwner");
         address spaceFactory = getDeployment("spaceFactory");

--- a/packages/contracts/src/tokens/towns/base/TownsDeployer.sol
+++ b/packages/contracts/src/tokens/towns/base/TownsDeployer.sol
@@ -8,7 +8,7 @@ import {Create2Utils} from "../../../utils/libraries/Create2Utils.sol";
 
 // contracts
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {Towns} from "src/tokens/towns/base/Towns.sol";
+import {Towns} from "./Towns.sol";
 
 contract TownsDeployer {
     constructor(address l1Token, address owner, bytes32 implementationSalt, bytes32 proxySalt) {
@@ -18,12 +18,9 @@ contract TownsDeployer {
         );
 
         // Create proxy initialization bytecode
-        bytes memory proxyBytecode = abi.encodePacked(
+        bytes memory proxyBytecode = bytes.concat(
             type(ERC1967Proxy).creationCode,
-            abi.encode(
-                implementation,
-                abi.encodePacked(Towns.initialize.selector, abi.encode(l1Token, owner))
-            )
+            abi.encode(implementation, abi.encodeCall(Towns.initialize, (l1Token, owner)))
         );
 
         // Deploy proxy using create2

--- a/packages/contracts/test/base/registry/DelegationProxy.t.sol
+++ b/packages/contracts/test/base/registry/DelegationProxy.t.sol
@@ -24,6 +24,7 @@ contract DelegationProxyTest is TestUtils {
         towns = deployTownsTokenBase.deploy(deployer);
         beacon = address(new UpgradeableBeacon(deployer, address(new DelegationProxy())));
         proxy = LibClone.deployERC1967BeaconProxy(beacon);
+        vm.label(towns, "Towns");
     }
 
     function test_initialize_revertIf_alreadyInitialized() public {
@@ -59,11 +60,12 @@ contract DelegationProxyTest is TestUtils {
         DelegationProxy(proxy).reinitialize(towns);
     }
 
-    function test_fuzz_reinitialize(address delegatee) public {
+    function test_fuzz_reinitialize(address delegatee, bytes32 implSalt, bytes32 proxySalt) public {
         test_fuzz_initialize(delegatee);
 
-        deployTownsTokenBase.setSalts(_randomBytes32(), _randomBytes32());
+        deployTownsTokenBase.setSalts(implSalt, proxySalt);
         address token = deployTownsTokenBase.deploy(deployer);
+        vm.assume(token != towns);
 
         vm.prank(deployer);
         DelegationProxy(proxy).reinitialize(token);

--- a/packages/contracts/test/mocks/MockTownsDeployer.sol
+++ b/packages/contracts/test/mocks/MockTownsDeployer.sol
@@ -19,12 +19,9 @@ contract MockTownsDeployer {
         );
 
         // Create proxy initialization bytecode
-        bytes memory proxyBytecode = abi.encodePacked(
+        bytes memory proxyBytecode = bytes.concat(
             type(ERC1967Proxy).creationCode,
-            abi.encode(
-                implementation,
-                abi.encodePacked(Towns.initialize.selector, abi.encode(l1Token, owner))
-            )
+            abi.encode(implementation, abi.encodeCall(Towns.initialize, (l1Token, owner)))
         );
 
         // Deploy proxy using create2


### PR DESCRIPTION
- Utilize `abi.encodeCall` for cleaner initialization bytecode.
- Simplify `_deploy` logic for improved broadcast and test handling.
- Add lint severity configuration and exclusions in `foundry.toml`.
- Enhance tests by labeling deployments and introducing additional fuzz test parameters.
- Update `Towns` imports to relative paths and remove unused environment variable in `InteractBaseAlpha`.