### PR TITLE
fix(publish): prevent hangs from pending CodeRabbit reviews

### DIFF
--- a/.github/workflows/Publish_npm_packages.yml
+++ b/.github/workflows/Publish_npm_packages.yml
@@ -75,3 +75,4 @@ jobs:
                   GH_TOKEN: ${{ secrets.RIVER_GITHUB_PAT }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: ./scripts/publish-to-npm.sh
+              timeout-minutes: 60

--- a/packages/generated/scripts/prepare.js
+++ b/packages/generated/scripts/prepare.js
@@ -155,7 +155,11 @@ function generateArtifacts() {
   }
   
   // Look for build script in contracts package (sibling to generated package)
-  const contractsDir = resolve(packageRoot, '../contracts');
+  if (!existsSync(contractsDir)) {
+    console.log('Contracts directory not found, cannot generate locally');
+    throw new Error('Cannot generate artifacts: contracts package not available and npm download failed');
+  }
+  
   const buildScript = resolve(contractsDir, 'scripts/build-contract-types.sh');
 
   if (!existsSync(buildScript)) {

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -90,39 +90,44 @@ gh pr merge "${PR_NUMBER}" --auto --squash
 
 echo "Created PR #${PR_NUMBER}"
 
+# Wait for required checks to pass (skip CodeRabbit and other non-required checks)
 while true; do
-    WAIT_TIME=5
-    while true; do
-    OUTPUT=$(gh pr checks "${BRANCH_NAME}" 2>&1)
-    if [[ "$OUTPUT" == *"no checks reported on the '${BRANCH_NAME}' branch"* ]]; then
-        echo "Checks for '${BRANCH_NAME}' haven't started yet. Waiting for $WAIT_TIME seconds..."
+    WAIT_TIME=10
+    # Get status of all checks except CodeRabbit
+    CHECKS_OUTPUT=$(gh pr checks "${BRANCH_NAME}" --json name,status,conclusion 2>/dev/null || echo "[]")
+    
+    if [[ "$CHECKS_OUTPUT" == "[]" ]]; then
+        echo "No checks reported yet, waiting..."
         sleep $WAIT_TIME
-    else
-        break
+        continue
     fi
-    done
-
-    gh pr checks "${BRANCH_NAME}" --fail-fast --interval 2 --watch
-    exit_status=$?
-
-    # Check if the command succeeded or failed
-    if [ $exit_status -ne 0 ]; then
-        echo "Failure detected in PR checks."
+    
+    # Filter out CodeRabbit and check if all other checks passed
+    FAILED_CHECKS=$(echo "$CHECKS_OUTPUT" | jq -r '.[] | select(.name != "CodeRabbit") | select(.status == "completed" and .conclusion != "success") | .name' 2>/dev/null | tr '\n' ' ')
+    PENDING_CHECKS=$(echo "$CHECKS_OUTPUT" | jq -r '.[] | select(.name != "CodeRabbit") | select(.status != "completed") | .name' 2>/dev/null | tr '\n' ' ')
+    
+    if [[ -n "$FAILED_CHECKS" && "$FAILED_CHECKS" != " " ]]; then
+        echo "Failed checks: $FAILED_CHECKS"
         if [[ $USER_MODE -eq 1 ]]; then
             read -p "Harmony CI is failing. Restart CI. (any key to retry/q) " -n 1 -r
             echo ""
             if [[ $REPLY =~ ^[Qq]$ ]]; then
                 echo "Pull request creation aborted."
-                exit $exit_status
+                exit 1
             fi
         else
             echo "Harmony CI is failing. Restart CI."
-            exit $exit_status
+            exit 1
         fi
-    else 
-        echo "All checks passed."
+    fi
+    
+    if [[ -z "$PENDING_CHECKS" || "$PENDING_CHECKS" == " " ]]; then
+        echo "All required checks passed (ignoring CodeRabbit)"
         break
     fi
+    
+    echo "Waiting for checks: $PENDING_CHECKS"
+    sleep $WAIT_TIME
 done
 
 # Wait for PR to be merged using the specific PR number


### PR DESCRIPTION
- Add timeout-minutes: 60 to GitHub Actions publish workflow
- Filter out CodeRabbit from required checks in publish-to-npm.sh to prevent infinite waiting
- Add contracts directory check in prepare.js before attempting local generation

This prevents publish workflows from hanging indefinitely when CodeRabbit stays in "pending" state, while maintaining all existing error handling logic.
