### PR TITLE
Add confirmedAtEpochMs for timeline events

### DIFF
--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -55,6 +55,7 @@ import { DecryptionSessionError, KeyFulfilmentData } from './decryptionExtension
 import { migrateSnapshot } from './migrations/migrateSnapshot'
 import { StreamsView } from './views/streamsView'
 import { TimelineEvent } from './views/models/timelineTypes'
+import { Timestamp } from '@bufbuild/protobuf/wkt'
 const log = dlog('csb:streams')
 const logError = dlogError('csb:streams:error')
 
@@ -332,6 +333,7 @@ export class StreamStateView {
                     eventNum: this.lastEventNum++,
                     miniblockNum: undefined,
                     confirmedEventNum: undefined,
+                    confirmedAtEpochMs: undefined,
                 })
                 const newlyConfirmed = this.processAppendedEvent(
                     event,
@@ -420,6 +422,9 @@ export class StreamStateView {
                     timelineEvent.confirmedEventNum =
                         payload.value.eventNumOffset + BigInt(payload.value.eventHashes.length)
                     timelineEvent.miniblockNum = payload.value.miniblockNum
+                    timelineEvent.confirmedAtEpochMs = payload.value.timestamp
+                        ? timestampToEpochMs(payload.value.timestamp)
+                        : undefined
                     confirmed = this.processMiniblockHeader(
                         payload.value,
                         payload.value.eventHashes,
@@ -471,6 +476,9 @@ export class StreamStateView {
             this.minipoolEvents.delete(eventId)
             event.miniblockNum = header.miniblockNum
             event.confirmedEventNum = header.eventNumOffset + BigInt(i)
+            event.confirmedAtEpochMs = header.timestamp
+                ? timestampToEpochMs(header.timestamp)
+                : undefined
             check(isConfirmedEvent(event), `Event is not confirmed ${eventId}`)
             switch (event.remoteEvent.event.payload.case) {
                 case 'memberPayload':
@@ -624,6 +632,9 @@ export class StreamStateView {
                 eventNum,
                 miniblockNum: miniblocks[0].header.miniblockNum,
                 confirmedEventNum: eventNum,
+                confirmedAtEpochMs: miniblocks[0].header.timestamp
+                    ? timestampToEpochMs(miniblocks[0].header.timestamp)
+                    : undefined,
             })
         })
         // the rest need to be added to the timeline
@@ -635,6 +646,9 @@ export class StreamStateView {
                     eventNum,
                     miniblockNum: mb.header.miniblockNum,
                     confirmedEventNum: eventNum,
+                    confirmedAtEpochMs: mb.header.timestamp
+                        ? timestampToEpochMs(mb.header.timestamp)
+                        : undefined,
                 })
             }),
         )
@@ -732,6 +746,9 @@ export class StreamStateView {
                     eventNum: mb.header.eventNumOffset + BigInt(i),
                     miniblockNum: mb.header.miniblockNum,
                     confirmedEventNum: mb.header.eventNumOffset + BigInt(i),
+                    confirmedAtEpochMs: mb.header.timestamp
+                        ? timestampToEpochMs(mb.header.timestamp)
+                        : undefined,
                 }),
             ),
         )
@@ -874,4 +891,9 @@ export class StreamStateView {
                 return new Set()
         }
     }
+}
+
+export function timestampToEpochMs(ts: Timestamp): number {
+    // nanos -> ms (0..999), then add to seconds*1000
+    return Number(ts.seconds) * 1000 + Math.floor(ts.nanos / 1e6)
 }

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -152,6 +152,7 @@ describe('clientTest', () => {
             )
             expect(event).toBeDefined()
             expect(event?.confirmedInBlockNum).toBeDefined()
+            expect(event?.confirmedAtEpochMs).toBeDefined()
         })
 
         await bobsClient.stopSync()
@@ -540,6 +541,7 @@ describe('clientTest', () => {
             )
             expect(event).toBeDefined()
             expect(event?.confirmedInBlockNum).toBeDefined()
+            expect(event?.confirmedAtEpochMs).toBeDefined()
         })
 
         log('bobSendsSingleMessage done')

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -86,6 +86,7 @@ export interface StreamTimelineEvent {
     decryptedContentError?: DecryptionSessionError
     miniblockNum?: bigint
     confirmedEventNum?: bigint
+    confirmedAtEpochMs?: number
 }
 
 export type RemoteTimelineEvent = Omit<StreamTimelineEvent, 'remoteEvent'> & {
@@ -103,6 +104,7 @@ export type ConfirmedTimelineEvent = Omit<
     remoteEvent: ParsedEvent
     confirmedEventNum: bigint
     miniblockNum: bigint
+    confirmedAtEpochMs: number
 }
 
 export type DecryptedTimelineEvent = Omit<
