### PR TITLE
chore(contract): replace `BASESCAN_API_KEY` with `ETHERSCAN_API_KEY` …

### DIFF
--- a/.github/workflows/Bytecode_diff_report.yml
+++ b/.github/workflows/Bytecode_diff_report.yml
@@ -7,7 +7,7 @@ env:
     BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
     FACET_SOURCE_PATH: ../../packages/contracts/src
     REPORT_OUT_DIR: ${{ vars.REPORT_OUT_DIR }}
-    BASESCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+    ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
     BASESCAN_SEPOLIA_URL: 'https://api.etherscan.io/v2/api?chainid=84532'
     BASESCAN_URL: 'https://api.etherscan.io/v2/api?chainid=8453'
     BLOCKSCOUT_SEPOLIA_URL: 'https://base-sepolia.blockscout.com/api'
@@ -56,7 +56,7 @@ on:
                 required: true
             BASE_SEPOLIA_RPC_URL:
                 required: true
-            BASESCAN_API_KEY:
+            ETHERSCAN_API_KEY:
                 required: true
             BLOCKSCOUT_BASE_SEPOLIA_API_KEY:
                 required: true
@@ -113,7 +113,7 @@ jobs:
               working-directory: packages/contracts/scripts/bytecode-diff
               env:
                   REPORT_OUT_DIR: ${{ env.REPORT_OUT_DIR }}
-                  BASESCAN_API_KEY: ${{ env.BASESCAN_API_KEY }}
+                  ETHERSCAN_API_KEY: ${{ env.ETHERSCAN_API_KEY }}
                   BASE_RPC_URL: ${{ env.BASE_RPC_URL }}
                   BASE_SEPOLIA_RPC_URL: ${{ env.BASE_SEPOLIA_RPC_URL }}
                   FACET_SOURCE_PATH: ${{ env.FACET_SOURCE_PATH }}
@@ -137,7 +137,7 @@ jobs:
                   BLOCKSCOUT_SEPOLIA_API_KEY: ${{ env.BLOCKSCOUT_SEPOLIA_API_KEY }}
                   BLOCKSCOUT_BASE_URL: ${{ env.BLOCKSCOUT_BASE_URL }}
                   BLOCKSCOUT_BASE_API_KEY: ${{ env.BLOCKSCOUT_BASE_API_KEY }}
-                  BASESCAN_API_KEY: ${{ env.BASESCAN_API_KEY }}
+                  ETHERSCAN_API_KEY: ${{ env.ETHERSCAN_API_KEY }}
                   BASESCAN_SEPOLIA_URL: ${{ env.BASESCAN_SEPOLIA_URL }}
                   BASESCAN_URL: ${{ env.BASESCAN_URL }}
                   TESTNET_PRIVATE_KEY: ${{ env.TESTNET_PRIVATE_KEY }}

--- a/.github/workflows/Bytecode_diff_report.yml
+++ b/.github/workflows/Bytecode_diff_report.yml
@@ -7,9 +7,9 @@ env:
     BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
     FACET_SOURCE_PATH: ../../packages/contracts/src
     REPORT_OUT_DIR: ${{ vars.REPORT_OUT_DIR }}
-    BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
-    BASESCAN_SEPOLIA_URL: 'https://api-sepolia.basescan.org/api'
-    BASESCAN_URL: 'https://api.basescan.org/api'
+    BASESCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+    BASESCAN_SEPOLIA_URL: 'https://api.etherscan.io/v2/api?chainid=84532'
+    BASESCAN_URL: 'https://api.etherscan.io/v2/api?chainid=8453'
     BLOCKSCOUT_SEPOLIA_URL: 'https://base-sepolia.blockscout.com/api'
     BLOCKSCOUT_BASE_URL: 'https://base.blockscout.com/api'
     BLOCKSCOUT_SEPOLIA_API_KEY: ${{ secrets.BLOCKSCOUT_BASE_SEPOLIA_API_KEY }}

--- a/.github/workflows/Network_diff_upgrade.yml
+++ b/.github/workflows/Network_diff_upgrade.yml
@@ -26,7 +26,7 @@ jobs:
         secrets:
             BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
             BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
