### PR TITLE
refactor: update ERC6900 imports to use v0.8.0 interface names

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -16,7 +16,7 @@
     "typings": "wagmi generate"
   },
   "dependencies": {
-    "@erc6900/reference-implementation": "^0.8.1",
+    "@erc6900/reference-implementation": "https://github.com/erc6900/reference-implementation/archive/refs/tags/v0.8.0.tar.gz",
     "@ethereum-attestation-service/eas-contracts": "^1.8.0",
     "@layerzerolabs/oft-evm": "^3.1.4",
     "@openzeppelin/contracts": "^5.4.0",

--- a/packages/contracts/src/apps/BaseApp.sol
+++ b/packages/contracts/src/apps/BaseApp.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 import {ITownsApp} from "./ITownsApp.sol";
 
 /// @title BaseApp
 /// @notice Base contract for Towns apps implementing core ERC-6900 module functionality
 /// @dev Provides base implementation for module installation/uninstallation and interface support
 /// @dev Inheriting contracts should override _onInstall and _onUninstall as needed
-/// @dev Implements IERC6900Module, IERC6900ExecutionModule, and ITownsApp interfaces
+/// @dev Implements IModule, IExecutionModule, and ITownsApp interfaces
 
 abstract contract BaseApp is ITownsApp {
     receive() external payable {
@@ -20,17 +20,17 @@ abstract contract BaseApp is ITownsApp {
     // External functions
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return
-            interfaceId == type(IERC6900ExecutionModule).interfaceId ||
-            interfaceId == type(IERC6900Module).interfaceId ||
+            interfaceId == type(IExecutionModule).interfaceId ||
+            interfaceId == type(IModule).interfaceId ||
             interfaceId == type(ITownsApp).interfaceId;
     }
 
-    /// @notice Required by IERC6900Module - called when module is installed
+    /// @notice Required by IModule - called when module is installed
     function onInstall(bytes calldata postInstallData) external {
         _onInstall(postInstallData);
     }
 
-    /// @notice Required by IERC6900Module - called when module is uninstalled
+    /// @notice Required by IModule - called when module is uninstalled
     function onUninstall(bytes calldata postUninstallData) external {
         _onUninstall(postUninstallData);
     }

--- a/packages/contracts/src/apps/ITownsApp.sol
+++ b/packages/contracts/src/apps/ITownsApp.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 /// @title ITownsApp Interface
 /// @notice Base interface for Towns apps implementing core module functionality
-/// @dev Combines IERC6900Module (module lifecycle), and IERC6900ExecutionModule (execution)
+/// @dev Combines IModule (module lifecycle), and IExecutionModule (execution)
 /// @dev Apps must implement required permissions and support these interfaces
-interface ITownsApp is IERC6900Module, IERC6900ExecutionModule {
+interface ITownsApp is IModule, IExecutionModule {
     /// @notice Returns the required permissions for the app
     /// @return permissions The required permissions for the app
     function requiredPermissions() external view returns (bytes32[] memory);

--- a/packages/contracts/src/apps/facets/registry/AppRegistryBase.sol
+++ b/packages/contracts/src/apps/facets/registry/AppRegistryBase.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {ITownsApp} from "../../ITownsApp.sol";
 import {IAppRegistryBase} from "./IAppRegistry.sol";
@@ -22,7 +22,7 @@ import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {CurrencyTransfer} from "../../../utils/libraries/CurrencyTransfer.sol";
 
 // types
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {Attestation, EMPTY_UID} from "@ethereum-attestation-service/eas-contracts/Common.sol";
 import {AttestationRequest, RevocationRequestData} from "@ethereum-attestation-service/eas-contracts/IEAS.sol";
 
@@ -389,8 +389,8 @@ abstract contract AppRegistryBase is IAppRegistryBase, SchemaBase, AttestationBa
         if (client == address(0)) InvalidAddressInput.selector.revertWith();
 
         if (
-            !IERC165(app).supportsInterface(type(IERC6900Module).interfaceId) ||
-            !IERC165(app).supportsInterface(type(IERC6900ExecutionModule).interfaceId) ||
+            !IERC165(app).supportsInterface(type(IModule).interfaceId) ||
+            !IERC165(app).supportsInterface(type(IExecutionModule).interfaceId) ||
             !IERC165(app).supportsInterface(type(ITownsApp).interfaceId)
         ) {
             AppDoesNotImplementInterface.selector.revertWith();

--- a/packages/contracts/src/apps/facets/registry/IAppRegistry.sol
+++ b/packages/contracts/src/apps/facets/registry/IAppRegistry.sol
@@ -8,7 +8,7 @@ import {ITownsApp} from "../../ITownsApp.sol";
 
 // libraries
 import {Attestation} from "@ethereum-attestation-service/eas-contracts/Common.sol";
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 
 interface IAppRegistryBase {
     struct AppParams {

--- a/packages/contracts/src/apps/helpers/SimpleApp.sol
+++ b/packages/contracts/src/apps/helpers/SimpleApp.sol
@@ -4,13 +4,12 @@ pragma solidity ^0.8.23;
 // interfaces
 import {ISimpleApp} from "../../apps/helpers/ISimpleApp.sol";
 import {ITownsApp} from "../../apps/ITownsApp.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest, IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 // contracts
 import {BaseApp} from "../../apps/BaseApp.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
 import {Initializable} from "solady/utils/Initializable.sol";
 
 // libraries
@@ -66,13 +65,13 @@ contract SimpleApp is ISimpleApp, Ownable, BaseApp, Initializable {
         return $.permissions;
     }
 
-    /// @inheritdoc IERC6900Module
+    /// @inheritdoc IModule
     function moduleId() public view returns (string memory) {
         SimpleAppStorage.Layout storage $ = SimpleAppStorage.getLayout();
         return $.name;
     }
 
-    /// @inheritdoc IERC6900ExecutionModule
+    /// @inheritdoc IExecutionModule
     function executionManifest() external pure returns (ExecutionManifest memory) {
         // solhint-disable no-empty-blocks
     }

--- a/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
@@ -5,12 +5,11 @@ pragma solidity ^0.8.23;
 import {IAppAccountBase} from "./IAppAccount.sol";
 import {IAppRegistry} from "src/apps/facets/registry/AppRegistryFacet.sol";
 import {ITownsApp} from "src/apps/ITownsApp.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Account} from "@erc6900/reference-implementation/interfaces/IERC6900Account.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IDiamondCut} from "@towns-protocol/diamond/src/facets/cut/IDiamondCut.sol";
 import {IAppRegistryBase} from "src/apps/facets/registry/IAppRegistry.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 // libraries
 import {MembershipStorage} from "src/spaces/facets/membership/MembershipStorage.sol";
@@ -25,7 +24,7 @@ import {ExecutorBase} from "../executor/ExecutorBase.sol";
 import {TokenOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/token/TokenOwnableBase.sol";
 
 // types
-import {ExecutionManifest, ManifestExecutionFunction} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest, ManifestExecutionFunction} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {Attestation, EMPTY_UID} from "@ethereum-attestation-service/eas-contracts/Common.sol";
 
 abstract contract AppAccountBase is
@@ -86,11 +85,11 @@ abstract contract AppAccountBase is
         // Call module's onInstall if it has install data using LibCall
         // revert if it fails
         if (postInstallData.length > 0) {
-            bytes memory callData = abi.encodeCall(IERC6900Module.onInstall, (postInstallData));
+            bytes memory callData = abi.encodeCall(IModule.onInstall, (postInstallData));
             LibCall.callContract(app.module, 0, callData);
         }
 
-        emit IERC6900Account.ExecutionInstalled(app.module, app.manifest);
+        emit ExecutionInstalled(app.module, app.manifest);
     }
 
     function _uninstallApp(bytes32 appId, bytes calldata uninstallData) internal {
@@ -119,12 +118,12 @@ abstract contract AppAccountBase is
         bool onUninstallSuccess = true;
         if (uninstallData.length > 0) {
             // solhint-disable-next-line no-empty-blocks
-            try IERC6900Module(app.module).onUninstall(uninstallData) {} catch {
+            try IModule(app.module).onUninstall(uninstallData) {} catch {
                 onUninstallSuccess = false;
             }
         }
 
-        emit IERC6900Account.ExecutionUninstalled(app.module, onUninstallSuccess, app.manifest);
+        emit ExecutionUninstalled(app.module, onUninstallSuccess, app.manifest);
     }
 
     function _onRenewApp(bytes32 appId, bytes calldata /* data */) internal {
@@ -251,19 +250,11 @@ abstract contract AppAccountBase is
 
     function _isInvalidSelector(bytes4 selector) internal pure returns (bool) {
         return
-            selector == IERC6900Account.installExecution.selector ||
-            selector == IERC6900Account.uninstallExecution.selector ||
-            selector == IERC6900Account.installValidation.selector ||
-            selector == IERC6900Account.uninstallValidation.selector ||
-            selector == IERC6900Account.execute.selector ||
-            selector == IERC6900Account.executeBatch.selector ||
-            selector == IERC6900Account.executeWithRuntimeValidation.selector ||
-            selector == IERC6900Account.accountId.selector ||
             selector == IERC165.supportsInterface.selector ||
-            selector == IERC6900Module.moduleId.selector ||
-            selector == IERC6900Module.onInstall.selector ||
-            selector == IERC6900Module.onUninstall.selector ||
-            selector == IERC6900ExecutionModule.executionManifest.selector ||
+            selector == IModule.moduleId.selector ||
+            selector == IModule.onInstall.selector ||
+            selector == IModule.onUninstall.selector ||
+            selector == IExecutionModule.executionManifest.selector ||
             selector == IDiamondCut.diamondCut.selector ||
             selector == ITownsApp.requiredPermissions.selector;
     }

--- a/packages/contracts/src/spaces/facets/account/IAppAccount.sol
+++ b/packages/contracts/src/spaces/facets/account/IAppAccount.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 
 // libraries
 
@@ -14,6 +15,9 @@ interface IAppAccountBase {
     error AppAlreadyInstalled();
     error UnauthorizedApp(address app);
     error InvalidCaller();
+
+    event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
+    event ExecutionUninstalled(address indexed module, bool success, ExecutionManifest manifest);
 }
 
 interface IAppAccount is IAppAccountBase {

--- a/packages/contracts/test/attest/AppRegistry.t.sol
+++ b/packages/contracts/test/attest/AppRegistry.t.sol
@@ -8,8 +8,8 @@ import {BaseSetup} from "test/spaces/BaseSetup.sol";
 import {ISchemaResolver} from "@ethereum-attestation-service/eas-contracts/resolver/ISchemaResolver.sol";
 import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {IAppRegistryBase} from "../../src/apps/facets/registry/IAppRegistry.sol";
+import {IAppAccountBase} from "../../src/spaces/facets/account/IAppAccount.sol";
 import {IAttestationRegistryBase} from "src/apps/facets/attest/IAttestationRegistry.sol";
-import {IERC6900Account} from "@erc6900/reference-implementation/interfaces/IERC6900Account.sol";
 import {IPlatformRequirements} from "src/factory/facets/platform/requirements/IPlatformRequirements.sol";
 import {ITownsApp} from "../../src/apps/ITownsApp.sol";
 import {ISimpleApp} from "../../src/apps/helpers/ISimpleApp.sol";
@@ -20,7 +20,6 @@ import {BasisPoints} from "../../src/utils/libraries/BasisPoints.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 // types
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
 
 //contracts
 import {AppRegistryFacet} from "../../src/apps/facets/registry/AppRegistryFacet.sol";
@@ -29,7 +28,7 @@ import {AppAccount} from "../../src/spaces/facets/account/AppAccount.sol";
 import {MockModule} from "../../test/mocks/MockModule.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBase {
+contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBase, IAppAccountBase {
     AppRegistryFacet internal registry;
     AppAccount internal appAccount;
     MockModule internal mockModule;
@@ -293,7 +292,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
 
         vm.prank(founder);
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionInstalled(address(mockModule), appInfo.manifest);
+        emit ExecutionInstalled(address(mockModule), appInfo.manifest);
         registry.installApp{value: totalRequired}(mockModule, appAccount, "");
     }
 
@@ -327,10 +326,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         uint256 requiredAmount = registry.getAppPrice(address(mockModule));
 
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionInstalled(
-            address(mockModule),
-            mockModule.executionManifest()
-        );
+        emit ExecutionInstalled(address(mockModule), mockModule.executionManifest());
         hoax(founder, requiredAmount);
         registry.installApp{value: requiredAmount}(mockModule, appAccount, "");
 
@@ -350,10 +346,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         uint256 totalPrice = registry.getAppPrice(address(mockModule));
 
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionInstalled(
-            address(mockModule),
-            mockModule.executionManifest()
-        );
+        emit ExecutionInstalled(address(mockModule), mockModule.executionManifest());
         hoax(founder, totalPrice);
         registry.installApp{value: totalPrice}(mockModule, appAccount, "");
 
@@ -373,10 +366,7 @@ contract AppRegistryTest is BaseSetup, IAppRegistryBase, IAttestationRegistryBas
         uint256 totalPrice = registry.getAppPrice(address(mockModule));
 
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionInstalled(
-            address(mockModule),
-            mockModule.executionManifest()
-        );
+        emit ExecutionInstalled(address(mockModule), mockModule.executionManifest());
 
         hoax(founder, totalPrice);
         registry.installApp{value: totalPrice}(mockModule, appAccount, "");

--- a/packages/contracts/test/attest/AttestationRegistry.t.sol
+++ b/packages/contracts/test/attest/AttestationRegistry.t.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
 import {ISchemaRegistry} from "@ethereum-attestation-service/eas-contracts/ISchemaRegistry.sol";
 import {ISchemaResolver} from "@ethereum-attestation-service/eas-contracts/resolver/ISchemaResolver.sol";
 import {IDiamond} from "@towns-protocol/diamond/src/IDiamond.sol";
 import {ISchemaBase} from "src/apps/facets/schema/ISchema.sol";
 import {IAttestationRegistryBase} from "src/apps/facets/attest/IAttestationRegistry.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 // types
-import {Attestation, EMPTY_UID, NotFound} from "@ethereum-attestation-service/eas-contracts/Common.sol";
+import {Attestation, EMPTY_UID} from "@ethereum-attestation-service/eas-contracts/Common.sol";
 import {AttestationRequest, AttestationRequestData, IEAS, RevocationRequest, RevocationRequestData} from "@ethereum-attestation-service/eas-contracts/IEAS.sol";
 import {SchemaRecord} from "@ethereum-attestation-service/eas-contracts/ISchemaRegistry.sol";
 
@@ -397,7 +397,7 @@ contract AttestationRegistryTest is TestUtils, IAttestationRegistryBase, ISchema
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     function registerApp(
-        IERC6900Module plugin,
+        IModule plugin,
         bool revocable
     ) internal returns (bytes32 schemaId, bytes32 attestationId) {
         schemaId = registerSchema(

--- a/packages/contracts/test/mocks/MockInvalidModule.sol
+++ b/packages/contracts/test/mocks/MockInvalidModule.sol
@@ -3,12 +3,11 @@ pragma solidity ^0.8.23;
 
 // interfaces
 import {IDiamond} from "@towns-protocol/diamond/src/Diamond.sol";
-
-// libraries
-import {ExecutionManifest, IERC6900ExecutionModule, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
+import {ExecutionManifest, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 import {ITownsApp} from "src/apps/ITownsApp.sol";
-import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
+// libraries
 
 // contracts
 import {OwnableFacet} from "@towns-protocol/diamond/src/facets/ownable/OwnableFacet.sol";
@@ -91,9 +90,8 @@ contract MockInvalidModule is OwnableFacet, ITownsApp {
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return
-            interfaceId == type(IERC6900ExecutionModule).interfaceId ||
-            interfaceId == type(IERC6900Module).interfaceId ||
-            interfaceId == type(ITownsApp).interfaceId ||
-            interfaceId == type(IERC173).interfaceId;
+            interfaceId == type(IExecutionModule).interfaceId ||
+            interfaceId == type(IModule).interfaceId ||
+            interfaceId == type(ITownsApp).interfaceId;
     }
 }

--- a/packages/contracts/test/mocks/MockModule.sol
+++ b/packages/contracts/test/mocks/MockModule.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {ExecutionManifest, IERC6900ExecutionModule, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
-import {ITownsApp} from "src/apps/ITownsApp.sol";
-import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
+import {ExecutionManifest, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 

--- a/packages/contracts/test/mocks/MockPlugin.sol
+++ b/packages/contracts/test/mocks/MockPlugin.sol
@@ -3,15 +3,13 @@ pragma solidity ^0.8.23;
 
 // interfaces
 
-import {IERC6900ExecutionModule} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
-
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {ITownsApp} from "src/apps/ITownsApp.sol";
 import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 // types
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest, IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 
 // contracts
 import {OwnableFacet} from "@towns-protocol/diamond/src/facets/ownable/OwnableFacet.sol";
@@ -45,8 +43,8 @@ contract MockPlugin is OwnableFacet, ITownsApp {
 
     function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return
-            interfaceId == type(IERC6900Module).interfaceId ||
-            interfaceId == type(IERC6900ExecutionModule).interfaceId ||
+            interfaceId == type(IModule).interfaceId ||
+            interfaceId == type(IExecutionModule).interfaceId ||
             interfaceId == type(ITownsApp).interfaceId ||
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC173).interfaceId;

--- a/packages/contracts/test/mocks/MockSavingsModule.sol
+++ b/packages/contracts/test/mocks/MockSavingsModule.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {ExecutionManifest, IERC6900ExecutionModule, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
-import {IERC6900Module} from "@erc6900/reference-implementation/interfaces/IERC6900Module.sol";
+import {ExecutionManifest, IExecutionModule, ManifestExecutionFunction, ManifestExecutionHook} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 import {ITownsApp} from "src/apps/ITownsApp.sol";
 import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 
@@ -40,8 +40,8 @@ contract MockSavingsModule is OwnableFacet, ITownsApp {
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return
-            interfaceId == type(IERC6900ExecutionModule).interfaceId ||
-            interfaceId == type(IERC6900Module).interfaceId ||
+            interfaceId == type(IExecutionModule).interfaceId ||
+            interfaceId == type(IModule).interfaceId ||
             interfaceId == type(ITownsApp).interfaceId ||
             interfaceId == type(IERC173).interfaceId;
     }
@@ -200,14 +200,14 @@ contract MockSavingsModule is OwnableFacet, ITownsApp {
     }
 
     /**
-     * @notice Required by IERC6900Module - called when module is installed
+     * @notice Required by IModule - called when module is installed
      */
     function onInstall(bytes calldata) external pure {
         // No initialization needed
     }
 
     /**
-     * @notice Required by IERC6900Module - called when module is uninstalled
+     * @notice Required by IModule - called when module is uninstalled
      */
     function onUninstall(bytes calldata) external view {
         // Ensure all funds are withdrawn before uninstall

--- a/packages/contracts/test/spaces/account/AppAccount.t.sol
+++ b/packages/contracts/test/spaces/account/AppAccount.t.sol
@@ -7,13 +7,13 @@ import {BaseSetup} from "test/spaces/BaseSetup.sol";
 //interfaces
 import {IOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {IExecutorBase} from "src/spaces/facets/executor/IExecutor.sol";
-import {IERC6900Account} from "@erc6900/reference-implementation/interfaces/IERC6900Account.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IAppAccountBase} from "src/spaces/facets/account/IAppAccount.sol";
 import {IAppRegistryBase} from "src/apps/facets/registry/IAppRegistry.sol";
 import {IPlatformRequirements} from "src/factory/facets/platform/requirements/IPlatformRequirements.sol";
 
 // types
-import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IERC6900ExecutionModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {Attestation, EMPTY_UID} from "@ethereum-attestation-service/eas-contracts/Common.sol";
 import {BasisPoints} from "src/utils/libraries/BasisPoints.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
@@ -78,7 +78,7 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase, IAppRegistr
         uint256 protocolFee = _getProtocolFee(totalRequired);
 
         hoax(founder, totalRequired);
-        emit IERC6900Account.ExecutionInstalled(address(mockModule), manifest);
+        emit IModularAccount.ExecutionInstalled(address(mockModule), manifest);
         registry.installApp{value: totalRequired}(mockModule, appAccount, "");
 
         // assert that the founder has paid the price
@@ -143,7 +143,7 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase, IAppRegistr
 
         vm.prank(appRegistry);
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionUninstalled(address(mockModule), true, manifest);
+        emit IModularAccount.ExecutionUninstalled(address(mockModule), true, manifest);
         appAccount.onUninstallApp(appId, "");
 
         vm.prank(client);
@@ -198,7 +198,7 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase, IAppRegistr
 
         vm.prank(founder);
         vm.expectEmit(address(appAccount));
-        emit IERC6900Account.ExecutionUninstalled(address(mockModule), false, manifest);
+        emit IModularAccount.ExecutionUninstalled(address(mockModule), false, manifest);
         registry.uninstallApp(mockModule, appAccount, uninstallData);
 
         assertEq(appAccount.isAppEntitled(address(mockModule), client, keccak256("Read")), false);
@@ -218,6 +218,7 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase, IAppRegistr
         assertEq(address(appAccount).balance, 1 ether);
         assertEq(address(mockModule).balance, 0);
     }
+
     function test_revertWhen_execute_bannedApp() external givenAppIsInstalled {
         vm.prank(deployer);
         registry.adminBanApp(address(mockModule));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,10 +1695,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@erc6900/reference-implementation@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "@erc6900/reference-implementation@npm:0.8.1"
-  checksum: 2b5198a6136deea17f79f4376c77fe1c5fb7f5cbb8a9f2be39bfa982d496020a10fa5577b20b6016e18cfa6b38078f2e5da7aef7ca75501a8d523437f6529f3a
+"@erc6900/reference-implementation@https://github.com/erc6900/reference-implementation/archive/refs/tags/v0.8.0.tar.gz":
+  version: 0.8.0
+  resolution: "@erc6900/reference-implementation@https://github.com/erc6900/reference-implementation/archive/refs/tags/v0.8.0.tar.gz"
+  checksum: 7463bb2aec540fb9f3dc5089d8a8db0b29151cef3b2ad24ee5f81892a55d66715ecafb11b2babf3d7eec2b0c12eeb9762fd9f47b3348205360537180e945e205
   languageName: node
   linkType: hard
 
@@ -8802,7 +8802,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@towns-protocol/contracts@workspace:packages/contracts"
   dependencies:
-    "@erc6900/reference-implementation": ^0.8.1
+    "@erc6900/reference-implementation": "https://github.com/erc6900/reference-implementation/archive/refs/tags/v0.8.0.tar.gz"
     "@ethereum-attestation-service/eas-contracts": ^1.8.0
     "@layerzerolabs/lz-evm-messagelib-v2": ^3.0.112
     "@layerzerolabs/lz-evm-protocol-v2": ^3.0.112


### PR DESCRIPTION
### Description

Updated ERC6900 interface imports to match the reference implementation v0.8.0, replacing deprecated interface names with their current versions.

### Changes

- Downgraded `@erc6900/reference-implementation` from v0.8.1 to v0.8.0
- Updated interface imports across the codebase:
    - `IERC6900Module` → `IModule`
    - `IERC6900ExecutionModule` → `IExecutionModule`
    - `IERC6900Account` → `IModularAccount`
- Moved event definitions from the ERC6900 interfaces to our own interfaces
- Fixed import paths for `ExecutionManifest` and other types
- Updated interface checks in `supportsInterface` implementations

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines