### PR TITLE
feat: simplify bot handlers, improve `onMessage`

### DIFF
--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -10,8 +10,8 @@ import { serve } from "@hono/node-server";
 
 const bot = await makeTownsBot("<app-private-data-base64>", "<jwt-secret>");
 
-bot.onMessage((client, { channelId, hasBotMention }) => {
-  if (hasBotMention) {
+bot.onMessage((client, { channelId, isMentioned }) => {
+  if (isMentioned) {
     client.sendMessage(channelId, "Hello, world!");
   }
 });

--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -8,11 +8,13 @@ A bot framework for Towns.
 import { makeTownsBot } from "@towns-protocol/bot";
 import { serve } from "@hono/node-server";
 
-const bot = await makeTownsBot("<app-private-data-base64>", "<env>");
+const bot = await makeTownsBot("<app-private-data-base64>", "<jwt-secret>");
 
-bot.onMentioned((client, { channelId }) =>
-  client.sendMessage(channelId, "Hello, world!"),
-);
+bot.onMessage((client, { channelId, hasBotMention }) => {
+  if (hasBotMention) {
+    client.sendMessage(channelId, "Hello, world!");
+  }
+});
 
 const { fetch } = await bot.start();
 serve({ fetch });

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -737,7 +737,8 @@ describe('Bot', { sequential: true }, () => {
         },
     )
 
-    it('never receive message from a uninstalled app', async () => {
+    // TODO: waiting for disable bot feature
+    it.skip('never receive message from a uninstalled app', async () => {
         await appRegistryDapp.uninstallApp(
             bob.signer,
             appAddress,

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -454,11 +454,11 @@ describe('Bot', { sequential: true }, () => {
         expect(threadEvent?.threadId).toBe(initialMessageId)
     })
 
-    it('onMessage should be triggered with hasBotMention when a bot is mentioned', async () => {
+    it('onMessage should be triggered with isMentioned when a bot is mentioned', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
         const receivedMentionedEvents: OnMessageType[] = []
         bot.onMessage((_h, e) => {
-            if (e.hasBotMention) {
+            if (e.isMentioned) {
                 receivedMentionedEvents.push(e)
             }
         })
@@ -475,12 +475,12 @@ describe('Bot', { sequential: true }, () => {
         await waitFor(() => receivedMentionedEvents.length > 0)
         const mentionedEvent = receivedMentionedEvents.find((x) => x.eventId === eventId)
         expect(mentionedEvent).toBeDefined()
-        expect(mentionedEvent?.hasBotMention).toBe(true)
+        expect(mentionedEvent?.isMentioned).toBe(true)
         expect(mentionedEvent?.mentions[0].userId).toBe(bot.botId)
         expect(mentionedEvent?.mentions[0].displayName).toBe(BOT_DISPLAY_NAME)
     })
 
-    it('hasBotMention should be false when someone else is mentioned', async () => {
+    it('isMentioned should be false when someone else is mentioned', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
         const receivedMessages: OnMessageType[] = []
         bot.onMessage((_h, e) => {
@@ -499,10 +499,10 @@ describe('Bot', { sequential: true }, () => {
         await waitFor(() => receivedMessages.length > 0)
         const message = receivedMessages.find((x) => x.eventId === eventId)
         expect(message).toBeDefined()
-        expect(message?.hasBotMention).toBe(false)
+        expect(message?.isMentioned).toBe(false)
     })
 
-    it('onMessage should be triggered with both threadId and hasBotMention when bot is mentioned in a thread', async () => {
+    it('onMessage should be triggered with both threadId and isMentioned when bot is mentioned in a thread', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
         const receivedMentionedInThreadEvents: OnMessageType[] = []
         bot.onMessage((_h, e) => {
@@ -533,10 +533,10 @@ describe('Bot', { sequential: true }, () => {
         expect(threadMentionEvent).toBeDefined()
         expect(threadMentionEvent?.userId).toBe(bob.userId)
         expect(threadMentionEvent?.threadId).toBe(initialMessageId)
-        expect(threadMentionEvent?.hasBotMention).toBe(true)
+        expect(threadMentionEvent?.isMentioned).toBe(true)
     })
 
-    it('thread message without bot mention should have hasBotMention false', async () => {
+    it('thread message without bot mention should have isMentioned false', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
         const receivedMessages: OnMessageType[] = []
         bot.onMessage((_h, e) => {
@@ -557,7 +557,7 @@ describe('Bot', { sequential: true }, () => {
         const message = receivedMessages.find((x) => x.eventId === threadEventId)
         expect(message).toBeDefined()
         expect(message?.threadId).toBe(initialMessageId)
-        expect(message?.hasBotMention).toBe(false)
+        expect(message?.isMentioned).toBe(false)
     })
 
     it('onReaction should be triggered when a reaction is added', async () => {

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -45,9 +45,6 @@ const SLASH_COMMANDS = [
 type OnMessageType = BotPayload<'message'>
 type OnChannelJoin = BotPayload<'channelJoin'>
 type OnMessageEditType = BotPayload<'messageEdit'>
-type OnThreadMessageType = BotPayload<'threadMessage'>
-type OnMentionedType = BotPayload<'mentioned'>
-type OnMentionedInThreadType = BotPayload<'mentionedInThread'>
 type OnSlashCommandType = BotPayload<'slashCommand', typeof SLASH_COMMANDS>
 
 describe('Bot', { sequential: true }, () => {
@@ -432,11 +429,13 @@ describe('Bot', { sequential: true }, () => {
         expect(editEvent?.message).toBe(editedMessage)
     })
 
-    it('onThreadMessage should be triggered when a message is sent in a thread', async () => {
+    it('onMessage should be triggered with threadId when a message is sent in a thread', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedThreadMessages: OnThreadMessageType[] = []
-        bot.onThreadMessage((_h, e) => {
-            receivedThreadMessages.push(e)
+        const receivedThreadMessages: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
+            if (e.threadId) {
+                receivedThreadMessages.push(e)
+            }
         })
 
         const initialMessage = 'Starting a thread'
@@ -455,11 +454,13 @@ describe('Bot', { sequential: true }, () => {
         expect(threadEvent?.threadId).toBe(initialMessageId)
     })
 
-    it('onMentioned should be triggered when a bot is mentioned', async () => {
+    it('onMessage should be triggered with hasBotMention when a bot is mentioned', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedEvents: OnMentionedType[] = []
-        bot.onMentioned((_h, e) => {
-            receivedMentionedEvents.push(e)
+        const receivedMentionedEvents: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
+            if (e.hasBotMention) {
+                receivedMentionedEvents.push(e)
+            }
         })
         const TEST_MESSAGE = 'Hello @bot'
         const { eventId } = await bobDefaultChannel.sendMessage(TEST_MESSAGE, {
@@ -474,15 +475,16 @@ describe('Bot', { sequential: true }, () => {
         await waitFor(() => receivedMentionedEvents.length > 0)
         const mentionedEvent = receivedMentionedEvents.find((x) => x.eventId === eventId)
         expect(mentionedEvent).toBeDefined()
+        expect(mentionedEvent?.hasBotMention).toBe(true)
         expect(mentionedEvent?.mentions[0].userId).toBe(bot.botId)
         expect(mentionedEvent?.mentions[0].displayName).toBe(BOT_DISPLAY_NAME)
     })
 
-    it('onMentioned should NOT BE triggered when someone else is mentioned', async () => {
+    it('hasBotMention should be false when someone else is mentioned', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedEvents: OnMentionedType[] = []
-        bot.onMentioned((_h, e) => {
-            receivedMentionedEvents.push(e)
+        const receivedMessages: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
+            receivedMessages.push(e)
         })
         const TEST_MESSAGE = 'Hello @alice'
         const { eventId } = await bobDefaultChannel.sendMessage(TEST_MESSAGE, {
@@ -494,14 +496,16 @@ describe('Bot', { sequential: true }, () => {
                 },
             ],
         })
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        expect(receivedMentionedEvents.find((x) => x.eventId === eventId)).toBeUndefined()
+        await waitFor(() => receivedMessages.length > 0)
+        const message = receivedMessages.find((x) => x.eventId === eventId)
+        expect(message).toBeDefined()
+        expect(message?.hasBotMention).toBe(false)
     })
 
-    it('onMentionedInThread should be triggered when bot is mentioned in a thread', async () => {
+    it('onMessage should be triggered with both threadId and hasBotMention when bot is mentioned in a thread', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedInThreadEvents: OnMentionedInThreadType[] = []
-        bot.onMentionedInThread((_h, e) => {
+        const receivedMentionedInThreadEvents: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
             receivedMentionedInThreadEvents.push(e)
         })
 
@@ -529,35 +533,14 @@ describe('Bot', { sequential: true }, () => {
         expect(threadMentionEvent).toBeDefined()
         expect(threadMentionEvent?.userId).toBe(bob.userId)
         expect(threadMentionEvent?.threadId).toBe(initialMessageId)
+        expect(threadMentionEvent?.hasBotMention).toBe(true)
     })
 
-    it('onMentionedInThread should NOT be triggered for regular mentions outside threads', async () => {
+    it('thread message without bot mention should have hasBotMention false', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedInThreadEvents: OnMentionedInThreadType[] = []
-        bot.onMentionedInThread((_h, e) => {
-            receivedMentionedInThreadEvents.push(e)
-        })
-
-        const regularMentionMessage = 'Mentioning @bot outside thread'
-        const { eventId } = await bobDefaultChannel.sendMessage(regularMentionMessage, {
-            mentions: [
-                {
-                    userId: bot.botId,
-                    displayName: bot.botId,
-                    mentionBehavior: { case: undefined, value: undefined },
-                },
-            ],
-        })
-
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        expect(receivedMentionedInThreadEvents.find((x) => x.eventId === eventId)).toBeUndefined()
-    })
-
-    it('onMentionedInThread should NOT be triggered for thread messages without bot mentions', async () => {
-        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedInThreadEvents: OnMentionedInThreadType[] = []
-        bot.onMentionedInThread((_h, e) => {
-            receivedMentionedInThreadEvents.push(e)
+        const receivedMessages: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
+            receivedMessages.push(e)
         })
 
         const initialMessage = 'Starting another thread'
@@ -570,10 +553,11 @@ describe('Bot', { sequential: true }, () => {
             },
         )
 
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        expect(
-            receivedMentionedInThreadEvents.find((x) => x.eventId === threadEventId),
-        ).toBeUndefined()
+        await waitFor(() => receivedMessages.length > 0)
+        const message = receivedMessages.find((x) => x.eventId === threadEventId)
+        expect(message).toBeDefined()
+        expect(message?.threadId).toBe(initialMessageId)
+        expect(message?.hasBotMention).toBe(false)
     })
 
     it('onReaction should be triggered when a reaction is added', async () => {
@@ -659,19 +643,25 @@ describe('Bot', { sequential: true }, () => {
             ).toBe(RiverTimelineEvent.RedactedEvent),
         )
     })
-    // TODO: flaky test
-    it.skip('onReply should be triggered when a message is replied to', async () => {
+    it.skip('onMessage should be triggered with replyId when a message is replied to', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS)
-        const receivedReplyEvents: BotPayload<'reply'>[] = []
-        bot.onReply((_h, e) => {
+        const receivedReplyEvents: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
             receivedReplyEvents.push(e)
         })
         const { eventId: messageId } = await bot.sendMessage(channelId, 'hii')
+        await waitFor(() =>
+            expect(
+                bobDefaultChannel.timeline.events.value.find((x) => x.eventId === messageId),
+            ).toBeDefined(),
+        )
         const { eventId: replyEventId } = await bobDefaultChannel.sendMessage('hi back', {
             replyId: messageId,
         })
         await waitFor(() => receivedReplyEvents.length > 0)
-        expect(receivedReplyEvents.find((x) => x.eventId === replyEventId)).toBeDefined()
+        const replyEvent = receivedReplyEvents.find((x) => x.eventId === replyEventId)
+        expect(replyEvent).toBeDefined()
+        expect(replyEvent?.replyId).toBe(messageId)
     })
 
     it('onTip should be triggered when a tip is received', async () => {
@@ -754,8 +744,8 @@ describe('Bot', { sequential: true }, () => {
             SpaceAddressFromSpaceId(spaceId) as Address,
         )
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
-        const receivedMentionedEvents: OnMentionedType[] = []
-        bot.onMentioned((_h, e) => {
+        const receivedMentionedEvents: OnMessageType[] = []
+        bot.onMessage((_h, e) => {
             receivedMentionedEvents.push(e)
         })
         const TEST_MESSAGE = 'wont be received'

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -103,7 +103,7 @@ export type BotEvents<Commands extends PlainMessage<SlashCommand>[] = []> = {
             /** Users mentioned in the message */
             mentions: Pick<ChannelMessage_Post_Mention, 'userId' | 'displayName'>[]
             /** Convenience flag to check if the bot was mentioned */
-            hasBotMention: boolean
+            isMentioned: boolean
         },
     ) => void | Promise<void>
     redaction: (
@@ -127,7 +127,7 @@ export type BotEvents<Commands extends PlainMessage<SlashCommand>[] = []> = {
             /** Users mentioned in the message */
             mentions: Pick<ChannelMessage_Post_Mention, 'userId' | 'displayName'>[]
             /** Convenience flag to check if the bot was mentioned */
-            hasBotMention: boolean
+            isMentioned: boolean
         },
     ) => void | Promise<void>
     reaction: (
@@ -516,7 +516,7 @@ export class Bot<
                     const replyId = payload.value.replyId
                     const threadId = payload.value.threadId
                     const mentions = parseMentions(payload.value.content.value.mentions)
-                    const hasBotMention = mentions.some((m) => m.userId === this.botId)
+                    const isMentioned = mentions.some((m) => m.userId === this.botId)
                     const forwardPayload: BotPayload<'message', Commands> = {
                         userId,
                         eventId: parsed.hashStr,
@@ -527,7 +527,7 @@ export class Bot<
                         isGdm: isGDMChannelStreamId(streamId),
                         createdAt,
                         mentions,
-                        hasBotMention,
+                        isMentioned,
                         replyId,
                         threadId,
                     }
@@ -571,7 +571,7 @@ export class Bot<
                 // TODO: framework doesnt handle non-text edits
                 if (payload.value.post?.content.case !== 'text') break
                 const mentions = parseMentions(payload.value.post?.content.value.mentions)
-                const hasBotMention = mentions.some((m) => m.userId === this.botId)
+                const isMentioned = mentions.some((m) => m.userId === this.botId)
                 this.emitter.emit('messageEdit', this.client, {
                     userId: userIdFromAddress(parsed.event.creatorAddress),
                     eventId: parsed.hashStr,
@@ -580,7 +580,7 @@ export class Bot<
                     refEventId: payload.value.refEventId,
                     message: payload.value.post?.content.value.body,
                     mentions,
-                    hasBotMention,
+                    isMentioned,
                     createdAt,
                     replyId: payload.value.post?.replyId,
                     threadId: payload.value.post?.threadId,

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -45,8 +45,8 @@ async function main() {
         }
     })
 
-    bot.onMessage(async (handler, { channelId, hasBotMention }) => {
-        if (hasBotMention) {
+    bot.onMessage(async (handler, { channelId, isMentioned }) => {
+        if (isMentioned) {
             await handler.sendMessage(channelId, 'You mentioned me! 🤖')
         }
     })

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -39,9 +39,7 @@ async function main() {
         }
     })
 
-    bot.onReaction(async (handler, { reaction, channelId, userId }) => {
-        if (userId === bot.botId) return
-
+    bot.onReaction(async (handler, { reaction, channelId }) => {
         if (reaction === '👋') {
             await handler.sendMessage(channelId, 'Thanks for the wave! 👋')
         }

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -14,9 +14,7 @@ async function main() {
         await handler.sendMessage(channelId, `Current time: ${currentTime} ⏰`)
     })
 
-    bot.onMessage(async (handler, { message, channelId, userId, eventId, createdAt }) => {
-        if (userId === bot.botId) return
-
+    bot.onMessage(async (handler, { message, channelId, eventId, createdAt }) => {
         if (message.toLowerCase().includes('hello')) {
             await handler.sendMessage(channelId, 'Hello there! 👋')
         }
@@ -49,38 +47,9 @@ async function main() {
         }
     })
 
-    bot.onMentioned(async (handler, { message, channelId, userId, eventId, createdAt }) => {
-        if (userId === bot.botId) return
-
-        if (message.toLowerCase().includes('hello')) {
-            await handler.sendMessage(channelId, 'Hello there! 👋')
-        }
-
-        if (message.toLowerCase().includes('help')) {
-            await handler.sendMessage(
-                channelId,
-                'I can respond to:\n• "hello" - I\'ll greet you back\n• "ping" - I\'ll respond with pong\n• "time" - I\'ll tell you the current time',
-            )
-        }
-
-        if (message.toLowerCase().includes('ping')) {
-            const now = new Date()
-            await handler.sendMessage(
-                channelId,
-                `Pong! 🏓 ${now.getTime() - createdAt.getTime()}ms`,
-            )
-        }
-
-        if (message.toLowerCase().includes('react')) {
-            await handler.sendReaction(channelId, eventId, '👍')
-        }
-    })
-
-    bot.onReaction(async (handler, { reaction, channelId, userId }) => {
-        if (userId === bot.botId) return
-
-        if (reaction === '👋') {
-            await handler.sendMessage(channelId, 'Thanks for the wave! 👋')
+    bot.onMessage(async (handler, { channelId, hasBotMention }) => {
+        if (hasBotMention) {
+            await handler.sendMessage(channelId, 'You mentioned me! 🤖')
         }
     })
 

--- a/packages/examples/bot-thread-ai/src/index.ts
+++ b/packages/examples/bot-thread-ai/src/index.ts
@@ -21,21 +21,23 @@ const openai = new OpenAI({
 
 const bot = await makeTownsBot(process.env.APP_PRIVATE_DATA!, process.env.JWT_SECRET!)
 
-bot.onMessage(async (h, { message, userId, eventId, channelId }) => {
-    console.log(`🧵 new thread: user ${shortId(userId)} sent message:`, message)
-    const newThreadId = eventId
-    const context = newThread(newThreadId, userId, message)
-    const a = await ai(context)
-    updateContext(newThreadId, bot.botId, a)
-    await h.sendMessage(channelId, a, { threadId: newThreadId })
-})
-
-bot.onThreadMessage(async (h, { channelId, threadId, userId, message }) => {
-    console.log(`🧵 thread message: user ${shortId(userId)} sent message:`, message)
-    const context = updateContext(threadId, userId, message)
-    const a = await ai(context)
-    updateContext(threadId, bot.botId, a)
-    await h.sendMessage(channelId, a, { threadId })
+bot.onMessage(async (h, { message, userId, eventId, channelId, threadId }) => {
+    if (threadId) {
+        // Thread reply
+        console.log(`🧵 thread message: user ${shortId(userId)} sent message:`, message)
+        const context = updateContext(threadId, userId, message)
+        const a = await ai(context)
+        updateContext(threadId, bot.botId, a)
+        await h.sendMessage(channelId, a, { threadId })
+    } else {
+        // New thread
+        console.log(`🧵 new thread: user ${shortId(userId)} sent message:`, message)
+        const newThreadId = eventId
+        const context = newThread(newThreadId, userId, message)
+        const a = await ai(context)
+        updateContext(newThreadId, bot.botId, a)
+        await h.sendMessage(channelId, a, { threadId: newThreadId })
+    }
 })
 
 const newThread = (messageId: string, userId: string, initialPrompt: string) => {


### PR DESCRIPTION
It all started in https://github.com/towns-protocol/towns/pull/4108#issuecomment-3283613915

Previous API was confusing. 
What happens if you have

```ts
onReply(client) => client.sendMessage('oh you replied me!')
onMessage(client) => client.sendMessage('new message!')
```

and you reply a message?
Will it trigger both? You send a reply, so it should trigger `onReply`. But the reply was also a message, so should it call `onMessage` too?

What if you sent a reply message in thread mentioning the bot? We had `onReply`, `onThreadMessage`, `onMentioned`, `onMentionedInThread`. Should it call all of three? 😵‍💫

This PR simplify handlers, removing `onReply`, `onMentioned`, `onThreadMessage`, `onMentionedInThread`. All of this data is now consolidated in `onMessage`.

You can get `threadId`, `replyId`, `mentions`, and I added a `hasBotMention` flag to the payload for convenience.