-            BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+            ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
             BLOCKSCOUT_BASE_API_KEY: ${{ secrets.BLOCKSCOUT_BASE_API_KEY }}
             BLOCKSCOUT_BASE_SEPOLIA_API_KEY: ${{ secrets.BLOCKSCOUT_BASE_SEPOLIA_API_KEY }}
             GAMMA_BASE_SEPOLIA_DEPLOYER_PK: ${{ secrets.GAMMA_BASE_SEPOLIA_DEPLOYER_PK }}
@@ -45,7 +45,7 @@ jobs:
         secrets:
             BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
             BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
-            BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+            ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
             BLOCKSCOUT_BASE_API_KEY: ${{ secrets.BLOCKSCOUT_BASE_API_KEY }}
             BLOCKSCOUT_BASE_SEPOLIA_API_KEY: ${{ secrets.BLOCKSCOUT_BASE_SEPOLIA_API_KEY }}
             GAMMA_BASE_SEPOLIA_DEPLOYER_PK: ${{ secrets.GAMMA_BASE_SEPOLIA_DEPLOYER_PK }}

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -18,14 +18,13 @@ HD_PATH="m/44\'/60\'/0\'/0/0"
 # ETHERSCAN_API_KEY is the API key for Etherscan
 # API Keys to use when verifying contracts on etherscan
 ETHERSCAN_API_KEY=
-BASESCAN_API_KEY=
-BASESCAN_SEPOLIA_API_KEY=
 BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
 
 # URLs foundry will use to verify contracts
-BASESCAN_URL=https://api.basescan.org/api
-BASESCAN_SEPOLIA_URL=https://api-sepolia.basescan.org/api
+ETHERSCAN_URL=https://api.etherscan.io/v2/api?chainid=1
+BASESCAN_URL=https://api.etherscan.io/v2/api?chainid=8453
+BASESCAN_SEPOLIA_URL=https://api.etherscan.io/v2/api?chainid=84532
 BLOCKSCOUT_BASE_URL=https://base.blockscout.com/api
 BLOCKSCOUT_SEPOLIA_URL=https://base-sepolia.blockscout.com/api
 RIVERSCAN_DEVNET_URL=https://testnet.explorer.towns.com/api

--- a/packages/contracts/.env.localhost
+++ b/packages/contracts/.env.localhost
@@ -13,14 +13,13 @@ HD_PATH="m/44\'/60\'/0\'/0/0"
 # ETHERSCAN_API_KEY is the API key for Etherscan
 # API Keys to use when verifying contracts on etherscan
 ETHERSCAN_API_KEY=
-BASESCAN_API_KEY=
-BASESCAN_SEPOLIA_API_KEY=
 BLOCKSCOUT_BASE_API_KEY=
 BLOCKSCOUT_SEPOLIA_API_KEY=
 
 # URLs foundry will use to verify contracts
-BASESCAN_URL=https://api.basescan.org/api
-BASESCAN_SEPOLIA_URL=https://api-sepolia.basescan.org/api
+ETHERSCAN_URL=https://api.etherscan.io/v2/api?chainid=1
+BASESCAN_URL=https://api.etherscan.io/v2/api?chainid=8453
+BASESCAN_SEPOLIA_URL=https://api.etherscan.io/v2/api?chainid=84532
 BLOCKSCOUT_BASE_URL=https://base.blockscout.com/api
 BLOCKSCOUT_SEPOLIA_URL=https://base-sepolia.blockscout.com/api
 RIVERSCAN_DEVNET_URL=https://testnet.explorer.towns.com/api

--- a/packages/contracts/CLAUDE.md
+++ b/packages/contracts/CLAUDE.md
@@ -251,7 +251,7 @@ Key environment variables needed:
 - `LOCAL_PRIVATE_KEY` - For local deployments
 - `TESTNET_PRIVATE_KEY` - For testnet deployments
 - `BASE_RPC_URL`, `BASE_ANVIL_RPC_URL`, etc. - RPC endpoints
-- `BASESCAN_API_KEY` - For contract verification
+- `ETHERSCAN_API_KEY` - For contract verification
 - `HD_PATH`, `SENDER_ADDRESS` - For hardware wallet deployments
 
 ## Common Workflows

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -16,8 +16,6 @@ test = "test" # The path to the test contract sources relative to the root of th
 extra_output = ["abi", "bin"]
 extra_output_files = ["abi", "bin"]
 
