### PR TITLE
Deploy contract script update - protect against setting block time to less than 1

### DIFF
--- a/scripts/deploy-contracts.sh
+++ b/scripts/deploy-contracts.sh
@@ -45,9 +45,12 @@ fi
 # make deploy-any-local context=$RIVER_ENV rpc=base_anvil type=utils contract=DeployEntrypoint
 # make deploy-any-local context=$RIVER_ENV rpc=base_anvil type=utils contract=DeployAccountFactory
 
-# Deploying contracts with automine is faster
-cast rpc evm_setAutomine true --rpc-url $BASE_ANVIL_RPC_URL
-cast rpc evm_setAutomine true --rpc-url $RIVER_ANVIL_RPC_URL
+# Deploying contracts with automine is faster if RIVER_BLOCK_TIME is ge 1
+# NOTE anvil fails if you try to set the block time to 0.1, but it's fine to start it with 0.1
+if [ "$RIVER_BLOCK_TIME" -ge 1 ]; then
+    cast rpc evm_setAutomine true --rpc-url $BASE_ANVIL_RPC_URL
+    cast rpc evm_setAutomine true --rpc-url $RIVER_ANVIL_RPC_URL
+fi
 
 # Deploy base contracts
 "$SCRIPT_DIR/deploy-base-contracts.sh" nobuild
@@ -61,8 +64,10 @@ cast rpc anvil_setCode $MULTICALL3_ADDRESS $MULTICALL3_BYTECODE --rpc-url $RIVER
 make deploy-any-local context=$RIVER_ENV rpc=river_anvil type=diamonds contract=DeployRiverRegistry
 
 # Restore to interval mining
-cast rpc evm_setIntervalMining $RIVER_BLOCK_TIME --rpc-url $BASE_ANVIL_RPC_URL
-cast rpc evm_setIntervalMining $RIVER_BLOCK_TIME --rpc-url $RIVER_ANVIL_RPC_URL
+if [ "$RIVER_BLOCK_TIME" -ge 1 ]; then
+    cast rpc evm_setIntervalMining $RIVER_BLOCK_TIME --rpc-url $BASE_ANVIL_RPC_URL
+    cast rpc evm_setIntervalMining $RIVER_BLOCK_TIME --rpc-url $RIVER_ANVIL_RPC_URL
+fi
 
 cd "$PROJECT_ROOT"
 


### PR DESCRIPTION
it’s fine to start anvil with a sub second block time, but you can’t cast setIntervalMining to less than one, you get a cryptic error
```
Error: server returned an error response: error code -32602: invalid number
```

Our user ops tests use 0.1 block times, and i’d like them to share this script