### PR TITLE
app-registry: listen app inbox to flush enqueued messages

### DIFF
--- a/core/node/app_registry/sync/streams_tracker.go
+++ b/core/node/app_registry/sync/streams_tracker.go
@@ -82,7 +82,7 @@ func NewAppRegistryStreamsTracker(
 func (tracker *AppRegistryStreamsTracker) TrackStream(streamId shared.StreamId, _ bool) bool {
 	streamType := streamId.Type()
 
-	return streamType == shared.STREAM_CHANNEL_BIN || streamType == shared.STREAM_USER_INBOX_BIN
+	return streamType == shared.STREAM_CHANNEL_BIN
 }
 
 func (tracker *AppRegistryStreamsTracker) NewTrackedStream(

--- a/core/node/app_registry/sync/streams_tracker.go
+++ b/core/node/app_registry/sync/streams_tracker.go
@@ -82,7 +82,7 @@ func NewAppRegistryStreamsTracker(
 func (tracker *AppRegistryStreamsTracker) TrackStream(streamId shared.StreamId, _ bool) bool {
 	streamType := streamId.Type()
 
-	return streamType == shared.STREAM_CHANNEL_BIN
+	return streamType == shared.STREAM_CHANNEL_BIN || streamType == shared.STREAM_USER_INBOX_BIN
 }
 
 func (tracker *AppRegistryStreamsTracker) NewTrackedStream(
@@ -98,5 +98,6 @@ func (tracker *AppRegistryStreamsTracker) NewTrackedStream(
 		stream,
 		tracker.StreamsTrackerImpl.Listener(),
 		tracker.queue,
+		tracker,
 	)
 }

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -271,7 +271,6 @@ export class Bot<
         const body = await c.req.arrayBuffer()
         const encryptionDevice = this.client.crypto.getUserDevice()
         const request = fromBinary(AppServiceRequestSchema, new Uint8Array(body))
-        console.log('request', JSON.stringify(request, null, 2))
 
         const statusResponse = create(AppServiceResponseSchema, {
             payload: {


### PR DESCRIPTION
Not sure if that's the root issue that was causing bots to be stuck in alpha in some channels / spaces, but locally it fixes it. Would like to give a try and deploy to `alpha`

Claude Code helped me to build this PR.