-
-
 # Test settings
 fuzz = { runs = 256 } # The amount of fuzz runs to perform for each fuzz test case.
 cache_path = "cache" # The path to the cache, relative to the root of the project.

--- a/packages/contracts/makefile
+++ b/packages/contracts/makefile
@@ -160,7 +160,7 @@ verify-on-blockscout :;
 	@$(MAKE) explicit-verify-any verifier=blockscout verifier-url=$(blockscout_url) args="$(if $(blockscout_key),--etherscan-api-key $(blockscout_key),)"
 
 verify-on-etherscan :;
-	@$(MAKE) explicit-verify-any verifier=etherscan verifier-url=$(etherscan_url) args="--etherscan-api-key $(etherscan_key)"
+	@$(MAKE) explicit-verify-any verifier=etherscan verifier-url=$(etherscan_url) args="--etherscan-api-key $(ETHERSCAN_API_KEY)"
 
 # ===========================
 # 					Ledger
@@ -298,12 +298,12 @@ verify-river-testnet :;
 deploy-ledger-base-sepolia :;
 	@$(MAKE) deploy-ledger-verify-both rpc=base_sepolia hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS} \
 		blockscout_url=${BLOCKSCOUT_SEPOLIA_URL} blockscout_key=${BLOCKSCOUT_SEPOLIA_API_KEY} \
-		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_SEPOLIA_API_KEY}
+		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${ETHERSCAN_API_KEY}
 
 deploy-base-sepolia :;
 	@$(MAKE) deploy-verify-both rpc=base_sepolia private_key=${TESTNET_PRIVATE_KEY} \
 		blockscout_url=${BLOCKSCOUT_SEPOLIA_URL} blockscout_key=${BLOCKSCOUT_SEPOLIA_API_KEY} \
-		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_SEPOLIA_API_KEY}
+		etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${ETHERSCAN_API_KEY}
 
 interact-base-sepolia :;
 	@$(MAKE) interact-any rpc=base_sepolia private_key=${TESTNET_PRIVATE_KEY}
@@ -313,7 +313,7 @@ fork-base-sepolia :;
 
 verify-base-sepolia :;
 	@$(MAKE) verify-on-blockscout rpc=base_sepolia blockscout_url=${BLOCKSCOUT_SEPOLIA_URL} blockscout_key=${BLOCKSCOUT_SEPOLIA_API_KEY}
-	@$(MAKE) verify-on-etherscan rpc=base_sepolia etherscan_url=${BASESCAN_SEPOLIA_URL} etherscan_key=${BASESCAN_API_KEY}
+	@$(MAKE) verify-on-etherscan rpc=base_sepolia etherscan_url=${BASESCAN_SEPOLIA_URL}
 
 # ===========================
 # 				Sepolia
@@ -353,7 +353,7 @@ interact-river :;
 deploy-base :;
 	@$(MAKE) deploy-ledger-verify-both rpc=base hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS} \
 		blockscout_url=${BLOCKSCOUT_BASE_URL} blockscout_key=${BLOCKSCOUT_BASE_API_KEY} \
-		etherscan_url=${BASESCAN_URL} etherscan_key=${BASESCAN_API_KEY}
+		etherscan_url=${BASESCAN_URL} etherscan_key=${ETHERSCAN_API_KEY}
 
 interact-base :;
 	@$(MAKE) interact-any-ledger rpc=base hd_path=$(call format_hd_path,$(HD_PATH)) sender=${SENDER_ADDRESS}
@@ -363,7 +363,7 @@ fork-base :;
 
 verify-base :;
 	@$(MAKE) verify-on-blockscout rpc=base blockscout_url=${BLOCKSCOUT_BASE_URL} blockscout_key=${BLOCKSCOUT_BASE_API_KEY}
-	@$(MAKE) verify-on-etherscan rpc=base etherscan_url=${BASESCAN_URL} etherscan_key=${BASESCAN_API_KEY}
+	@$(MAKE) verify-on-etherscan rpc=base etherscan_url=${BASESCAN_URL}
 
 # ===========================
 # 				Mainnet
@@ -379,7 +379,7 @@ fork-mainnet :;
 
 verify-mainnet :;
 	@$(MAKE) verify-any rpc=mainnet
-	@$(MAKE) verify-on-etherscan rpc=mainnet etherscan_url=${ETHERSCAN_URL} etherscan_key=${ETHERSCAN_API_KEY}
+	@$(MAKE) verify-on-etherscan rpc=mainnet etherscan_url=${ETHERSCAN_URL}
 
 
 # ================================== ENVIRONMENTS ==================================
