### PR TITLE
Remove softlinks and associated README files from the project.

### DIFF
--- a/core/contracts/src/README.md
+++ b/core/contracts/src/README.md
@@ -1,5 +1,0 @@
-Directories are softlinked from `contracts/src/river/registry`.
-
-This provides better context if ./core is open in Cursor or VSCode.
-It's advantageous to provide only needed context to the AI tools,
-and opening at the root of the repo provides more context than AI tools can handle efficiently at the moment.

--- a/core/contracts/src/river/registry
+++ b/core/contracts/src/river/registry
@@ -1,1 +1,0 @@
-../../../../contracts/src/river/registry

--- a/core/node/protocol/src/README.md
+++ b/core/node/protocol/src/README.md
@@ -1,5 +1,0 @@
-`*.proto` files are softlinked from `./protocol` directory.
-
-This provides better context if ./core is open in Cursor or VSCode.
-It's advantageous to provide only needed context to the AI tools,
-and opening at the root of the repo provides more context than AI tools can handle efficiently at the moment.

--- a/core/node/protocol/src/auth.proto
+++ b/core/node/protocol/src/auth.proto
@@ -1,1 +1,0 @@
-../../../../protocol/auth.proto

--- a/core/node/protocol/src/bots.proto
+++ b/core/node/protocol/src/bots.proto
@@ -1,1 +1,0 @@
-../../../../protocol/bots.proto

--- a/core/node/protocol/src/internode.proto
+++ b/core/node/protocol/src/internode.proto
@@ -1,1 +1,0 @@
-../../../../protocol/internode.proto

--- a/core/node/protocol/src/notifications.proto
+++ b/core/node/protocol/src/notifications.proto
@@ -1,1 +1,0 @@
-../../../../protocol/notifications.proto

--- a/core/node/protocol/src/protocol.proto
+++ b/core/node/protocol/src/protocol.proto
@@ -1,1 +1,0 @@
-../../../../protocol/protocol.proto


### PR DESCRIPTION
### Description

llm tools are smart enough to load correct files now. these hacks to reduce context are no longer required.

Remove symlinked files across repo.