### PR TITLE
feat: add appRegistry address for Base delta deployment

### DIFF
--- a/packages/contracts/deployments/delta/base/addresses/appRegistry.json
+++ b/packages/contracts/deployments/delta/base/addresses/appRegistry.json
@@ -1,0 +1,3 @@
+{
+  "address": "0x9fCd4F3F98b170C7A1AfB9d20E76C6f5ca9Cbe71"
+}


### PR DESCRIPTION
### Description

Added the AppRegistry contract address for the Base network in the Delta deployment configuration.

### Changes

- Added a new JSON file containing the AppRegistry contract address (`0x9fCd4F3F98b170C7A1AfB9d20E76C6f5ca9Cbe71`) for the Base Sepolia network in the Delta deployment

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines