### PR TITLE
node: move entitlement log to event decoding to crypto pkg

### DIFF
--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/linkdata/deadlock"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/towns-protocol/towns/core/contracts/base"
 	"github.com/towns-protocol/towns/core/contracts/river"
 	"github.com/towns-protocol/towns/core/node/infra"
 	"github.com/towns-protocol/towns/core/node/logging"
@@ -120,6 +122,26 @@ type (
 		nodeABI      *abi.ABI
 	}
 
+	// OnEntitlementRequestCallback is called when an entitlement check request is detected.
+	OnEntitlementRequestCallback = func(context.Context, *base.IEntitlementCheckerEntitlementCheckRequested)
+
+	// OnEntitlementRequestV2Callback is called when an entitlement check V2 request is detected.
+	OnEntitlementRequestV2Callback = func(context.Context, *base.IEntitlementCheckerEntitlementCheckRequestedV2)
+
+	// EntitlementCheckChainMonitor monitors the base chain for entitlement check request events
+	// and calls the registered callbacks for each event.
+	EntitlementCheckChainMonitor interface {
+		OnEntitlementCheckRequest(from BlockNumber, cb OnEntitlementRequestCallback)
+		OnEntitlementCheckRequestV2(from BlockNumber, cb OnEntitlementRequestV2Callback)
+	}
+
+	entitlementCheckChainMonitor struct {
+		chainMonitor        ChainMonitor
+		checkerContract     *bind.BoundContract
+		checkerContractAddr common.Address
+		checkerABI          *abi.ABI
+	}
+
 	// ChainMonitorPollInterval determines the next poll interval for the chain monitor
 	ChainMonitorPollInterval interface {
 		Interval(took time.Duration, gotBlock bool, hitBlockRangeLimit bool, gotErr bool) time.Duration
@@ -137,9 +159,10 @@ type (
 )
 
 var (
-	_ ChainMonitor             = (*chainMonitor)(nil)
-	_ NodeRegistryChainMonitor = (*nodeRegistryChainMonitor)(nil)
-	_ ChainMonitorPollInterval = (*defaultChainMonitorPollIntervalCalculator)(nil)
+	_ ChainMonitor                 = (*chainMonitor)(nil)
+	_ NodeRegistryChainMonitor     = (*nodeRegistryChainMonitor)(nil)
+	_ EntitlementCheckChainMonitor = (*entitlementCheckChainMonitor)(nil)
+	_ ChainMonitorPollInterval     = (*defaultChainMonitorPollIntervalCalculator)(nil)
 )
 
 // NewChainMonitor constructs an EVM chain monitor that can track state changes on an EVM chain.
@@ -165,6 +188,28 @@ func NewNodeRegistryChainMonitor(chainMonitor ChainMonitor, nodeRegistry common.
 	}
 }
 
