### PR TITLE
node: reconcile from stream registry record for streams at mb 0

### DIFF
--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -655,7 +655,7 @@ func (s *Stream) tryCleanup(expiration time.Duration) bool {
 	return true
 }
 
-// GetMiniblocks returns miniblock data directly fromn storage, bypassing the cache.
+// GetMiniblocks returns miniblock data directly from storage, bypassing the cache.
 // This is useful when we expect block data to be substantial and do not want to bust the cache.
 // miniblocks: with indexes from fromIndex inclusive, to toIndex exclusive
 // terminus: true if fromIndex is 0, or if there are no more blocks because they've been garbage collected

--- a/core/node/events/stream_reconcile_task.go
+++ b/core/node/events/stream_reconcile_task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/towns-protocol/towns/core/node/logging"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	. "github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/storage"
 )
 
 type reconcileTask struct {
@@ -242,6 +243,20 @@ func (s *StreamCache) reconcileStreamFromPeers(
 		return nil
 	}
 
+	// Several streams are in a state where the genesis miniblock is still stored on-chain, but
+	// the node that has the genesis block left the network and other nodes can't reconcile this
+	// stream anymore.
+	// This was the result of a bug when a node left the network, and the logic that checked if
+	// the leaving node didn't have any streams assigned didn't handle streamRecord.MbRef.Num == 0
+	// correct.
+	// If the stream record is still at miniblock 0, try to reconcile the stream from the genesis
+	// block in the stream registry instead of a peer.
+	if streamRecord.LastMbNum() == 0 {
+		if err := s.reconcileStreamFromStreamRegistryGenesisBlock(stream); err == nil {
+			return nil
+		}
+	}
+
 	stream.mu.Lock()
 	nonReplicatedStream := len(stream.nodesLocked.GetQuorumNodes()) == 1
 	stream.mu.Unlock()
@@ -290,6 +305,33 @@ func (s *StreamCache) reconcileStreamFromPeers(
 		"No peer could provide miniblocks for stream reconciliation",
 	).
 		Tags("stream", stream.streamId, "missingFromInclusive", nextFromInclusive, "missingToExclusive", toExclusive)
+}
+
+// reconcileStreamFromStreamRegistryGenesisBlock reconciles the database for the given stream from the stream registry.
+// If the stream record has advanced beyond the genesis miniblock, this function returns an error and the caller is
+// expected to reconcile from peers.
+func (s *StreamCache) reconcileStreamFromStreamRegistryGenesisBlock(stream *Stream) error {
+	ctx, cancel := context.WithTimeout(s.params.ServerCtx, time.Minute)
+	defer cancel()
+
+	streamID := stream.StreamId()
+	_, _, mb, err := s.params.Registry.GetStreamWithGenesis(ctx, streamID, 0)
+	if err != nil {
+		return err
+	}
+
+	if len(mb) == 0 {
+		return RiverError(Err_UNAVAILABLE, "Unable to read genesis mb from registry").
+			Tags("streamId", streamID).
+			Func("reconcileStreamFromStreamRegistryGenesisBlock")
+	}
+
+	genesisBlock, err := NewMiniblockInfoFromDescriptor(&storage.MiniblockDescriptor{Data: mb, HasLegacySnapshot: true})
+	if err != nil {
+		return err
+	}
+
+	return stream.importMiniblocks(ctx, []*MiniblockInfo{genesisBlock})
 }
 
 // reconcileStreamFromSinglePeer reconciles the database for the given streamResult by fetching missing blocks from a single peer.


### PR DESCRIPTION
## Summary
Fixed stream reconciliation for streams stuck at miniblock 0 by implementing fallback to genesis block recovery from the stream registry. It turns out that some streams are still assigned to a node dat left the network causing other nodes not able to reconcile the stream.  For streams that never moved beyond genesis it is possible to reconcile from the stream record in the steams registry.

Some of the following log entries are the result of this problem.
```
reconcileStreamFromPeers: Unable to reconcile stream from peers
```

An example stream `0xa5a087d6de203a8494d6b6e6bcb1e0ae2426c95b830000000000000000000000`
```
     stream: 0xa5a087d6de203a8494d6b6e6bcb1e0ae2426c95b830000000000000000000000
  miniblock: 0
       hash: 0x88f3eb633f3475011a18cfe66ddf8ff1a4b524be6516dc320cbb9ff85e85cbc1
      nodes: [0x190926b34daeec803b73ec73a35853081e0a5b3f, 0xc69cebb1e84ca8dda9a9ad68d345fbe4ac21fd54, 0x420c05ed091f255ba2e875c1415dd6e09b0e0592]
repl factor: 1
river block: 19995830
```

Followup action is to move these streams off from the problematic node and set the replication factor to 3.


## Changes

### Fixes
- **Stream Reconciliation**: Added special handling for streams at miniblock 0 to reconcile from the stream registry's genesis block instead of peers

### Implementation Details
- Added `reconcileStreamFromStreamRegistryGenesisBlock()` method in `core/node/events/stream_reconcile_task.go`
  - Fetches genesis miniblock directly from stream registry when stream is at miniblock 0
  - Falls back to peer reconciliation if registry fetch fails
- Fixed typo in comment: "fromn" → "from" in `core/node/events/stream.go:658`

### Tests
- Added comprehensive test `TestStreamReconciliationFromRegistryGenesisBlock` in `core/node/rpc/repl_test.go`
  - Verifies that nodes can reconcile streams from registry when stuck at genesis
  - Tests the special case where stream hasn't progressed beyond miniblock 0
  - Ensures proper fallback behavior when original node with genesis block is unavailable

## Impact
This fix ensures streams can always be reconciled even when the original node holding the genesis block leaves the network, improving system resilience and preventing streams from becoming permanently inaccessible.%







