### PR TITLE
sdk: delete orphan address in the static contracts info

### DIFF
--- a/packages/sdk/src/riverConfig.ts
+++ b/packages/sdk/src/riverConfig.ts
@@ -81,7 +81,6 @@ function makeWeb3Deployment(environmentId: string): Web3Deployment {
                 spaceOwner: process.env.SPACE_OWNER_ADDRESS as Address,
                 riverAirdrop: process.env.RIVER_AIRDROP_ADDRESS as Address | undefined,
                 swapRouter: process.env.SWAP_ROUTER_ADDRESS as Address | undefined,
-                towns: process.env.TOWNS_ADDRESS as Address | undefined,
                 appRegistry: process.env.APP_REGISTRY_ADDRESS as Address | undefined,
                 utils: {
                     mockNFT: process.env.MOCK_NFT_ADDRESS as Address | undefined,

--- a/packages/web3/src/utils/IStaticContractsInfo.ts
+++ b/packages/web3/src/utils/IStaticContractsInfo.ts
@@ -10,7 +10,6 @@ export interface BaseChainConfig {
         baseRegistry: Address
         riverAirdrop: Address | undefined
         swapRouter: Address | undefined
-        towns: Address | undefined
         appRegistry: Address | undefined
         utils: {
             mockNFT: Address | undefined // mockErc721aAddress


### PR DESCRIPTION
there is no towns address on the main level, it got moved into utils. theres a townsMainnet that gets deployed on anvil, but i dont’ see it anywhere else.