+// NewEntitlementCheckChainMonitor constructs an EntitlementCheckChainMonitor that can monitor the base
+// chain for entitlement request and calls the registered callbacks for each event.
+func NewEntitlementCheckChainMonitor(
+	chainMonitor ChainMonitor,
+	entitlementChecker common.Address,
+) *entitlementCheckChainMonitor {
+	checkerABI, err := base.IEntitlementCheckerMetaData.GetAbi()
+	if err != nil {
+		logging.DefaultLogger(zapcore.InfoLevel).
+			Panicw("IEntitlementChecker ABI invalid", "error", err)
+	}
+
+	checkerContract := bind.NewBoundContract(entitlementChecker, *checkerABI, nil, nil, nil)
+
+	return &entitlementCheckChainMonitor{
+		chainMonitor:        chainMonitor,
+		checkerContract:     checkerContract,
+		checkerContractAddr: entitlementChecker,
+		checkerABI:          checkerABI,
+	}
+}
+
 func NewChainMonitorPollIntervalCalculator(
 	blockPeriod time.Duration,
 	errSlowdownLimit time.Duration,
@@ -175,6 +220,47 @@ func NewChainMonitorPollIntervalCalculator(
 		errCounter:        0,
 		errSlowdownLimit:  max(errSlowdownLimit, time.Second),
 	}
+}
+
+func (cm *entitlementCheckChainMonitor) OnEntitlementCheckRequest(from BlockNumber, cb OnEntitlementRequestCallback) {
+	entitlementCheckRequestedTopic := cm.checkerABI.Events["EntitlementCheckRequested"].ID
+	cm.chainMonitor.OnContractWithTopicsEvent(
+		from,
+		cm.checkerContractAddr,
+		[][]common.Hash{{entitlementCheckRequestedTopic}},
+		func(ctx context.Context, log types.Log) {
+			var e base.IEntitlementCheckerEntitlementCheckRequested
+			if err := cm.checkerABI.UnpackIntoInterface(&e, "EntitlementCheckRequested", log.Data); err == nil {
+				e.Raw = log
+				cb(ctx, &e)
+			} else {
+				logging.FromCtx(ctx).Errorw("unable to unpack EntitlementCheckRequested event",
+					"error", err, "tx", log.TxHash, "index", log.Index, "log", log)
+			}
+		},
+	)
+}
+
+func (cm *entitlementCheckChainMonitor) OnEntitlementCheckRequestV2(
+	from BlockNumber,
+	cb OnEntitlementRequestV2Callback,
+) {
+	entitlementCheckRequestedTopic := cm.checkerABI.Events["EntitlementCheckRequestedV2"].ID
+	cm.chainMonitor.OnContractWithTopicsEvent(
+		from,
+		cm.checkerContractAddr,
+		[][]common.Hash{{entitlementCheckRequestedTopic}},
+		func(ctx context.Context, log types.Log) {
+			var e base.IEntitlementCheckerEntitlementCheckRequestedV2
+			if err := cm.checkerABI.UnpackIntoInterface(&e, "EntitlementCheckRequestedV2", log.Data); err == nil {
+				e.Raw = log
+				cb(ctx, &e)
+			} else {
+				logging.FromCtx(ctx).Errorw("unable to unpack EntitlementCheckRequestedV2 event",
+					"error", err, "tx", log.TxHash, "index", log.Index, "log", log)
+			}
+		},
+	)
 }
 
 func (p *defaultChainMonitorPollIntervalCalculator) Interval(

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -7,10 +7,13 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/towns-protocol/towns/core/config"
 	"github.com/towns-protocol/towns/core/contracts/base"
+	contract_types "github.com/towns-protocol/towns/core/contracts/types"
+	. "github.com/towns-protocol/towns/core/node/base"
+	"github.com/towns-protocol/towns/core/node/crypto"
+	"github.com/towns-protocol/towns/core/node/infra"
+	"github.com/towns-protocol/towns/core/node/logging"
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/registries"
 	"github.com/towns-protocol/towns/core/xchain/contracts"
@@ -21,13 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	. "github.com/towns-protocol/towns/core/node/base"
-	"github.com/towns-protocol/towns/core/node/crypto"
-	"github.com/towns-protocol/towns/core/node/infra"
-	"github.com/towns-protocol/towns/core/node/logging"
-
-	contract_types "github.com/towns-protocol/towns/core/contracts/types"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type (
@@ -302,11 +299,11 @@ func (x *xchain) Run(ctx context.Context) {
 		log                                 = x.Log(ctx)
 		entitlementAddress                  = x.config.GetEntitlementContractAddress()
 		entitlementCheckReceipts            = make(chan *entitlementCheckReceipt, 256)
-		onEntitlementCheckRequestedCallback = func(ctx context.Context, event types.Log) {
-			x.onEntitlementCheckRequested(ctx, event, entitlementCheckReceipts)
+		onEntitlementCheckRequestedCallback = func(ctx context.Context, req *base.IEntitlementCheckerEntitlementCheckRequested) {
+			x.onEntitlementCheckRequested(ctx, req, entitlementCheckReceipts)
 		}
-		onEntitlementCheckRequestedV2Callback = func(ctx context.Context, event types.Log) {
-			x.onEntitlementCheckRequestedV2(ctx, event, entitlementCheckReceipts)
+		onEntitlementCheckRequestedV2Callback = func(ctx context.Context, req *base.IEntitlementCheckerEntitlementCheckRequestedV2) {
+			x.onEntitlementCheckRequestedV2(ctx, req, entitlementCheckReceipts)
 		}
 	)
 	x.cancel = cancel
@@ -326,19 +323,9 @@ func (x *xchain) Run(ctx context.Context) {
 		x.metricsPublisher.StartMetricsServer(runCtx, cfg)
 	}
 
-	// Register callback for Base EntitlementCheckRequested V1 events
-	x.baseChain.ChainMonitor.OnContractWithTopicsEvent(
-		x.baseChainStartBlock,
-		entitlementAddress,
-		[][]common.Hash{{x.checkerABI.Events["EntitlementCheckRequested"].ID}},
-		onEntitlementCheckRequestedCallback)
-
-	// Register callback for Base EntitlementCheckRequested V2 events
-	x.baseChain.ChainMonitor.OnContractWithTopicsEvent(
-		x.baseChainStartBlock,
-		entitlementAddress,
-		[][]common.Hash{{x.checkerABI.Events["EntitlementCheckRequestedV2"].ID}},
-		onEntitlementCheckRequestedV2Callback)
+	entitlementChainMonitor := crypto.NewEntitlementCheckChainMonitor(x.baseChain.ChainMonitor, entitlementAddress)
+	entitlementChainMonitor.OnEntitlementCheckRequest(x.baseChainStartBlock, onEntitlementCheckRequestedCallback)
+	entitlementChainMonitor.OnEntitlementCheckRequestV2(x.baseChainStartBlock, onEntitlementCheckRequestedV2Callback)
 
 	// Read entitlement check results from entitlementCheckReceipts and write the result to Base
 	x.writeEntitlementCheckResults(runCtx, entitlementCheckReceipts)
@@ -348,42 +335,33 @@ func (x *xchain) Run(ctx context.Context) {
 // event emitted on Base from the entitlement contract.
 func (x *xchain) onEntitlementCheckRequested(
 	ctx context.Context,
-	event types.Log,
+	reqV1 *base.IEntitlementCheckerEntitlementCheckRequested,
 	entitlementCheckResults chan<- *entitlementCheckReceipt,
 ) {
-	var (
-		log                     = x.Log(ctx)
-		entitlementCheckRequest = base.IEntitlementCheckerEntitlementCheckRequested{}
-	)
-
-	// try to decode the EntitlementCheckRequested event
-	if err := x.checkerContract.UnpackLog(&entitlementCheckRequest, "EntitlementCheckRequested", event); err != nil {
-		x.entitlementCheckRequested.IncFail()
-		log.Errorw("Unable to decode EntitlementCheckRequested event", "error", err)
-		return
-	}
+	log := x.Log(ctx)
 
 	log.Infow("Received EntitlementCheckRequested",
-		"xchain.req.txid", hex.EncodeToString(entitlementCheckRequest.TransactionId[:]),
-		"request", entitlementCheckRequest,
+		"xchain.req.txid", hex.EncodeToString(reqV1.TransactionId[:]),
+		"request", reqV1,
 	)
 
 	// process the entitlement request and post the result to entitlementCheckResults
 	// First, convert the check to a V2 request for unified processing.
-	v2Request := base.IEntitlementCheckerEntitlementCheckRequestedV2{
-		WalletAddress:   entitlementCheckRequest.CallerAddress,
-		SpaceAddress:    entitlementCheckRequest.ContractAddress,
-		ResolverAddress: entitlementCheckRequest.ContractAddress,
-		TransactionId:   entitlementCheckRequest.TransactionId,
-		RoleId:          entitlementCheckRequest.RoleId,
-		SelectedNodes:   entitlementCheckRequest.SelectedNodes,
-		Raw:             entitlementCheckRequest.Raw,
+	reqV2 := base.IEntitlementCheckerEntitlementCheckRequestedV2{
+		WalletAddress:   reqV1.CallerAddress,
+		SpaceAddress:    reqV1.ContractAddress,
+		ResolverAddress: reqV1.ContractAddress,
+		TransactionId:   reqV1.TransactionId,
+		RoleId:          reqV1.RoleId,
+		SelectedNodes:   reqV1.SelectedNodes,
+		Raw:             reqV1.Raw,
 	}
-	outcome, err := x.handleEntitlementCheckRequest(ctx, v2Request)
+
+	outcome, err := x.handleEntitlementCheckRequest(ctx, &reqV2)
 	if err != nil {
 		x.entitlementCheckRequested.IncFail()
 		log.Errorw("Entitlement check failed to process",
-			"error", err, "xchain.req.txid", hex.EncodeToString(entitlementCheckRequest.TransactionId[:]))
+			"error", err, "xchain.req.txid", hex.EncodeToString(reqV1.TransactionId[:]))
 		return
 	}
 
@@ -393,7 +371,7 @@ func (x *xchain) onEntitlementCheckRequested(
 
 		// Convert outcome back to a V1 outcome so that the post method knows
 		// how to branch
-		outcome.Event = entitlementCheckRequest
+		outcome.Event = *reqV1
 		outcome.EventV2 = base.IEntitlementCheckerEntitlementCheckRequestedV2{}
 
 		log.Infow(
@@ -416,20 +394,10 @@ func (x *xchain) onEntitlementCheckRequested(
 // EntitlementCheckRequestedV2 event emitted on Base from the entitlement contract.
 func (x *xchain) onEntitlementCheckRequestedV2(
 	ctx context.Context,
-	event types.Log,
+	entitlementCheckRequestV2 *base.IEntitlementCheckerEntitlementCheckRequestedV2,
 	entitlementCheckResults chan<- *entitlementCheckReceipt,
 ) {
-	var (
-		log                       = x.Log(ctx)
-		entitlementCheckRequestV2 = base.IEntitlementCheckerEntitlementCheckRequestedV2{}
-	)
-
-	// try to decode the EntitlementCheckRequested event
-	if err := x.checkerContract.UnpackLog(&entitlementCheckRequestV2, "EntitlementCheckRequestedV2", event); err != nil {
-		x.entitlementCheckRequested.IncFail()
-		log.Errorw("Unable to decode EntitlementCheckRequestedV2 event", "error", err)
-		return
-	}
+	log := x.Log(ctx)
 
 	log.Infow("Received EntitlementCheckRequestedV2",
 		"xchain.req.txid", hex.EncodeToString(entitlementCheckRequestV2.TransactionId[:]))
@@ -459,7 +427,7 @@ func (x *xchain) onEntitlementCheckRequestedV2(
 // It can return nil, nil in case the request wasn't targeted for the current xchain instance.
 func (x *xchain) handleEntitlementCheckRequest(
 	ctx context.Context,
-	request base.IEntitlementCheckerEntitlementCheckRequestedV2,
+	request *base.IEntitlementCheckerEntitlementCheckRequestedV2,
 ) (*entitlementCheckReceipt, error) {
 	log := x.Log(ctx).
 		With("function", "handleEntitlementCheckRequest").
@@ -477,7 +445,7 @@ func (x *xchain) handleEntitlementCheckRequest(
 				TransactionID: request.TransactionId,
 				RoleId:        request.RoleId,
 				Outcome:       outcome,
-				EventV2:       request,
+				EventV2:       *request,
 			}, nil
 		}
 	}
@@ -746,7 +714,7 @@ func (x *xchain) getRuleData(
 // It returns an indication of the request passes checks.
 func (x *xchain) process(
 	ctx context.Context,
-	request base.IEntitlementCheckerEntitlementCheckRequestedV2,
+	request *base.IEntitlementCheckerEntitlementCheckRequestedV2,
 	client crypto.BlockchainClient,
 	callerAddress common.Address,
 ) (result bool, err error) {


### PR DESCRIPTION
This PR refactors the entitlement check event handling by moving the event decoding logic from the
  xchain server into a dedicated EntitlementCheckChainMonitor in the crypto package.

  Changes

  - Added EntitlementCheckChainMonitor interface and implementation in crypto/chain_monitor.go
    - Provides specialized monitoring for entitlement check events on the base chain
    - Handles unpacking of both V1 and V2 EntitlementCheckRequested events
    - Encapsulates the ABI decoding logic and error handling
  - Simplified xchain server event handling in xchain/server/server.go
    - Removed direct ABI unpacking logic from event handlers
    - Now receives pre-decoded event structs via callbacks
    - Cleaner separation of concerns between event monitoring and business logic

  Benefits

  1. Better encapsulation: Event decoding logic is now co-located with other chain monitoring
  functionality
  2. Improved error handling: Decoding errors are handled consistently in one place
  3. Cleaner code: The xchain server focuses on business logic rather than low-level event parsing
  4. Reusability: The EntitlementCheckChainMonitor can be reused by other components that need to
  monitor entitlement events

  Technical Details

  The refactor maintains backward compatibility and all existing functionality. The monitor:
  - Automatically unpacks EntitlementCheckRequested and EntitlementCheckRequestedV2 events
  - Logs decoding errors with appropriate context
  - Passes decoded events to registered callbacks for processing

  This change follows the existing pattern established by NodeRegistryChainMonitor for specialized
  event monitoring.
