### PR TITLE
Removed handling of legacy notifications configuration

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -469,10 +469,6 @@ type NotificationsConfig struct {
 	SenditApp AppNotificationConfig
 	// Apps holds the notification configuration for each app
 	Apps []AppNotificationConfig
-	// APN holds the Apple Push Notification settings (deprecated - use Apps instead)
-	APN APNPushNotificationsConfig
-	// Web holds the Web Push notification settings (deprecated - use Apps instead)
-	Web WebPushNotificationConfig `mapstructure:"webpush"`
 
 	// Authentication holds configuration for the Client API authentication service.
 	Authentication AuthenticationConfig

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -65,12 +65,17 @@ func TestTlsConfig_KeyDoesNotLog(t *testing.T) {
 
 func TestNotificationsConfig_SensitiveKeysDontLog(t *testing.T) {
 	cfg := config.NotificationsConfig{
-		APN: config.APNPushNotificationsConfig{
-			AuthKey: "APN_AUTH_KEY",
-		},
-		Web: config.WebPushNotificationConfig{
-			Vapid: config.WebPushVapidNotificationConfig{
-				PrivateKey: "WEB_VAPID_PRIVATE_KEY",
+		Apps: []config.AppNotificationConfig{
+			{
+				App: "towns",
+				APN: config.APNPushNotificationsConfig{
+					AuthKey: "APN_AUTH_KEY",
+				},
+				Web: config.WebPushNotificationConfig{
+					Vapid: config.WebPushVapidNotificationConfig{
+						PrivateKey: "WEB_VAPID_PRIVATE_KEY",
+					},
+				},
 			},
 		},
 		Authentication: config.AuthenticationConfig{

--- a/core/node/notifications/push/push.go
+++ b/core/node/notifications/push/push.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/infra"
 	"github.com/towns-protocol/towns/core/node/logging"
-	"github.com/towns-protocol/towns/core/node/notifications/apps"
 	"github.com/towns-protocol/towns/core/node/notifications/types"
 	"github.com/towns-protocol/towns/core/node/protocol"
 )
@@ -134,16 +133,6 @@ func NewMessageNotifier(
 	cfg *config.NotificationsConfig,
 	metricsFactory infra.MetricsFactory,
 ) (*MessageNotifications, error) {
-	// Handle legacy configuration (single app)
-	if len(cfg.Apps) == 0 && (cfg.APN.AppBundleID != "" || cfg.Web.Vapid.PrivateKey != "") {
-		// Convert legacy config to Apps format
-		cfg.Apps = []config.AppNotificationConfig{{
-			App: apps.Default,
-			APN: cfg.APN,
-			Web: cfg.Web,
-		}}
-	}
-
 	appConfigs := make(map[string]*AppNotificationConfig)
 	apnsClients := make(map[string]struct {
 		production  *apns2.Client

--- a/core/node/notifications/push/push_test.go
+++ b/core/node/notifications/push/push_test.go
@@ -24,29 +24,37 @@ func TestAPNSPushNotification(t *testing.T) {
 	t.Parallel()
 
 	var (
-		req = require.New(t)
-		ctx = context.Background()
-		cfg = &config.NotificationsConfig{
-			APN: config.APNPushNotificationsConfig{
-				AppBundleID: "com.towns.internal",
-				Expiration:  30 * time.Minute,
-				KeyID:       os.Getenv("TEST_APN_KEY_ID"),
-				TeamID:      os.Getenv("TEST_APN_TEAM_ID"),
-				AuthKey:     os.Getenv("TEST_APN_AUTH_KEY"),
-			},
-			Web: config.WebPushNotificationConfig{
-				Vapid: config.WebPushVapidNotificationConfig{
-					PrivateKey: os.Getenv("TEST_WEB_PUSH_VAPID_PRIV_KEY"),
-					PublicKey:  os.Getenv("TEST_WEB_PUSH_VAPID_PUB_KEY"),
-					Subject:    "support@towns.com",
+		req            = require.New(t)
+		ctx            = context.Background()
+		apnKeyID       = os.Getenv("TEST_APN_KEY_ID")
+		apnTeamID      = os.Getenv("TEST_APN_TEAM_ID")
+		apnAuthKey     = os.Getenv("TEST_APN_AUTH_KEY")
+		deviceTokenHex = os.Getenv("TEST_APN_APPLE_DEVICE_TOKEN")
+		cfg            = &config.NotificationsConfig{
+			Apps: []config.AppNotificationConfig{
+				{
+					App: apps.Towns,
+					APN: config.APNPushNotificationsConfig{
+						AppBundleID: "com.towns.internal",
+						Expiration:  30 * time.Minute,
+						KeyID:       apnKeyID,
+						TeamID:      apnTeamID,
+						AuthKey:     apnAuthKey,
+					},
+					Web: config.WebPushNotificationConfig{
+						Vapid: config.WebPushVapidNotificationConfig{
+							PrivateKey: os.Getenv("TEST_WEB_PUSH_VAPID_PRIV_KEY"),
+							PublicKey:  os.Getenv("TEST_WEB_PUSH_VAPID_PUB_KEY"),
+							Subject:    "support@towns.com",
+						},
+					},
 				},
 			},
 		}
-		notifier, err  = push.NewMessageNotifier(cfg, infra.NewMetricsFactory(nil, "", ""))
-		deviceTokenHex = os.Getenv("TEST_APN_APPLE_DEVICE_TOKEN")
+		notifier, err = push.NewMessageNotifier(cfg, infra.NewMetricsFactory(nil, "", ""))
 	)
 
-	if cfg.APN.KeyID == "" || cfg.APN.TeamID == "" || cfg.APN.AuthKey == "" || deviceTokenHex == "" {
+	if apnKeyID == "" || apnTeamID == "" || apnAuthKey == "" || deviceTokenHex == "" {
 		t.Skip("Missing required config to run this test")
 	}
 
@@ -74,21 +82,29 @@ func TestWebPushWithVapid(t *testing.T) {
 	t.Parallel()
 
 	var (
-		req = require.New(t)
-		ctx = context.Background()
-		cfg = &config.NotificationsConfig{
-			APN: config.APNPushNotificationsConfig{
-				AppBundleID: "com.towns.internal",
-				Expiration:  30 * time.Minute,
-				KeyID:       os.Getenv("TEST_APN_KEY_ID"),
-				TeamID:      os.Getenv("TEST_APN_TEAM_ID"),
-				AuthKey:     os.Getenv("TEST_APN_AUTH_KEY"),
-			},
-			Web: config.WebPushNotificationConfig{
-				Vapid: config.WebPushVapidNotificationConfig{
-					PrivateKey: os.Getenv("TEST_WEB_PUSH_VAPID_PRIV_KEY"),
-					PublicKey:  os.Getenv("TEST_WEB_PUSH_VAPID_PUB_KEY"),
-					Subject:    "support@towns.com",
+		req             = require.New(t)
+		ctx             = context.Background()
+		vapidPrivateKey = os.Getenv("TEST_WEB_PUSH_VAPID_PRIV_KEY")
+		vapidPublicKey  = os.Getenv("TEST_WEB_PUSH_VAPID_PUB_KEY")
+		vapidSubject    = "support@towns.com"
+		cfg             = &config.NotificationsConfig{
+			Apps: []config.AppNotificationConfig{
+				{
+					App: apps.Towns,
+					APN: config.APNPushNotificationsConfig{
+						AppBundleID: "com.towns.internal",
+						Expiration:  30 * time.Minute,
+						KeyID:       os.Getenv("TEST_APN_KEY_ID"),
+						TeamID:      os.Getenv("TEST_APN_TEAM_ID"),
+						AuthKey:     os.Getenv("TEST_APN_AUTH_KEY"),
+					},
+					Web: config.WebPushNotificationConfig{
+						Vapid: config.WebPushVapidNotificationConfig{
+							PrivateKey: vapidPrivateKey,
+							PublicKey:  vapidPublicKey,
+							Subject:    vapidSubject,
+						},
+					},
 				},
 			},
 		}
@@ -114,7 +130,7 @@ func TestWebPushWithVapid(t *testing.T) {
 		payload = []byte("Some message")
 	)
 
-	if cfg.Web.Vapid.PrivateKey == "" || cfg.Web.Vapid.PublicKey == "" || cfg.Web.Vapid.Subject == "" {
+	if vapidPrivateKey == "" || vapidPublicKey == "" || vapidSubject == "" {
 		t.Skip("Missing required config to run this test")
 	}
 


### PR DESCRIPTION
### Description

Now that we fully support two apps, there is no need to be backward compatible, all the of the envs have the correct configuration

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
