### PR TITLE
Add generic types for event content

### DIFF
--- a/packages/sdk/src/views/models/timelineTypes.ts
+++ b/packages/sdk/src/views/models/timelineTypes.ts
@@ -103,6 +103,13 @@ export type TimelineEvent_OneOf =
     | UserReceivedBlockchainTransactionEvent
     | UnpinEvent
 
+export type TimelineEventWithContent<T extends TimelineEvent_OneOf> = Omit<
+    TimelineEvent,
+    'content'
+> & {
+    content: T
+}
+
 export enum RiverTimelineEvent {
     ChannelCreate = 'm.channel.create',
     ChannelMessage = 'm.channel.message',
@@ -374,6 +381,13 @@ export interface ChannelMessageEvent {
     editsEventId?: string
     content: ChannelMessageEventContentOneOf
     attachments?: Attachment[]
+}
+
+export type ChannelMessageEventWithContent<T extends ChannelMessageEventContentOneOf> = Omit<
+    ChannelMessageEvent,
+    'content'
+> & {
+    content: T
 }
 
 // original event: the event that was redacted


### PR DESCRIPTION
### Description

Adds a couple of generic type wrappers for message events to be used with custom assertions.

for example, a timeline event containing text (a common case) could be asserted and represented as such:

```ts
TimelineEventWithContent<ChannelMessageEventWithContent<ChannelMessageEventContent_Text|ChannelMessageEventContent_Image>>
```

### Changes

Added types

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
