### PR TITLE
remove validation for image extension in `SetAppMetadata`

### DIFF
--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -7,6 +7,11 @@ import (
 	"github.com/towns-protocol/towns/core/node/protocol"
 )
 
+// We allow up to 8K length of URLs to external resources for bot profile image links, etc.
+const MAX_RESOURCE_URL_LENGTH = 8192
+
+const MAX_SLASH_COMMANDS = 25
+
 type SlashCommand struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -101,10 +106,10 @@ func ValidateImageFileUrl(urlStr string) error {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL cannot be empty")
 	}
 
-	if len(urlStr) > 8192 {
+	if len(urlStr) > MAX_RESOURCE_URL_LENGTH {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
 			Tag("url_length", len(urlStr)).
-			Tag("max_length", 8192)
+			Tag("max_length", MAX_RESOURCE_URL_LENGTH)
 	}
 
 	parsedUrl, err := url.Parse(urlStr)
@@ -124,10 +129,10 @@ func ValidateImageFileUrl(urlStr string) error {
 }
 
 func ValidateExternalUrl(urlStr string) error {
-	if len(urlStr) > 8192 {
+	if len(urlStr) > MAX_RESOURCE_URL_LENGTH {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
 			Tag("url_length", len(urlStr)).
-			Tag("max_length", 8192)
+			Tag("max_length", MAX_RESOURCE_URL_LENGTH)
 	}
 
 	parsedUrl, err := url.Parse(urlStr)
@@ -185,9 +190,11 @@ func ValidateAppMetadata(metadata *protocol.AppMetadata) error {
 
 	// Validate slash commands
 	slashCommands := metadata.GetSlashCommands()
-	if len(slashCommands) > 25 {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "cannot have more than 25 slash commands").
-			Tag("commandCount", len(slashCommands))
+	if len(slashCommands) > MAX_SLASH_COMMANDS {
+		return base.RiverError(protocol.Err_INVALID_ARGUMENT,
+			"app metadata slash command count exceeds maximum").
+			Tag("commandCount", len(slashCommands)).
+			Tag("maximum", MAX_SLASH_COMMANDS)
 	}
 
 	// Check for duplicate command names

--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/protocol"
@@ -97,16 +96,6 @@ var validExternalUrlSchemes = map[string]struct{}{
 	"http":  {},
 }
 
-// validExtensions defines allowed file extensions
-var validExtensions = map[string]struct{}{
-	"png":  {},
-	"jpg":  {},
-	"jpeg": {},
-	"gif":  {},
-	"webp": {},
-	"svg":  {},
-}
-
 func ValidateImageFileUrl(urlStr string) error {
 	if urlStr == "" {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL cannot be empty")
@@ -123,27 +112,6 @@ func ValidateImageFileUrl(urlStr string) error {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid scheme (https, http, or ipfs)").
 			Tag("url", urlStr).
 			Tag("scheme", parsedUrl.Scheme)
-	}
-
-	// Check if path exists
-	if parsedUrl.Path == "" || parsedUrl.Path == "/" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid path to a file").
-			Tag("url", urlStr)
-	}
-
-	// Extract file extension from path
-	path := parsedUrl.Path
-	lastDot := strings.LastIndex(path, ".")
-	if lastDot == -1 || lastDot == len(path)-1 {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must point to a file with a valid extension").
-			Tag("url", urlStr)
-	}
-
-	extension := strings.ToLower(path[lastDot+1:])
-	if _, extOk := validExtensions[extension]; !extOk {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must point to a file with a supported extension (png, jpg, jpeg, gif, webp, svg)").
-			Tag("url", urlStr).
-			Tag("extension", extension)
 	}
 
 	return nil

--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -101,6 +101,12 @@ func ValidateImageFileUrl(urlStr string) error {
 		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL cannot be empty")
 	}
 
+	if len(urlStr) > 8192 {
+		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
+			Tag("url_length", len(urlStr)).
+			Tag("max_length", 8192)
+	}
+
 	parsedUrl, err := url.Parse(urlStr)
 	if err != nil {
 		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).
@@ -118,6 +124,12 @@ func ValidateImageFileUrl(urlStr string) error {
 }
 
 func ValidateExternalUrl(urlStr string) error {
+	if len(urlStr) > 8192 {
+		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
+			Tag("url_length", len(urlStr)).
+			Tag("max_length", 8192)
+	}
+
 	parsedUrl, err := url.Parse(urlStr)
 	if err != nil {
 		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -852,7 +852,7 @@ func TestAppRegistry_SetGetAppMetadata(t *testing.T) {
 					return commands
 				}(),
 			},
-			expectedErr: "cannot have more than 25 slash commands",
+			expectedErr: "app metadata slash command count exceeds maximum",
 		},
 		"Failure: empty command description": {
 			appId:                appWallet.Address[:],
@@ -2188,7 +2188,7 @@ func TestAppRegistry_Register(t *testing.T) {
 				}(),
 			},
 			authenticatingWallet: ownerWallet,
-			expectedErr:          "cannot have more than 25 slash commands",
+			expectedErr:          "app metadata slash command count exceeds maximum",
 		},
 	}
 	for name, tc := range tests {

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -675,32 +675,6 @@ func TestAppRegistry_SetGetAppMetadata(t *testing.T) {
 			},
 			expectedErr: "metadata avatar_url validation failed",
 		},
-		"Failure: avatar URL missing file path": {
-			appId:                appWallet.Address[:],
-			authenticatingWallet: appWallet,
-			metadata: &protocol.AppMetadata{
-				Username: "test_app",
-
-				DisplayName: "Test App",
-				Description: "Avatar URL missing file path",
-				ImageUrl:    "https://example.com/image.png",
-				AvatarUrl:   "https://example.com/",
-			},
-			expectedErr: "metadata avatar_url validation failed",
-		},
-		"Failure: avatar URL invalid file extension": {
-			appId:                appWallet.Address[:],
-			authenticatingWallet: appWallet,
-			metadata: &protocol.AppMetadata{
-				Username: "test_app",
-
-				DisplayName: "Test App",
-				Description: "Avatar URL with invalid extension",
-				ImageUrl:    "https://example.com/image.png",
-				AvatarUrl:   "https://example.com/avatar.txt",
-			},
-			expectedErr: "metadata avatar_url validation failed",
-		},
 		"Failure: image URL invalid scheme": {
 			appId:                appWallet.Address[:],
 			authenticatingWallet: appWallet,
@@ -710,32 +684,6 @@ func TestAppRegistry_SetGetAppMetadata(t *testing.T) {
 				DisplayName: "Test App",
 				Description: "Image URL with invalid scheme",
 				ImageUrl:    "ftp://example.com/image.png",
-				AvatarUrl:   "https://example.com/avatar.png",
-			},
-			expectedErr: "metadata image_url validation failed",
-		},
-		"Failure: image URL missing file path": {
-			appId:                appWallet.Address[:],
-			authenticatingWallet: appWallet,
-			metadata: &protocol.AppMetadata{
-				Username: "test_app",
-
-				DisplayName: "Test App",
-				Description: "Image URL missing file path",
-				ImageUrl:    "https://example.com/",
-				AvatarUrl:   "https://example.com/avatar.png",
-			},
-			expectedErr: "metadata image_url validation failed",
-		},
-		"Failure: image URL invalid file extension": {
-			appId:                appWallet.Address[:],
-			authenticatingWallet: appWallet,
-			metadata: &protocol.AppMetadata{
-				Username: "test_app",
-
-				DisplayName: "Test App",
-				Description: "Image URL with invalid extension",
-				ImageUrl:    "https://example.com/image.txt",
 				AvatarUrl:   "https://example.com/avatar.png",
 			},
 			expectedErr: "metadata image_url validation failed",

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -191,8 +191,8 @@ describe('Bot', { sequential: true }, () => {
                 username: BOT_USERNAME,
                 displayName: 'Bot Witness of Infinity',
                 description: BOT_DESCRIPTION,
-                avatarUrl: 'https://placehold.co/64x64.png',
-                imageUrl: 'https://placehold.co/600x600.png',
+                avatarUrl: 'https://placehold.co/64x64',
+                imageUrl: 'https://placehold.co/600x600',
             },
         })
         jwtSecretBase64 = bin_toBase64(hs256SharedSecret)

--- a/protocol/apps.proto
+++ b/protocol/apps.proto
@@ -225,12 +225,10 @@ message AppMetadata {
 
     string description = 2;
 
-    // image_url is an image URL with an acceptable schema and file extension.
     string image_url = 3;
 
     optional string external_url = 4;
 
-    // avatar_url is an image URL with an acceptable schema and file extension.
     string avatar_url = 5;
 
     // slash_commands is a list of commands the bot supports.


### PR DESCRIPTION
So we can use the stream metadata `/user/:appId/image` in the image / avatar field

Added a max len check, using [Amazon Cloudfront max url size](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorS3Origin.html)