@@ -196,6 +198,7 @@ export function makeRemoteTimelineEvent(params: {
     eventNum: bigint
     miniblockNum?: bigint
     confirmedEventNum?: bigint
+    confirmedAtEpochMs?: number
 }): RemoteTimelineEvent {
     return {
         hashStr: params.parsedEvent.hashStr,
@@ -205,6 +208,7 @@ export function makeRemoteTimelineEvent(params: {
         remoteEvent: params.parsedEvent,
         miniblockNum: params.miniblockNum,
         confirmedEventNum: params.confirmedEventNum,
+        confirmedAtEpochMs: params.confirmedAtEpochMs,
     }
 }
 

--- a/packages/sdk/src/views/models/timelineEvent.ts
+++ b/packages/sdk/src/views/models/timelineEvent.ts
@@ -116,6 +116,7 @@ export function toEvent(timelineEvent: StreamTimelineEvent, userId: string): Tim
         isSendFailed: timelineEvent.localEvent?.status === 'failed',
         confirmedEventNum: timelineEvent.confirmedEventNum,
         confirmedInBlockNum: timelineEvent.miniblockNum,
+        confirmedAtEpochMs: timelineEvent.confirmedAtEpochMs,
         threadParentId: getThreadParentId(content),
         replyParentId: getReplyParentId(content),
         reactionParentId: getReactionParentId(content),

--- a/packages/sdk/src/views/models/timelineTypes.ts
+++ b/packages/sdk/src/views/models/timelineTypes.ts
@@ -58,6 +58,7 @@ export interface TimelineEvent {
     isSendFailed: boolean
     confirmedEventNum?: bigint
     confirmedInBlockNum?: bigint
+    confirmedAtEpochMs?: number // time miniblock containing this event was created, should be around 2 seconds after the event was created
     threadParentId?: string
     replyParentId?: string
     reactionParentId?: string
@@ -407,6 +408,7 @@ export interface TimelineEventConfirmation {
     eventId: string
     confirmedEventNum: bigint
     confirmedInBlockNum: bigint
+    confirmedAtEpochMs: number
 }
 
 export interface ThreadStatsData {

--- a/packages/sdk/src/views/streams/timelines.ts
+++ b/packages/sdk/src/views/streams/timelines.ts
@@ -80,6 +80,7 @@ export class TimelinesView extends Observable<TimelinesViewModel> {
                 eventId: event.hashStr,
                 confirmedInBlockNum: event.miniblockNum,
                 confirmedEventNum: event.confirmedEventNum,
+                confirmedAtEpochMs: event.confirmedAtEpochMs,
             }))
             this.setState.confirmEvents(confirmations, streamId)
         }

--- a/packages/sdk/src/views/streams/timelinesModel.ts
+++ b/packages/sdk/src/views/streams/timelinesModel.ts
@@ -298,6 +298,7 @@ export function makeTimelinesViewInterface(
             ...oldEvent,
             confirmedEventNum: confirmation.confirmedEventNum,
             confirmedInBlockNum: confirmation.confirmedInBlockNum,
+            confirmedAtEpochMs: confirmation.confirmedAtEpochMs,
         }
 
         const threadParentId = newEvent.threadParentId
@@ -495,6 +496,7 @@ function toReplacedMessageEvent(prev: TimelineEvent, next: TimelineEvent): Timel
             latestEventNum: next.eventNum,
             confirmedEventNum: prev.confirmedEventNum ?? next.confirmedEventNum,
             confirmedInBlockNum: prev.confirmedInBlockNum ?? next.confirmedInBlockNum,
+            confirmedAtEpochMs: next.confirmedAtEpochMs,
             createdAtEpochMs: prev.createdAtEpochMs,
             updatedAtEpochMs: next.createdAtEpochMs,
             content: {
@@ -516,6 +518,7 @@ function toReplacedMessageEvent(prev: TimelineEvent, next: TimelineEvent): Timel
             latestEventNum: next.eventNum,
             confirmedEventNum: prev.confirmedEventNum ?? next.confirmedEventNum,
             confirmedInBlockNum: prev.confirmedInBlockNum ?? next.confirmedInBlockNum,
+            confirmedAtEpochMs: next.confirmedAtEpochMs,
             createdAtEpochMs: prev.createdAtEpochMs,
             updatedAtEpochMs: next.createdAtEpochMs,
             threadParentId: prev.threadParentId,
@@ -529,6 +532,7 @@ function toReplacedMessageEvent(prev: TimelineEvent, next: TimelineEvent): Timel
             latestEventNum: next.eventNum,
             confirmedEventNum: prev.confirmedEventNum ?? next.confirmedEventNum,
             confirmedInBlockNum: prev.confirmedInBlockNum ?? next.confirmedInBlockNum,
+            confirmedAtEpochMs: next.confirmedAtEpochMs,
         }
     } else {
         // make sure we carry the createdAtEpochMs of the previous event
@@ -542,6 +546,7 @@ function toReplacedMessageEvent(prev: TimelineEvent, next: TimelineEvent): Timel
             latestEventNum: next.eventNum,
             confirmedEventNum: prev.confirmedEventNum ?? next.confirmedEventNum,
             confirmedInBlockNum: prev.confirmedInBlockNum ?? next.confirmedInBlockNum,
+            confirmedAtEpochMs: next.confirmedAtEpochMs,
             createdAtEpochMs: prev.createdAtEpochMs,
             updatedAtEpochMs: next.createdAtEpochMs,
         }


### PR DESCRIPTION
this is a time that isn’t set by other clients that you can trust in the ui