### PR TITLE
node/core/crypto: fix minor documentation issues

### DIFF
--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -55,7 +55,7 @@ type (
 	// NodeRegistryChainMonitor monitors the River Registry contract for node events and calls
 	// registered callbacks for each event.
 	NodeRegistryChainMonitor interface {
-		// OnNodeStatusUpdated registers a callback that is called each time a node is added to the
+		// OnNodeAdded registers a callback that is called each time a node is added to the
 		// River Registry contract.
 		OnNodeAdded(from BlockNumber, cb OnNodeAddedCallback)
 
@@ -63,16 +63,16 @@ type (
 		// in the River Registry contract.
 		OnNodeStatusUpdated(from BlockNumber, cb OnNodeStatusUpdatedCallback)
 
-		// OnNodeStatusUpdated registers a callback that is called each time a node url is updated
+		// OnNodeUrlUpdated registers a callback that is called each time a node url is updated
 		// in the River Registry contract.
 		OnNodeUrlUpdated(from BlockNumber, cb OnNodeUrlUpdatedCallback)
 
-		// OnNodeStatusUpdated registers a callback that is called each time a node is removed from the
+		// OnNodeRemoved registers a callback that is called each time a node is removed from the
 		// River Registry contract.
 		OnNodeRemoved(from BlockNumber, cb OnNodeRemovedCallback)
 	}
 
-	// OnNodeRemovedCallback calles each time a node url is removed.
+	// OnNodeAddedCallback calles each time a node url is removed.
 	OnNodeAddedCallback = func(ctx context.Context, event *river.NodeRegistryV1NodeAdded)
 
 	// OnNodeStatusUpdatedCallback calles each time a node status is updated.


### PR DESCRIPTION
This PR fixes incorrect documentation comments in the NodeRegistryChainMonitor interface and
  related type definitions.

  Changes

  - Fixed copy-paste errors in interface method documentation:
    - OnNodeAdded: Corrected description (was incorrectly labeled as "OnNodeStatusUpdated")
    - OnNodeUrlUpdated: Corrected description (was incorrectly labeled as "OnNodeStatusUpdated")
    - OnNodeRemoved: Corrected description (was incorrectly labeled as "OnNodeStatusUpdated")
  - Fixed type definition comment:
    - OnNodeAddedCallback: Corrected comment that incorrectly stated "called each time a node url is
  removed" to properly match the callback purpose

  Impact

  This is a documentation-only change with no functional impact. It improves code clarity and helps
  developers understand the correct purpose of each callback method in the NodeRegistryChainMonitor
  interface.

