### PR TITLE
fix: remove `node:http2` from bot examples

### DIFF
--- a/packages/examples/bot-ask-poll/src/index.ts
+++ b/packages/examples/bot-ask-poll/src/index.ts
@@ -1,6 +1,5 @@
 import { serve } from '@hono/node-server'
 import { makeTownsBot } from '@towns-protocol/bot'
-import { createServer } from 'node:http2'
 import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 
@@ -113,9 +112,5 @@ const app = new Hono()
 app.use(logger())
 app.post('/webhook', jwtMiddleware, handler)
 
-serve({
-    fetch: app.fetch,
-    port: parseInt(process.env.PORT!),
-    createServer,
-})
+serve({ fetch: app.fetch, port: parseInt(process.env.PORT!) })
 console.log(`✅ Poll Bot is running on https://localhost:${process.env.PORT}`)

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -1,6 +1,5 @@
 import { serve } from '@hono/node-server'
 import { makeTownsBot } from '@towns-protocol/bot'
-import { createServer } from 'node:http2'
 import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 
@@ -85,11 +84,7 @@ async function main() {
     app.use(logger())
     app.post('/webhook', jwtMiddleware, handler)
 
-    serve({
-        fetch: app.fetch,
-        port: parseInt(process.env.PORT!),
-        createServer,
-    })
+    serve({ fetch: app.fetch, port: parseInt(process.env.PORT!) })
     console.log(`✅ Quickstart Bot is running on https://localhost:${process.env.PORT}`)
 }
 

--- a/packages/examples/bot-thread-ai/src/index.ts
+++ b/packages/examples/bot-thread-ai/src/index.ts
@@ -1,7 +1,6 @@
 import OpenAI from 'openai'
 import { makeTownsBot } from '@towns-protocol/bot'
 import { serve } from '@hono/node-server'
-import { createServer } from 'node:http2'
 import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 
@@ -90,9 +89,5 @@ const app = new Hono()
 app.use(logger())
 app.post('/webhook', jwtMiddleware, handler)
 
-serve({
-    fetch: app.fetch,
-    port: parseInt(process.env.PORT!),
-    createServer,
-})
+serve({ fetch: app.fetch, port: parseInt(process.env.PORT!) })
 console.log(`✅ Thread AI Bot is running on https://localhost:${process.env.PORT}`)


### PR DESCRIPTION
The bot server itself isnt responsable of this. Lets leave it to render / vercel / fly.io. I always had this issue when deploying bots. We can come with a better way of testing bots local later