### PR TITLE
fix(docker): complete Docker-based contract deployment and config ext…

### DIFF
--- a/core/justfile
+++ b/core/justfile
@@ -154,14 +154,9 @@ just-deploy-contracts:
     echo "Deploying contracts"
 
     if [ "${USE_DOCKER_CHAINS}" = "1" ]; then
-        # Create destination directories for contract addresses
-        mkdir -p ${CONTRACTS_DIR}/base/addresses
-        mkdir -p ${CONTRACTS_DIR}/river/addresses
-
-        # Copy deployment files from container
-        echo "Extracting contract addresses from Docker containers"
-        docker cp towns-base-chain:/app/local_dev/base/addresses/. ${CONTRACTS_DIR}/base/addresses/
-        docker cp towns-river-chain:/app/local_dev/river/addresses/. ${CONTRACTS_DIR}/river/addresses/
+        # Copy entire local_dev structure from container
+        echo "Extracting contracts and configs from Docker container"
+        docker cp towns-base-chain:/app/local_dev/. ${CONTRACTS_DIR}/
     else
         echo "Deploying contracts"
         ../scripts/deploy-contracts.sh

--- a/packages/contracts/docker/Dockerfile
+++ b/packages/contracts/docker/Dockerfile
@@ -61,7 +61,12 @@ COPY ./turbo.json turbo.json
 # Copy workspace package.json files (needed for workspace resolution)
 COPY ./protocol/package.json protocol/package.json
 COPY ./packages/contracts/package.json packages/contracts/package.json
+COPY ./packages/generated/package.json packages/generated/package.json
+COPY ./packages/generated/scripts packages/generated/scripts
 COPY ./packages/prettier-config/package.json packages/prettier-config/package.json
+
+# Create empty deployments directory to satisfy preinstall script
+RUN mkdir -p packages/generated/deployments
 
 # Install dependencies with Yarn
 RUN yarn install && yarn cache clean

--- a/packages/contracts/docker/setup.sh
+++ b/packages/contracts/docker/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# This script deploys our contracts to base and river chains, and registers the nodes.
+# This script deploys contracts to base and river chains and creates contracts.env.
 # The anvil instances are run with --dump-state, so we can load the state into the chains.
 # This file is meant to be run in a `RUN` block in a Dockerfile as part of the build process.
 # run.sh is the entrypoint for the container.
@@ -15,8 +15,7 @@ main() {
   wait_for_base_chain
   wait_for_river_chain
   deploy_contracts
-  copy_contract_addresses
-  echo "Done!"
+  create_contracts_env
 }
 
 start_base_chain() {
@@ -119,10 +118,10 @@ deploy_contracts() {
   popd
 }
 
-# Copy contract addresses to a known location for easy extraction
-copy_contract_addresses() {
-  echo "Copying contract addresses..."
-  contracts_dir="./packages/contracts/deployments/local_dev"
+# Copy contract addresses and create contracts.env file
+create_contracts_env() {
+  echo "Copying contract addresses and creating contracts.env..."
+  contracts_dir="packages/contracts/deployments/local_dev"
 
   # Fail if contract deployment directory doesn't exist
   if [ ! -d "$contracts_dir" ]; then
@@ -149,7 +148,21 @@ copy_contract_addresses() {
     fi
   done
 
-  echo "Contract addresses copied to ./local_dev"
+  # Create contracts.env file using justfile recipe
+  cd ./core
+  just CONTRACTS_DIR="../${contracts_dir}" RUN_BASE="../local_dev" create-contracts-env
+  cd ..
+  
+  # Generate config using packages/generated
+  if [ -d "./packages/generated" ]; then
+    cd ./packages/generated
+    yarn make-config
+    # Copy generated .env to local_dev for extraction
+    cp "./deployments/local_dev/.env" "../../local_dev/.env"
+    cd ../..
+  fi
+  
+  echo "Contract addresses and contracts.env created successfully"
 }
 
 # cd ./core && just config build

--- a/packages/contracts/docker/setup.sh
+++ b/packages/contracts/docker/setup.sh
@@ -130,7 +130,8 @@ create_contracts_env() {
     exit 1
   fi
 
-  mkdir -p ./local_dev
+  output_dir="/app/local_dev"
+  mkdir -p $output_dir
 
   # Copy contract addresses and fail if any are missing
   for chain in base river; do
@@ -140,7 +141,7 @@ create_contracts_env() {
       exit 1
     fi
 
-    target_dir="./local_dev/${chain}/addresses"
+    target_dir="${output_dir}/${chain}/addresses"
     mkdir -p "$target_dir"
     if ! cp -r "$source_dir"/. "$target_dir/"; then
       echo "ERROR: Failed to copy $chain contract addresses"
@@ -150,7 +151,7 @@ create_contracts_env() {
 
   # Create contracts.env file using justfile recipe
   cd ./core
-  just CONTRACTS_DIR="../${contracts_dir}" RUN_BASE="../local_dev" create-contracts-env
+  just CONTRACTS_DIR="../${contracts_dir}" RUN_BASE="${output_dir}" create-contracts-env
   cd ..
   
   # Generate config using packages/generated
@@ -158,7 +159,7 @@ create_contracts_env() {
     cd ./packages/generated
     yarn make-config
     # Copy generated .env to local_dev for extraction
-    cp "./deployments/local_dev/.env" "../../local_dev/.env"
+    cp "./deployments/local_dev/.env" "${output_dir}/.env"
     cd ../..
   fi
   


### PR DESCRIPTION
…raction

### Description

This ensures contracts.env and .env files are available at ./run_files/local_dev/ for River nodes when using Docker-based development workflow.

Problem: When using Docker chains with "~Start Local Dev~", the contracts.env and configuration files were missing from the local filesystem, causing River nodes to fail startup with missing contract addresses and chain IDs.

Root cause: The Docker extraction process was incomplete and missing the packages/generated configuration generation step.

### Changes

- Add packages/generated support to Docker build process
- Create empty deployments directory to satisfy preinstall script
- Update setup.sh to call justfile's create-contracts-env recipe
- Add yarn make-config to generate complete .env configuration files
- Copy generated .env to /app/local_dev for Docker extraction
- Simplify Docker extraction to copy entire /app/local_dev structure
- Fix missing contracts.env extraction from Docker containers
- Update comments to reflect current Docker-first workflow

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)