### PR TITLE
sdk: Update wrap transaction to throw original error

### DIFF
--- a/packages/web3/src/space-dapp/wrapTransaction.ts
+++ b/packages/web3/src/space-dapp/wrapTransaction.ts
@@ -33,7 +33,8 @@ export async function wrapTransaction(
             } catch (error) {
                 retryCount++
                 if (retryCount >= retryLimit) {
-                    throw new Error('Transaction failed after retries: ' + (error as Error).message)
+                    logger.error('Transaction failed after retries', { error, retryCount })
+                    throw error
                 }
                 logger.error('Transaction submission failed, retrying...', { error, retryCount })
                 await new Promise((resolve) => setTimeout(resolve, 1000))


### PR DESCRIPTION
this function is primarily for tests, if we want to parse the error later we need the original error i think