### PR TITLE
add `towns-bot-` prefix to app private data key

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -1,5 +1,6 @@
 import {
     Client,
+    makeAppPrivateData,
     makeBaseProvider,
     makeRiverConfig,
     makeRiverProvider,
@@ -20,8 +21,7 @@ import { Bot as SyncAgentTest, AppRegistryService, getAppRegistryUrl } from '@to
 import { bin_fromHexString, bin_toBase64 } from '@towns-protocol/dlog'
 import { makeTownsBot } from './bot'
 import { ethers } from 'ethers'
-import { AppPrivateDataSchema, ForwardSettingValue } from '@towns-protocol/proto'
-import { toBinary, create } from '@bufbuild/protobuf'
+import { ForwardSettingValue } from '@towns-protocol/proto'
 import {
     AppRegistryDapp,
     ETH_ADDRESS,
@@ -69,7 +69,7 @@ describe('Bot', { sequential: true }, () => {
     let channelId: string
     let botWallet: ethers.Wallet
     let botClientAddress: Address
-    let appPrivateDataBase64: string
+    let appPrivateData: string
     let jwtSecretBase64: string
     let appRegistryRpcClient: AppRegistryRpcClient
     let appAddress: Address
@@ -168,17 +168,12 @@ describe('Bot', { sequential: true }, () => {
 
         const exportedDevice = await botClient.cryptoBackend?.exportDevice()
         expect(exportedDevice).toBeDefined()
-        appPrivateDataBase64 = bin_toBase64(
-            toBinary(
-                AppPrivateDataSchema,
-                create(AppPrivateDataSchema, {
-                    privateKey: botWallet.privateKey,
-                    encryptionDevice: exportedDevice,
-                    env: process.env.RIVER_ENV!,
-                }),
-            ),
+        appPrivateData = makeAppPrivateData(
+            botWallet.privateKey,
+            exportedDevice!,
+            process.env.RIVER_ENV!,
         )
-        expect(appPrivateDataBase64).toBeDefined()
+        expect(appPrivateData).toBeDefined()
     }
 
     const shouldRegisterBotInAppRegistry = async () => {
@@ -204,7 +199,7 @@ describe('Bot', { sequential: true }, () => {
     }
 
     const shouldRunBotServerAndRegisterWebhook = async () => {
-        bot = await makeTownsBot(appPrivateDataBase64, jwtSecretBase64)
+        bot = await makeTownsBot(appPrivateData, jwtSecretBase64)
         expect(bot).toBeDefined()
         expect(bot.botId).toBe(botClientAddress)
         const { jwtMiddleware, handler } = await bot.start()

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -23,6 +23,7 @@ import {
     spaceIdFromChannelId,
     type CreateTownsClientParams,
     make_ChannelPayload_Redaction,
+    parseAppPrivateData,
 } from '@towns-protocol/sdk'
 import { type Context, type Env, type Next } from 'hono'
 import { createMiddleware } from 'hono/factory'
@@ -39,7 +40,6 @@ import {
     type EventPayload,
     SessionKeysSchema,
     type UserInboxPayload_GroupEncryptionSessions,
-    AppPrivateDataSchema,
     MembershipOp,
     type PlainMessage,
     Tags,
@@ -688,19 +688,16 @@ export class Bot<HonoEnv extends Env = BlankEnv> {
 }
 
 export const makeTownsBot = async <HonoEnv extends Env = BlankEnv>(
-    appPrivateDataBase64: string,
+    appPrivateData: string,
     jwtSecretBase64: string,
     opts: {
         baseRpcUrl?: string
     } & Partial<Omit<CreateTownsClientParams, 'env' | 'encryptionDevice'>> = {},
 ) => {
     const { baseRpcUrl, ...clientOpts } = opts
-    const { privateKey, encryptionDevice, env } = fromBinary(
-        AppPrivateDataSchema,
-        bin_fromBase64(appPrivateDataBase64),
-    )
+    const { privateKey, encryptionDevice, env } = parseAppPrivateData(appPrivateData)
     if (!env) {
-        throw new Error('Failed to parse APP_PRIVATE_DATA_BASE64')
+        throw new Error('Failed to parse APP_PRIVATE_DATA')
     }
     const baseConfig = makeBaseChainConfig(env)
     const viemClient = createViemClient({

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -14,7 +14,7 @@ This directory contains example implementations to help you get started with bui
 
 Most examples require these core environment variables:
 
-- `APP_PRIVATE_DATA_BASE64`: Your Towns app private data
+- `APP_PRIVATE_DATA`: Your Towns app private data
 - `JWT_SECRET`: JWT secret for authentication
 - `RIVER_ENV`: Environment (local_multi/alpha/omega)
 - `PORT`: Port to run the application on

--- a/packages/examples/bot-ask-poll/.env.sample
+++ b/packages/examples/bot-ask-poll/.env.sample
@@ -1,3 +1,3 @@
-APP_PRIVATE_DATA_BASE64=your_app_private_data_base64_here
+APP_PRIVATE_DATA=your_app_private_data_here
 JWT_SECRET=your_jwt_secret_here
 PORT=5123

--- a/packages/examples/bot-ask-poll/README.md
+++ b/packages/examples/bot-ask-poll/README.md
@@ -17,7 +17,7 @@ A bot that creates interactive polls with emoji reactions for voting.
 
 ## Environment Variables
 
-- `APP_PRIVATE_DATA_BASE64`: Your Towns app private data
+- `APP_PRIVATE_DATA`: Your Towns app private data
 - `JWT_SECRET`: JWT secret for authentication
 - `RIVER_ENV`: Environment (development/production)
 - `PORT`: Port to run the bot on

--- a/packages/examples/bot-ask-poll/src/index.ts
+++ b/packages/examples/bot-ask-poll/src/index.ts
@@ -26,7 +26,7 @@ const state: State = {
 }
 const emojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟']
 
-const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA_BASE64!, process.env.JWT_SECRET!)
+const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA!, process.env.JWT_SECRET!)
 
 bot.onMessage(async (handler, { message, channelId }) => {
     if (!message.startsWith('@poll')) return

--- a/packages/examples/bot-quickstart/.env.sample
+++ b/packages/examples/bot-quickstart/.env.sample
@@ -1,3 +1,3 @@
-APP_PRIVATE_DATA_BASE64=your_app_private_data_base64_here
+APP_PRIVATE_DATA=your_app_private_data_here
 JWT_SECRET=your_jwt_secret_here
 PORT=5123

--- a/packages/examples/bot-quickstart/README.md
+++ b/packages/examples/bot-quickstart/README.md
@@ -30,7 +30,7 @@ This bot demonstrates the basic functionality of a Towns bot:
 
 ## Environment Variables
 
-- `APP_PRIVATE_DATA_BASE64`: Your Towns app private data
+- `APP_PRIVATE_DATA`: Your Towns app private data
 - `JWT_SECRET`: JWT secret for authentication
 - `RIVER_ENV`: Environment (development/production)
 - `PORT`: Port to run the bot on

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 
 async function main() {
-    const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA_BASE64!, process.env.JWT_SECRET!)
+    const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA!, process.env.JWT_SECRET!)
 
     bot.onMessage(async (handler, { message, channelId, userId, eventId }) => {
         if (userId === bot.botId) return

--- a/packages/examples/bot-thread-ai/.env.sample
+++ b/packages/examples/bot-thread-ai/.env.sample
@@ -1,4 +1,4 @@
-APP_PRIVATE_DATA_BASE64=your_app_private_data_base64_here
+APP_PRIVATE_DATA=your_app_private_data_here
 JWT_SECRET=your_jwt_secret_here
 PORT=5123
 OPENAI_API_KEY=your_openai_api_key_here

--- a/packages/examples/bot-thread-ai/README.md
+++ b/packages/examples/bot-thread-ai/README.md
@@ -17,7 +17,7 @@ A bot that creates AI-powered threads in response to messages using OpenAI's GPT
 
 ## Environment Variables
 
-- `APP_PRIVATE_DATA_BASE64`: Your Towns app private data
+- `APP_PRIVATE_DATA`: Your Towns app private data
 - `JWT_SECRET`: JWT secret for authentication
 - `RIVER_ENV`: Environment (development/production)
 - `PORT`: Port to run the bot on

--- a/packages/examples/bot-thread-ai/src/index.ts
+++ b/packages/examples/bot-thread-ai/src/index.ts
@@ -19,7 +19,7 @@ const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
 })
 
-const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA_BASE64!, process.env.JWT_SECRET!)
+const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA!, process.env.JWT_SECRET!)
 
 bot.onMessage(async (h, { message, userId, eventId, channelId }) => {
     console.log(`🧵 new thread: user ${shortId(userId)} sent message:`, message)

--- a/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
+++ b/packages/playground/src/components/dialog/create-bot/bot-credentials-dialog.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/utils'
 
 interface BotCredentialsData {
     botAddress: string
-    appPrivateDataBase64: string
+    appPrivateData: string
     jwtSecretBase64: string
 }
 
@@ -27,7 +27,7 @@ export const BotCredentialsDialog = ({ open, onOpenChange, data }: BotCredential
         return null
     }
 
-    const envContent = `APP_PRIVATE_DATA_BASE64=${data.appPrivateDataBase64}
+    const envContent = `APP_PRIVATE_DATA=${data.appPrivateData}
 JWT_SECRET=${data.jwtSecretBase64}`
 
     return (


### PR DESCRIPTION
Backward compatible update. 

This PR creates a helper to build / parse private key data and adds a prefix to the key to make it findable.

Should close TOWNS-31001