@@ -448,5 +448,5 @@ interact-any-account :;
 	--rpc-url ${rpc} --broadcast --verify --verifier-url ${verifier-url} --verifier ${verifier} ${args}
 
 deploy-base-sepolia-with-account :;
-	@$(MAKE) deploy-any-account rpc=base_sepolia verifier=etherscan verifier-url=${BASESCAN_SEPOLIA_URL} args="--etherscan-api-key ${BASESCAN_SEPOLIA_API_KEY}"
+	@$(MAKE) deploy-any-account rpc=base_sepolia verifier=etherscan verifier-url=${BASESCAN_SEPOLIA_URL} args="--etherscan-api-key ${ETHERSCAN_API_KEY}"
 	@$(MAKE) deploy-any-account rpc=base_sepolia verifier=blockscout verifier-url=${BLOCKSCOUT_SEPOLIA_URL} args="--resume"

--- a/packages/contracts/scripts/bytecode-diff/README.md
+++ b/packages/contracts/scripts/bytecode-diff/README.md
@@ -136,7 +136,7 @@ You can also set the following environment variables instead of using flags:
 - `BASE_RPC_URL`: Base RPC provider URL
 - `BASE_SEPOLIA_RPC_URL`: Base Sepolia RPC provider URL
 - `FACET_SOURCE_PATH`: Path to facet source files
-- `BASESCAN_API_KEY`: Your API key for BaseScan.
+- `ETHERSCAN_API_KEY`: Your API key for Etherscan.
 - `COMPILED_FACETS_PATH`: (Optional) Path to compiled facets
 - `DEPLOYMENTS_PATH`: (Optional) Path to deployed contracts
 - `REPORT_OUT_DIR`: (Optional) Path to report output directory

