### PR TITLE
Build subgraph as part of CI

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -4,6 +4,7 @@
     "packageManager": "yarn@3.8.0",
     "type": "module",
     "scripts": {
+        "build": "tsc",
         "codegen": "ponder codegen",
         "db": "ponder db",
         "dev": "ponder dev",
@@ -14,8 +15,7 @@
         "lint": "eslint \"src/**/*.{ts,tsx}\" \"ponder.config.ts\" \"ponder.schema.ts\"",
         "serve": "ponder serve",
         "start": "ponder start",
-        "transfer-ownership": "tsx interactions/transfer-ownership.ts",
-        "typecheck": "tsc"
+        "transfer-ownership": "tsx interactions/transfer-ownership.ts"
     },
     "dependencies": {
         "hono": "^4.7.11",

--- a/turbo.json
+++ b/turbo.json
@@ -47,7 +47,7 @@
             "outputs": []
         },
         "typings": {
-            "dependsOn": ["^build"],
+            "dependsOn": ["build"],
             "cache": true,
             "outputs": ["generated/**", "src/generated/**"]
         },

--- a/turbo.json
+++ b/turbo.json
@@ -46,12 +46,17 @@
             "cache": false,
             "outputs": []
         },
+        "typings": {
+            "dependsOn": ["^build"],
+            "cache": true,
+            "outputs": ["generated/**", "src/generated/**"]
+        },
         "build": {
             // note: output globs are relative to each package's `package.json`
             // (and not the monorepo root
             "outputs": ["dist/**", "build/**", "out/**", "cache/**"],
             "cache": true,
-            "dependsOn": ["^build"]
+            "dependsOn": ["^build", "^typings"]
         },
         "lint": {
             "cache": true


### PR DESCRIPTION
Build subgraph as part of CI though ponder runs on-the-fly compilation to javascript rendering the build artifacts unused, errors are picked up at build time such as when contract typings break the subgraph schema. This will help keep the subgraph up to date as contract dependencies change. 

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
