### PR TITLE
add proto as dependency to quickstart example

### DIFF
--- a/packages/examples/bot-quickstart/package.json
+++ b/packages/examples/bot-quickstart/package.json
@@ -17,6 +17,7 @@
         "@connectrpc/connect-node": "^2.0.0",
         "@hono/node-server": "^1.14.0",
         "@towns-protocol/bot": "workspace:^",
+        "@towns-protocol/proto": "workspace:^",
         "hono": "^4.7.11"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9325,6 +9325,7 @@ __metadata:
     "@connectrpc/connect-node": ^2.0.0
     "@hono/node-server": ^1.14.0
     "@towns-protocol/bot": "workspace:^"
+    "@towns-protocol/proto": "workspace:^"
     "@types/node": ^20.14.8
     "@typescript-eslint/eslint-plugin": ^8.29.0
     "@typescript-eslint/parser": ^8.29.0


### PR DESCRIPTION
we're using it to build slash commands.

wasn't caught in CI since yarn hoists it for us