--- a/packages/contracts/scripts/bytecode-diff/cmd/root.go
+++ b/packages/contracts/scripts/bytecode-diff/cmd/root.go
@@ -171,7 +171,7 @@ var rootCmd = &cobra.Command{
 		baseConfig := utils.BaseConfig{
 			BaseRpcUrl:        baseRpcUrl,
 			BaseSepoliaRpcUrl: baseSepoliaRpcUrl,
-			BasescanAPIKey:    os.Getenv("BASESCAN_API_KEY"),
+			EtherscanAPIKey:   os.Getenv("ETHERSCAN_API_KEY"),
 		}
 		riverConfig := utils.RiverChainConfig{
 			MainnetRpcUrl:   riverRpcUrl,
@@ -217,9 +217,9 @@ var rootCmd = &cobra.Command{
 				}
 			}
 
-			basescanAPIKey := os.Getenv("BASESCAN_API_KEY")
-			if basescanAPIKey == "" {
-				log.Fatal().Msg("BaseScan API key not provided. Set it using BASESCAN_API_KEY environment variable")
+			etherscanAPIKey := os.Getenv("ETHERSCAN_API_KEY")
+			if etherscanAPIKey == "" {
+				log.Fatal().Msg("Etherscan API key not provided. Set it using ETHERSCAN_API_KEY environment variable")
 			}
 
 			log.Info().Str("sourceEnvironment", sourceEnvironment).Str("targetEnvironment", targetEnvironment).Msg("Running diff for environment")
@@ -307,7 +307,7 @@ func executeSourceDiff(
 		facets, err := utils.ReadAllFacets(
 			clients.BaseClient,
 			diamondAddress,
-			chainConfig.BaseConfig.BasescanAPIKey,
+			chainConfig.BaseConfig.EtherscanAPIKey,
 			false,
 			&baseScanChain,
 		)
@@ -438,7 +438,7 @@ func executeEnvrionmentDiff(
 		facets, err := utils.ReadAllFacets(
 			clients[sourceEnvironment].BaseRpcClient,
 			diamondAddress,
-			chainConfig.BaseConfig.BasescanAPIKey,
+			chainConfig.BaseConfig.EtherscanAPIKey,
 			true,
 			&baseScanChain,
 		)
@@ -485,7 +485,7 @@ func executeEnvrionmentDiff(
 		facets, err := utils.ReadAllFacets(
 			clients[targetEnvironment].BaseRpcClient,
 			diamondAddress,
-			chainConfig.BaseConfig.BasescanAPIKey,
+			chainConfig.BaseConfig.EtherscanAPIKey,
 			true,
 			&baseScanChain,
 		)

--- a/packages/contracts/scripts/bytecode-diff/scripts/upgrade-facets.sh
+++ b/packages/contracts/scripts/bytecode-diff/scripts/upgrade-facets.sh
@@ -58,7 +58,7 @@ process_file() {
         chain_id=8453
         context="omega"
         make_command="make deploy-any rpc=base private_key=${OMEGA_PRIVATE_KEY}"
-        resume_any="make resume-any rpc=base private_key=${OMEGA_PRIVATE_KEY} verifier=${BASESCAN_URL} etherscan=${BASESCAN_API_KEY}"
+        resume_any="make resume-any rpc=base private_key=${OMEGA_PRIVATE_KEY} verifier=${BASESCAN_URL} etherscan=${ETHERSCAN_API_KEY}"
     elif [[ "$network" == "gamma" ]]; then
         chain_id=84532
         context="gamma"

--- a/packages/contracts/scripts/bytecode-diff/scripts/upgrade-facets.sh
+++ b/packages/contracts/scripts/bytecode-diff/scripts/upgrade-facets.sh
@@ -58,7 +58,7 @@ process_file() {
         chain_id=8453
         context="omega"
         make_command="make deploy-any rpc=base private_key=${OMEGA_PRIVATE_KEY}"
-        resume_any="make resume-any rpc=base private_key=${OMEGA_PRIVATE_KEY} verifier=${BASESCAN_URL} etherscan=${ETHERSCAN_API_KEY}"
+        resume_any="make resume-any rpc=base private_key=${OMEGA_PRIVATE_KEY} verifier=etherscan verifier-url=${BASESCAN_URL} etherscan=${ETHERSCAN_API_KEY}"
     elif [[ "$network" == "gamma" ]]; then
         chain_id=84532
         context="gamma"

--- a/scripts/verify-facets-basescan.sh
+++ b/scripts/verify-facets-basescan.sh
@@ -8,7 +8,7 @@ fi
 
 SOURCE_DIFF_YAML=$1
 BASESCAN_SEPOLIA_URL=${BASESCAN_SEPOLIA_URL:-'https://api-sepolia.basescan.org/api'}
-BASESCAN_SEPOLIA_API_KEY=${BASESCAN_SEPOLIA_API_KEY:-'your_api_key_here'}
+ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY:-'your_api_key_here'}
 echo "Source diff yaml: ${SOURCE_DIFF_YAML}"
 
 # Read the updated facets from the YAML file and verify each one
@@ -21,7 +21,7 @@ yq e '.updated[].facets[]' "${SOURCE_DIFF_YAML}" | while read -r facet; do
     make explicit-verify-any \
         rpc=base-sepolia \
         verifier="${BASESCAN_SEPOLIA_URL}" \
-        etherscan="${BASESCAN_SEPOLIA_API_KEY}" \
+        etherscan="${ETHERSCAN_API_KEY}" \
         address="${DEPLOYED_ADDRESS}" \
         contract="${FACET_NAME}"
 done 

--- a/scripts/verify-facets-basescan.sh
+++ b/scripts/verify-facets-basescan.sh
@@ -18,10 +18,8 @@ yq e '.updated[].facets[]' "${SOURCE_DIFF_YAML}" | while read -r facet; do
     
     echo "Verifying $FACET_NAME at $DEPLOYED_ADDRESS"
     
-    make explicit-verify-any \
-        rpc=base-sepolia \
-        verifier="${BASESCAN_SEPOLIA_URL}" \
-        etherscan="${ETHERSCAN_API_KEY}" \
+    make verify-on-etherscan \
+        etherscan_url="${BASESCAN_SEPOLIA_URL}" \
         address="${DEPLOYED_ADDRESS}" \
         contract="${FACET_NAME}"
 done 


### PR DESCRIPTION
…and update URLs

- Unified API key usage by replacing `BASESCAN_API_KEY` references with `ETHERSCAN_API_KEY`.
- Updated deployment scripts, Makefile, and environment files to reflect new API key and URL structure.
- Standardized URLs for Base Mainnet and Sepolia to align with Etherscan API conventions.
