### PR TITLE
add row-level locking to app registry storage to prevent race conditions

### DIFF
--- a/core/node/rpc/app_registry_norace_test.go
+++ b/core/node/rpc/app_registry_norace_test.go
@@ -144,7 +144,6 @@ func testBotConversation(
 }
 
 func TestBotConversationNoRace(t *testing.T) {
-	t.Skip("Skipping TestBotConversationNoRace - flaky")
 	t.Parallel()
 
 	t.Run("Small bot chat test", func(t *testing.T) {

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -407,8 +407,6 @@ func generateSessionKeys(deviceKey string, sessionIds []string) string {
 }
 
 func TestAppRegistry_ForwardsChannelEvents(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 
@@ -566,8 +564,6 @@ func registerWebhook(
 }
 
 func TestAppRegistry_SetGetAppMetadata(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 	tester := NewAppRegistryServiceTester(t, &appRegistryTesterOpts{numBots: 3})
 	tester.StartBotServices()
 	_, _ = tester.RegisterBotService(0, protocol.ForwardSettingValue_FORWARD_SETTING_UNSPECIFIED)
@@ -1203,8 +1199,6 @@ func TestAppRegistry_SetGetAppMetadata(t *testing.T) {
 }
 
 func TestAppRegistry_SetGetSettings(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 	tester.StartBotServices()
@@ -1296,8 +1290,6 @@ func TestAppRegistry_SetGetSettings(t *testing.T) {
 }
 
 func TestAppRegistry_MessageForwardSettings(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	ctx := test.NewTestContext(t)
 	require := require.New(t)
@@ -1533,8 +1525,6 @@ func TestAppRegistry_MessageForwardSettings(t *testing.T) {
 }
 
 func TestAppRegistry_GetSession(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 	require := tester.require
@@ -1688,8 +1678,6 @@ func TestAppRegistry_GetSession(t *testing.T) {
 }
 
 func TestAppRegistry_RegisterWebhook(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 	require := tester.require
@@ -1823,8 +1811,6 @@ func TestAppRegistry_RegisterWebhook(t *testing.T) {
 }
 
 func TestAppRegistry_Status(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 
@@ -1932,8 +1918,6 @@ func TestAppRegistry_Status(t *testing.T) {
 }
 
 func TestAppRegistry_RotateSecret(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 	appWallet, ownerWallet := tester.BotWallets(0)
@@ -2006,8 +1990,6 @@ func TestAppRegistry_RotateSecret(t *testing.T) {
 }
 
 func TestAppRegistry_ValidateBotName(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, &appRegistryTesterOpts{numBots: 2})
 	tester.StartBotServices()
@@ -2089,8 +2071,6 @@ func TestAppRegistry_ValidateBotName(t *testing.T) {
 }
 
 func TestAppRegistry_Register(t *testing.T) {
-	// TODO: refactor app registry sql to use row-locking in order to fix flakes
-	t.Skip("flaky")
 
 	tester := NewAppRegistryServiceTester(t, nil)
 


### PR DESCRIPTION
- Add lockApp method with FOR UPDATE/FOR SHARE locking pattern

- Update all write operations (createApp, updateSettings, rotateSecret, registerWebhook, setAppMetadata) to use row locking

  - Remove locking from read operations in read-only transactions to avoid PostgreSQL errors

  - Re-enable 11 previously skipped flaky tests that were affected by race conditions

**Made by Claude Code**