### PR TITLE
node: log error when closing DB conn fails

### DIFF
--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -225,7 +225,9 @@ func (s *PostgresStreamStore) maintainSchemaLock(
 
 			// Close the connection to encourage the db server to immediately clean up the
 			// session so we can go ahead and re-take the lock from a new session.
-			conn.Conn().Close(ctx)
+			if err := conn.Conn().Close(ctx); err != nil {
+				log.Warnw("Error closing bad connection", "error", err)
+			}
 			// Fine to call multiple times.
 			conn.Release()
 


### PR DESCRIPTION
## Summary
- Added error handling when closing database connections during schema lock maintenance
- Log warnings instead of silently ignoring connection close errors

## Details
Previously, when releasing a schema lock after encountering an error, the code would attempt to close the database connection but ignore any errors that occurred during the close operation. This change captures and logs those errors as warnings to improve observability and debugging.

The change specifically affects the `maintainSchemaLock` function in the PostgresStreamStore, where after encountering certain errors (like `ErrReleaseLockFailed`), we close the connection to encourage the database server to clean up the session immediately.

## Test plan
- [x] Existing tests pass
- [x] Error handling follows existing patterns in codebase
- [x] Logging uses structured logging with zap as per codebase standards