### PR TITLE
fix: use onMentioned in bot quickstart example

### DIFF
--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -43,7 +43,7 @@ async function main() {
         }
     })
 
-    bot.onMessage(async (handler, { message, channelId, userId, eventId }) => {
+    bot.onMentioned(async (handler, { message, channelId, userId, eventId }) => {
         if (userId === bot.botId) return
 
         if (message.toLowerCase().includes('hello')) {


### PR DESCRIPTION
Bug

Super annoying when we deploy the quickstart bot but the app registry is only forwarding mentions. 