### PR TITLE
Add web3 deps subgraph dockerfile

### DIFF
--- a/packages/subgraph/Dockerfile
+++ b/packages/subgraph/Dockerfile
@@ -35,6 +35,11 @@ COPY buf.yaml ./
 COPY packages/subgraph ./packages/subgraph/
 COPY packages/prettier-config ./packages/prettier-config/
 COPY packages/contracts ./packages/contracts/
+COPY packages/web3 ./packages/web3/
+COPY packages/generated ./packages/generated/
+COPY packages/dlog ./packages/dlog/
+COPY packages/proto ./packages/proto/
+COPY protocol ./protocol/
 
 # Add entrypoint script
 RUN chmod +x ./packages/subgraph/docker-entrypoint.sh

--- a/packages/subgraph/Dockerfile
+++ b/packages/subgraph/Dockerfile
@@ -28,6 +28,8 @@ RUN corepack enable
 # Copy monorepo configuration from root
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn ./.yarn
+COPY packages/tsconfig.base.json ./packages/
+COPY buf.yaml ./
 
 # Copy the required packages
 COPY packages/subgraph ./packages/subgraph/
@@ -47,6 +49,15 @@ WORKDIR /river
 
 # Generate contract typings
 RUN yarn workspace @towns-protocol/contracts typings
+
+# Build proto package (dependency of dlog)
+RUN yarn workspace @towns-protocol/proto build
+
+# Build dlog package (dependency of web3)
+RUN yarn workspace @towns-protocol/dlog build
+
+# Build web3 package
+RUN yarn workspace @towns-protocol/web3 build
 
 # Set working directory to subgraph package
 WORKDIR /river/packages/subgraph

--- a/packages/subgraph/docker-compose.yml
+++ b/packages/subgraph/docker-compose.yml
@@ -19,10 +19,6 @@ services:
             - subgraph-db:/var/lib/postgresql/data
 
     subgraph-indexer:
-        # TODO: remove this in favor of building from Dockerfile locally
-        # once we have fixed issues building image on arm64 machine
-        # image: public.ecr.aws/h5v6m2x1/subgraph:60570c1
-        platform: linux/amd64
         build:
             context: ../../
             dockerfile: packages/subgraph/Dockerfile
@@ -42,10 +38,6 @@ services:
             - PONDER_ENVIRONMENT=${PONDER_ENVIRONMENT}
 
     subgraph-server:
-        # TODO: remove this in favor of building from Dockerfile locally
-        # once we have fixed issues building image on arm64 machine
-        # image: public.ecr.aws/h5v6m2x1/subgraph:60570c1
-        platform: linux/amd64
         build:
             context: ../../
             dockerfile: packages/subgraph/Dockerfile

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -407,7 +407,7 @@ ponder.on('BaseRegistry:Withdraw', async ({ event, context }) => {
                 existingStake.amount >= withdrawAmount ? existingStake.amount - withdrawAmount : 0n
 
             if (existingStake.delegatee) {
-                await handleStakeToSpace(context, existingStake.delegatee, -withdrawAmount)
+                await handleStakeToSpace(context, existingStake.delegatee, 0n - withdrawAmount)
             }
 
             await context.db.sql

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -76,7 +76,7 @@ export async function handleRedelegation(
 ): Promise<void> {
     try {
         if (oldDelegatee) {
-            await handleStakeToSpace(context, oldDelegatee, -amount)
+            await handleStakeToSpace(context, oldDelegatee, 0n - amount)
         }
         if (newDelegatee) {
             await handleStakeToSpace(context, newDelegatee, amount)

--- a/turbo.json
+++ b/turbo.json
@@ -49,7 +49,7 @@
         "typings": {
             "dependsOn": ["build"],
             "cache": true,
-            "outputs": ["generated/**", "src/generated/**"]
+            "outputs": ["typings/**", "generated/**", "src/generated/**"]
         },
         "build": {
             // note: output globs are relative to each package's `package.json`


### PR DESCRIPTION
### Description

- add web3 deps to dockerfile needed by https://github.com/towns-protocol/towns/pull/3901. Also removes platform specification which is not needed anymore as Dockerfile can be built in arm64/amd architectures now. 

- fixes turbo cache so ci passes

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
