### PR TITLE
Silence import meta build warnings in esbuilds

### DIFF
--- a/packages/examples/bot-quickstart/esbuild.config.mjs
+++ b/packages/examples/bot-quickstart/esbuild.config.mjs
@@ -24,6 +24,9 @@ const config = {
     target: 'es2022',
     minify: false,
     treeShaking: true,
+    logOverride: {
+        'empty-import-meta': 'silent', // Add this line to silence the warning
+    },
 }
 
 if (isWatch) {

--- a/packages/metrics-discovery/esbuild.config.mjs
+++ b/packages/metrics-discovery/esbuild.config.mjs
@@ -37,6 +37,9 @@ build({
     target: 'es2022',
     minify: false, // No minification for easier debugging. Add minification in production later
     treeShaking: true, // Enable tree shaking to remove unused code
+    logOverride: {
+        'empty-import-meta': 'silent', // Add this line to silence the warning
+    },
 }).catch((e) => {
     console.error(e)
     process.exit(1)

--- a/packages/stream-metadata/esbuild.config.mjs
+++ b/packages/stream-metadata/esbuild.config.mjs
@@ -39,6 +39,9 @@ build({
 	target: 'es2022',
 	minify: false, // No minification for easier debugging. Add minification in production later
 	treeShaking: true, // Enable tree shaking to remove unused code
+	logOverride: {
+		'empty-import-meta': 'silent', // Add this line to silence the warning
+	},
 }).catch((e) => {
 	console.error(e)
 	process.exit(1)

--- a/packages/stress/esbuild.config.mjs
+++ b/packages/stress/esbuild.config.mjs
@@ -26,6 +26,9 @@ build({
         '.ts': 'ts',
         '.wasm': 'file',
     },
+    logOverride: {
+        'empty-import-meta': 'silent', // Add this line to silence the warning
+    },
 }).catch((e) => {
     console.error(e)
     process.exit(1)

--- a/packages/xchain-monitor/esbuild.config.mjs
+++ b/packages/xchain-monitor/esbuild.config.mjs
@@ -33,6 +33,9 @@ build({
     target: 'es2022',
     minify: false, // No minification for easier debugging. Add minification in production later
     treeShaking: true, // Enable tree shaking to remove unused code
+    logOverride: {
+        'empty-import-meta': 'silent', // Add this line to silence the warning
+    },
 }).catch((e) => {
     console.error(e)
     process.exit(1)


### PR DESCRIPTION
Our code is compiled for multiple platforms. We don’t need to see this everywhere

Warning: G] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]

    ../dlog/dist/envUtils.js:10:19:
      10 │         if (typeof import.meta === 'object' && 'env' in import.met...
         ╵                    ~~~~~~~~~~~