### PR TITLE
refactor(docker): modularize Docker builds with reusable workflows

### DIFF
--- a/.github/workflows/Metrics_discovery_docker.yml
+++ b/.github/workflows/Metrics_discovery_docker.yml
@@ -5,7 +5,10 @@ on:
         branches:
             - main
         paths:
-            - 'packages/**'
+            - '.github/workflows/Metrics_discovery_docker.yml'
+            - '.github/workflows/_build-docker-arch.yml'
+            - 'packages/metrics-discovery/**'
+            - 'packages/web3/**'
     workflow_dispatch:
 
 env:
@@ -14,49 +17,31 @@ env:
 jobs:
     build:
         name: Build docker image
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: river-metrics-discovery
+            dockerfile: ./packages/metrics-discovery/Dockerfile
+            cache_scope_prefix: metrics-discovery
+        secrets: inherit
 
+    # Slack notification on failure
+    notify-failure:
+        name: Notify on failure
+        if: failure()
+        needs: [build]
         runs-on: ubuntu-latest
-
-        permissions:
-            contents: write
-            packages: write
-
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Build and push docker image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
-                  #This can be custom alias once requested to aws and approved for public repo
-                  REGISTRY_ALIAS: h5v6m2x1
-                  ECR_REPOSITORY: river-metrics-discovery
-              run: |
-                  docker build -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest . -f ./packages/metrics-discovery/Dockerfile
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-
-            # If action failed, we send a slack notification
             - name: Slack notification
-              if: failure()
               uses: slackapi/slack-github-action@v1.24.0
               with:
                   payload: |
                       {
                           "step": "Build Metrics Discovery Docker Image",
-                          "environment": "N/",
+                          "environment": "N/A",
                           "branch": "${{ github.ref }}",
                           "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "commit": "${{ github.sha }}",

--- a/.github/workflows/Stream_metadata_docker.yml
+++ b/.github/workflows/Stream_metadata_docker.yml
@@ -5,15 +5,10 @@ on:
         branches:
             - main
         paths:
-            - 'packages/stream-metadata/**'
+            - '.github/workflows/Stream_metadata_docker.yml'
+            - '.github/workflows/_build-docker-arch.yml'
             - 'packages/**'
     workflow_dispatch:
-        inputs:
-            is_latest: # This is a boolean input
-                description: 'Add docker:latest tag'
-                required: true
-                default: false
-                type: boolean
 
 env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
@@ -21,63 +16,34 @@ env:
 jobs:
     build:
         name: Build docker image
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: river-stream-metadata
+            dockerfile: ./packages/stream-metadata/Dockerfile
+            cache_scope_prefix: stream-metadata
+            build_args: |
+                GIT_SHA=${{ github.sha }}
+            extra_tags: ${{ github.sha }}
+        secrets: inherit
 
+    # Slack notification on failure
+    notify-failure:
+        name: Notify on failure
+        if: failure()
+        needs: [build]
         runs-on: ubuntu-latest
-
-        permissions:
-            contents: write
-            packages: write
-
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Build and push docker image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
-                  #This can be custom alias once requested to aws and approved for public repo
-                  REGISTRY_ALIAS: h5v6m2x1
-                  ECR_REPOSITORY: river-stream-metadata
-                  IS_LATEST_OR_PUSH: ${{ github.event_name == 'push' || github.event.inputs.is_latest }}
-              run: |
-                  docker build \
-                    --build-arg GIT_SHA=${{ github.sha }} \
-                    -f ./packages/stream-metadata/Dockerfile \
-                    -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest \
-                    -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }} \
-                    .
-
-                  if [ $IS_LATEST_OR_PUSH == true ]; then
-                      echo "Pushing docker image with latest tag"
-                      docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-                  else
-                      echo "Not pushing docker image with latest tag"
-                  fi
-
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }}
-
-            # If action failed, we send a slack notification
             - name: Slack notification
-              if: failure()
               uses: slackapi/slack-github-action@v1.24.0
               with:
                   payload: |
                       {
                           "step": "Build Stream Metadata Docker Image",
-                          "environment": "N/",
+                          "environment": "N/A",
                           "branch": "${{ github.ref }}",
                           "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "commit": "${{ github.sha }}",

--- a/.github/workflows/Stress_test_node_docker.yml
+++ b/.github/workflows/Stress_test_node_docker.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - main
         paths:
+            - '.github/workflows/Stress_test_node_docker.yml'
+            - '.github/workflows/_build-docker-arch.yml'
             - 'packages/**'
     workflow_dispatch:
 
@@ -16,49 +18,31 @@ env:
 jobs:
     build:
         name: Build docker image
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: river-stress-test-node
+            dockerfile: ./packages/stress-testing/Dockerfile
+            cache_scope_prefix: stress-testing
+        secrets: inherit
 
+    # Slack notification on failure
+    notify-failure:
+        name: Notify on failure
+        if: failure()
+        needs: [build]
         runs-on: ubuntu-latest
-
-        permissions:
-            contents: write
-            packages: write
-
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Build and push docker image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
-                  #This can be custom alias once requested to aws and approved for public repo
-                  REGISTRY_ALIAS: h5v6m2x1
-                  ECR_REPOSITORY: river-stress-test-node
-              run: |
-                  docker build -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest . -f ./packages/stress-testing/Dockerfile
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-
-            # If action failed, we send a slack notification
             - name: Slack notification
-              if: failure()
               uses: slackapi/slack-github-action@v1.24.0
               with:
                   payload: |
                       {
                           "step": "Build Stress Test Node Docker Image",
-                          "environment": "N/",
+                          "environment": "N/A",
                           "branch": "${{ github.ref }}",
                           "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "commit": "${{ github.sha }}",

--- a/.github/workflows/Subgraph_docker.yml
+++ b/.github/workflows/Subgraph_docker.yml
@@ -6,6 +6,11 @@ on:
     push:
         branches:
             - main
+        paths:
+            - '.github/workflows/Subgraph_docker.yml'
+            - '.github/workflows/_build-docker-arch.yml'
+            - 'packages/contracts/**'
+            - 'packages/subgraph/**'
     workflow_dispatch: # A build was manually requested
         inputs:
             release_version:
@@ -16,107 +21,145 @@ on:
                 required: false
 
 env:
-    DOCKER_NAMESPACE: herenotthere
-    GHCR_NAMESPACE: herenotthere
-    PLATFORMS: linux/amd64,linux/arm64
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL || secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
 
 jobs:
-    build:
-        name: Build docker image
+    # Generate complex tags for subgraph (beyond standard commit+latest)
+    generate-tags:
+        name: Generate Docker tags
         runs-on: ubuntu-latest
-        outputs:
-            release_image_tag: ${{ steps.build-image.outputs.release_image_tag }}
         permissions:
-            contents: write
-            packages: write
+            contents: read
+        outputs:
+            extra_tags: ${{ steps.generate-tags.outputs.EXTRA_TAGS }}
+            release_image_tag: ${{ steps.generate-tags.outputs.RELEASE_IMAGE_TAG }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Build and push image to Amazon ECR
-              id: build-image
+            - name: Generate extra tags for subgraph
+              id: generate-tags
               env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
-                  #This can be custom alias once requested to aws and approved for public repo
-                  REGISTRY_ALIAS: h5v6m2x1
-                  ECR_REPOSITORY: subgraph
                   RELEASE_VERSION: ${{ inputs.release_version }}
                   ADDITIONAL_TAGS: ${{ inputs.additional_tags_csv }}
               run: |
-                  COMMIT_HASH=$(git describe --tags --always --dirty)
-                  echo "release_image_tag=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
-                  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-                  TAGS=($COMMIT_HASH)
+                  COMMIT_HASH=$(git rev-parse --short HEAD)
+                  echo "RELEASE_IMAGE_TAG=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+                  BRANCH="${{ github.ref_name }}"
 
-                  # if release version is not provided, we set it to "subgraph"
-                  if [ -z "$RELEASE_VERSION" ]; then
-                    RELEASE_VERSION="subgraph"
-                  else
-                    # If this is a release, we also tag the image with the release version.
-                    TAGS+=($RELEASE_VERSION)
+                  EXTRA_TAGS_ARRAY=()
+
+                  # if release version is provided, add it as tag
+                  if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "subgraph" ]; then
+                    EXTRA_TAGS_ARRAY+=($RELEASE_VERSION)
                   fi
 
-                  # If this is a push to main, we also tag the image as dev,
-                  # But RELEASE_VERSION remains untouched, as `dev` is not a version, but just a tag.
+                  # If this is a push to main, we also tag the image as dev
                   if [ "$BRANCH" == "main" ] && [ "${{ github.event_name }}" == "push" ]; then
-                    TAGS+=(dev)
+                    EXTRA_TAGS_ARRAY+=(dev)
                   fi
 
                   # Add additional tags if provided
                   if [ -n "$ADDITIONAL_TAGS" ]; then
                     IFS=',' read -ra ADDITIONAL_TAGS_ARRAY <<< "$ADDITIONAL_TAGS"
                     for tag in "${ADDITIONAL_TAGS_ARRAY[@]}"; do
-                      TAGS+=($tag)
+                      # Trim whitespace
+                      tag=$(echo "$tag" | xargs)
+                      if [ -n "$tag" ]; then
+                        EXTRA_TAGS_ARRAY+=($tag)
+                      fi
                     done
                   fi
 
-                  echo "Building image with the following tags: ${TAGS[@]}"
+                  echo "Extra tags beyond commit hash: ${EXTRA_TAGS_ARRAY[@]}"
                   echo "Commit hash: $COMMIT_HASH"
                   echo "Branch: $BRANCH"
-                  echo "Release version: $RELEASE_VERSION"
+                  echo "Release version: ${RELEASE_VERSION:-subgraph}"
 
-                  docker build \
-                    --build-arg GIT_SHA=${{ github.sha }} \
-                    --build-arg VER_VERSION=$RELEASE_VERSION \
-                    --build-arg VER_BRANCH=$BRANCH \
-                    --build-arg VER_COMMIT=$COMMIT_HASH \
-                    -t subgraph:local-latest \
-                    -f packages/subgraph/Dockerfile \
-                    .
-
-                  echo "::set-output name=tag_valid::false"
-                  for tag in "${TAGS[@]}"; do
-                    if [ "$tag" == "mainnet" ] || [ "$tag" == "testnet" ]; then
-                      echo "::set-output name=tag_valid::true"
-                      echo "::set-output name=tag_value::$tag"
+                  # Convert to comma-separated string
+                  EXTRA_TAGS=""
+                  for tag in "${EXTRA_TAGS_ARRAY[@]}"; do
+                    if [ -n "$EXTRA_TAGS" ]; then
+                      EXTRA_TAGS="$EXTRA_TAGS,$tag"
+                    else
+                      EXTRA_TAGS="$tag"
                     fi
-                    docker tag subgraph:local-latest $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag
-                    docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag
                   done
 
-            # If action failed, we send a slack notification
+                  echo "EXTRA_TAGS=$EXTRA_TAGS" >> $GITHUB_OUTPUT
+
+    # Build AMD64 image on native runner
+    build-amd64:
+        name: Build AMD64 image
+        needs: generate-tags
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: subgraph
+            dockerfile: ./packages/subgraph/Dockerfile
+            cache_scope_prefix: subgraph
+            append_arch_suffix: true
+            tag_latest_on_main: false
+            extra_tags: ${{ needs.generate-tags.outputs.extra_tags }}
+            build_args: |
+                GIT_SHA=${{ github.sha }}
+                VER_VERSION=${{ inputs.release_version || 'subgraph' }}
+                VER_BRANCH=${{ github.ref_name }}
+                VER_COMMIT=${{ github.sha }}
+        secrets: inherit
+
+    # Build ARM64 image on native runner
+    build-arm64:
+        name: Build ARM64 image
+        needs: generate-tags
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: subgraph
+            dockerfile: ./packages/subgraph/Dockerfile
+            cache_scope_prefix: subgraph
+            append_arch_suffix: true
+            tag_latest_on_main: false
+            extra_tags: ${{ needs.generate-tags.outputs.extra_tags }}
+            build_args: |
+                GIT_SHA=${{ github.sha }}
+                VER_VERSION=${{ inputs.release_version || 'subgraph' }}
+                VER_BRANCH=${{ github.ref_name }}
+                VER_COMMIT=${{ github.sha }}
+        secrets: inherit
+
+    # Merge architecture-specific images into multi-arch manifest
+    merge-manifest:
+        needs: [generate-tags, build-amd64, build-arm64]
+        uses: ./.github/workflows/_create-docker-manifest.yml
+        with:
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: subgraph
+            amd64_tags: ${{ needs.build-amd64.outputs.arch_tags }}
+            arm64_tags: ${{ needs.build-arm64.outputs.arch_tags }}
+            validation_tag: ${{ needs.generate-tags.outputs.release_image_tag }}
+        secrets: inherit
+
+    # Slack notification on failure
+    notify-failure:
+        name: Notify on failure
+        if: failure()
+        needs: [generate-tags, build-amd64, build-arm64, merge-manifest]
+        runs-on: ubuntu-latest
+        steps:
             - name: Slack notification
-              if: failure()
               uses: slackapi/slack-github-action@v1.24.0
               with:
                   payload: |
                       {
-                          "step": "Build Subgraph Docker Image",
-                          "environment": "N/",
+                          "step": "Build Subgraph Docker Image (Multi-arch)",
+                          "environment": "N/A",
                           "branch": "${{ github.ref }}",
                           "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "commit": "${{ github.sha }}",
@@ -125,11 +168,11 @@ jobs:
 
     deploy:
         if: success() && github.event_name != 'workflow_dispatch'
-        needs: build
+        needs: [generate-tags, merge-manifest]
         uses: ./.github/workflows/Subgraph_service_continuous_deployment.yml
         with:
             environment_name: gamma
-            docker_image_tag: ${{ needs.build.outputs.release_image_tag }}
+            docker_image_tag: ${{ needs.generate-tags.outputs.release_image_tag }}
         secrets:
             SLACK_CD_WORKFLOW_WEBHOOK_URL: ${{ secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
             ARGOCD_GITHUB_PAT: ${{ secrets.ARGOCD_GITHUB_PAT }}

--- a/.github/workflows/Towns_anvil_docker.yml
+++ b/.github/workflows/Towns_anvil_docker.yml
@@ -20,77 +20,32 @@ on:
     workflow_dispatch: # A build was manually requested
 
 env:
-    ECR_REGISTRY_ALIAS: h5v6m2x1
-    ECR_REPOSITORY: towns-anvil
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL || secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
 
 jobs:
-    # Generate tags once for all architectures
+    # Generate BUILD_HASH for Towns Anvil
     generate-tags:
-        name: Generate Docker tags
+        name: Generate build hash
         runs-on: ubuntu-latest
         permissions:
             contents: read
         outputs:
-            docker_tags: ${{ steps.generate-tags.outputs.DOCKER_TAGS }}
             build_hash: ${{ steps.generate-tags.outputs.BUILD_HASH }}
-            ecr_registry: ${{ steps.login-aws-ecr.outputs.registry }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
             - uses: taiki-e/install-action@just
 
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Generate tags for multi-arch build
+            - name: Generate build hash for Towns Anvil
               id: generate-tags
-              env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
               run: |
-                  COMMIT_HASH=$(git describe --tags --always --dirty)
-                  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-                  # Compute the hash of all files that affect the Docker build - this is the primary tag
+                  # Compute the hash of all files that affect the Docker build
                   cd core
                   BUILD_HASH=$(just _get-docker-build-hash)
                   cd ..
-                  TAGS=($BUILD_HASH)
 
-                  # Also tag with commit hash for traceability
-                  TAGS+=($COMMIT_HASH)
-
-                  # If this is a push to main, we also tag the image as latest
-                  if [ "$BRANCH" == "main" ] && [ "${{ github.event_name }}" == "push" ]; then  
-                    TAGS+=(latest)
-                  fi
-
-                  echo "Building image with the following tags: ${TAGS[@]}"
                   echo "Build hash: $BUILD_HASH"
-                  echo "Commit hash: $COMMIT_HASH"
-                  echo "Branch: $BRANCH"
-
-                  # Create comma-separated tags for build-push-action
-                  DOCKER_TAGS=""
-                  for tag in "${TAGS[@]}"; do
-                    if [ -n "$DOCKER_TAGS" ]; then
-                      DOCKER_TAGS="$DOCKER_TAGS,"
-                    fi
-                    DOCKER_TAGS="$DOCKER_TAGS$ECR_REGISTRY/${{ env.ECR_REGISTRY_ALIAS }}/${{ env.ECR_REPOSITORY }}:$tag"
-                  done
-
-                  echo "DOCKER_TAGS=$DOCKER_TAGS" >> $GITHUB_OUTPUT
                   echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
 
     # Build AMD64 image on native runner
@@ -102,9 +57,12 @@ jobs:
             architecture: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-            docker_tags: ${{ needs.generate-tags.outputs.docker_tags }}
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: towns-anvil
             dockerfile: ./packages/anvil-docker/Dockerfile
             cache_scope_prefix: towns-anvil
+            append_arch_suffix: true
+            extra_tags: ${{ needs.generate-tags.outputs.build_hash }}
         secrets: inherit
 
     # Build ARM64 image on native runner
@@ -116,90 +74,25 @@ jobs:
             architecture: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
-            docker_tags: ${{ needs.generate-tags.outputs.docker_tags }}
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: towns-anvil
             dockerfile: ./packages/anvil-docker/Dockerfile
             cache_scope_prefix: towns-anvil
+            append_arch_suffix: true
+            extra_tags: ${{ needs.generate-tags.outputs.build_hash }}
         secrets: inherit
 
     # Merge architecture-specific images into multi-arch manifest
     merge-manifest:
-        name: Create multi-arch manifest
         needs: [generate-tags, build-amd64, build-arm64]
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        steps:
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Login to Amazon ECR
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Create and push multi-arch manifest
-              env:
-                  ECR_REGISTRY: ${{ needs.generate-tags.outputs.ecr_registry }}
-                  AMD64_TAGS: ${{ needs.build-amd64.outputs.arch_tags }}
-                  ARM64_TAGS: ${{ needs.build-arm64.outputs.arch_tags }}
-                  DOCKER_TAGS: ${{ needs.generate-tags.outputs.docker_tags }}
-              run: |
-                  echo "Creating multi-arch manifest from:"
-                  echo "AMD64 tags: $AMD64_TAGS"
-                  echo "ARM64 tags: $ARM64_TAGS"
-                  echo "Target tags: $DOCKER_TAGS"
-
-                  # Convert comma-separated tags to arrays
-                  IFS=',' read -ra AMD64_ARRAY <<< "$AMD64_TAGS"
-                  IFS=',' read -ra ARM64_ARRAY <<< "$ARM64_TAGS"
-                  IFS=',' read -ra TARGET_ARRAY <<< "$DOCKER_TAGS"
-
-                  # For each target tag, create a manifest from the corresponding arch-specific tags
-                  for i in "${!TARGET_ARRAY[@]}"; do
-                    TARGET_TAG="${TARGET_ARRAY[$i]}"
-                    AMD64_TAG="${AMD64_ARRAY[$i]}"
-                    ARM64_TAG="${ARM64_ARRAY[$i]}"
-
-                    echo "Creating manifest for $TARGET_TAG from $AMD64_TAG and $ARM64_TAG"
-
-                    docker buildx imagetools create \
-                      --tag "$TARGET_TAG" \
-                      "$AMD64_TAG" \
-                      "$ARM64_TAG"
-                  done
-
-            - name: Validate multi-arch manifest
-              env:
-                  ECR_REGISTRY: ${{ needs.generate-tags.outputs.ecr_registry }}
-                  BUILD_HASH: ${{ needs.generate-tags.outputs.build_hash }}
-              run: |
-                  echo "Validating multi-arch manifest for build hash: $BUILD_HASH"
-                  IMAGE_URL="$ECR_REGISTRY/${{ env.ECR_REGISTRY_ALIAS }}/${{ env.ECR_REPOSITORY }}:$BUILD_HASH"
-
-                  # Inspect the manifest to verify both architectures are present
-                  MANIFEST_PLATFORMS=$(docker buildx imagetools inspect --format '{{range .Manifest.Manifests}}{{printf "%s/%s\n" .Platform.OS .Platform.Architecture}}{{end}}' "$IMAGE_URL")
-                  echo "Manifest platforms:"
-                  echo "$MANIFEST_PLATFORMS"
-
-                  # Check for both required platforms
-                  if ! echo "$MANIFEST_PLATFORMS" | grep -q '^linux/amd64$'; then
-                    echo "❌ ERROR: linux/amd64 platform not found in manifest"
-                    exit 1
-                  fi
-
-                  if ! echo "$MANIFEST_PLATFORMS" | grep -q '^linux/arm64$'; then
-                    echo "❌ ERROR: linux/arm64 platform not found in manifest"
-                    exit 1
-                  fi
-
-                  echo "✅ SUCCESS: Multi-arch manifest contains both linux/amd64 and linux/arm64"
+        uses: ./.github/workflows/_create-docker-manifest.yml
+        with:
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: towns-anvil
+            amd64_tags: ${{ needs.build-amd64.outputs.arch_tags }}
+            arm64_tags: ${{ needs.build-arm64.outputs.arch_tags }}
+            validation_tag: ${{ needs.generate-tags.outputs.build_hash }}
+        secrets: inherit
 
     # Slack notification on failure
     notify-failure:

--- a/.github/workflows/XChain_monitor_docker.yml
+++ b/.github/workflows/XChain_monitor_docker.yml
@@ -5,15 +5,11 @@ on:
         branches:
             - main
         paths:
+            - '.github/workflows/XChain_monitor_docker.yml'
+            - '.github/workflows/_build-docker-arch.yml'
+            - 'packages/web3/**'
             - 'packages/xchain-monitor/**'
-            - 'packages/**'
     workflow_dispatch:
-        inputs:
-            is_latest: # This is a boolean input
-                description: 'Add docker:latest tag'
-                required: true
-                default: false
-                type: boolean
 
 env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
@@ -21,67 +17,34 @@ env:
 jobs:
     build:
         name: Build docker image
+        uses: ./.github/workflows/_build-docker-arch.yml
+        with:
+            architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            ecr_registry_alias: h5v6m2x1
+            ecr_repository: xchain-monitor
+            dockerfile: ./packages/xchain-monitor/Dockerfile
+            cache_scope_prefix: xchain-monitor
+            build_args: |
+                GIT_SHA=${{ github.sha }}
+            extra_tags: ${{ github.sha }}
+        secrets: inherit
 
+    # Slack notification on failure
+    notify-failure:
+        name: Notify on failure
+        if: failure()
+        needs: [build]
         runs-on: ubuntu-latest
-
-        permissions:
-            contents: write
-            packages: write
-
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: login-aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
-              with:
-                  registry-type: 'public'
-
-            - name: Build and push docker image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
-                  #This can be custom alias once requested to aws and approved for public repo
-                  REGISTRY_ALIAS: h5v6m2x1
-                  ECR_REPOSITORY: xchain-monitor
-                  IS_LATEST_OR_PUSH: ${{ github.event_name == 'push' || github.event.inputs.is_latest }}
-              run: |
-                  COMMIT_HASH=$(git describe --tags --always --dirty)
-                  echo "Building docker image with following tags: $COMMIT_HASH, ${{ github.sha }}"
-                  docker build \
-                    --build-arg GIT_SHA=${{ github.sha }} \
-                    -f ./packages/xchain-monitor/Dockerfile \
-                    -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest \
-                    -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }} \
-                    -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$COMMIT_HASH \
-                    .
-
-                  if [ $IS_LATEST_OR_PUSH == true ]; then
-                      echo "Pushing docker image with latest tag"
-                      docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-                  else
-                      echo "Not pushing docker image with latest tag"
-                  fi
-
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }}
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$COMMIT_HASH
-
-            # If action failed, we send a slack notification
             - name: Slack notification
-              if: failure()
               uses: slackapi/slack-github-action@v1.24.0
               with:
                   payload: |
                       {
                           "step": "Build XChain Monitor Docker Image",
-                          "environment": "N/",
+                          "environment": "N/A",
                           "branch": "${{ github.ref }}",
                           "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "commit": "${{ github.sha }}",

--- a/.github/workflows/_build-docker-arch.yml
+++ b/.github/workflows/_build-docker-arch.yml
@@ -16,8 +16,12 @@ on:
                 description: 'GitHub runner type'
                 required: true
                 type: string
-            docker_tags:
-                description: 'Comma-separated list of tags'
+            ecr_registry_alias:
+                description: 'ECR registry alias'
+                required: true
+                type: string
+            ecr_repository:
+                description: 'ECR repository name'
                 required: true
                 type: string
             dockerfile:
@@ -38,12 +42,26 @@ on:
                 description: 'Docker build arguments (key=value, one per line)'
                 required: false
                 type: string
+            tag_latest_on_main:
+                description: 'Whether to tag as latest on main push'
+                required: false
+                type: boolean
+                default: true
+            extra_tags:
+                description: 'Additional tags beyond commit hash (comma-separated)'
+                required: false
+                type: string
+            append_arch_suffix:
+                description: 'Whether to append architecture suffix to tags'
+                required: false
+                type: boolean
+                default: false
         outputs:
             image_digest:
                 description: 'Digest of the built image'
                 value: ${{ jobs.build.outputs.digest }}
             arch_tags:
-                description: 'Architecture-specific tags'
+                description: 'Final tags used for the image'
                 value: ${{ jobs.build.outputs.arch_tags }}
 
 jobs:
@@ -56,7 +74,7 @@ jobs:
 
         outputs:
             digest: ${{ steps.build-push.outputs.digest }}
-            arch_tags: ${{ steps.generate-arch-tags.outputs.arch_tags }}
+            arch_tags: ${{ steps.generate-tags.outputs.arch_tags }}
 
         steps:
             - name: Checkout
@@ -69,38 +87,70 @@ jobs:
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws-region: us-east-1
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v2
               with:
                   registry-type: 'public'
 
-            - name: Generate architecture-specific tags
-              id: generate-arch-tags
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Generate tags
+              id: generate-tags
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
               run: |
-                  # Convert comma-separated tags to architecture-specific tags
-                  ARCH_TAGS=""
-                  IFS=',' read -ra TAGS_ARRAY <<< "${{ inputs.docker_tags }}"
+                  echo "Generating tags from ECR inputs"
+                  COMMIT_HASH=$(git rev-parse --short HEAD)
+                  BRANCH="${{ github.ref_name }}"
 
-                  for tag in "${TAGS_ARRAY[@]}"; do
-                    # Extract the tag part after the last colon
-                    TAG_NAME="${tag##*:}"
-                    # Rebuild with arch suffix
-                    REPO_PART="${tag%:*}"
-                    ARCH_TAG="$REPO_PART:$TAG_NAME-${{ inputs.architecture }}"
+                  # Start with commit hash
+                  TAGS=($COMMIT_HASH)
 
-                    if [ -n "$ARCH_TAGS" ]; then
-                      ARCH_TAGS="$ARCH_TAGS,$ARCH_TAG"
+                  # Add latest tag if on main push and enabled
+                  if [ "${{ inputs.tag_latest_on_main }}" == "true" ] && [ "$BRANCH" == "main" ] && [ "${{ github.event_name }}" == "push" ]; then
+                    TAGS+=(latest)
+                  fi
+
+                  # Add extra tags if provided
+                  if [ -n "${{ inputs.extra_tags }}" ]; then
+                    IFS=',' read -ra EXTRA_TAGS_ARRAY <<< "${{ inputs.extra_tags }}"
+                    for extra_tag in "${EXTRA_TAGS_ARRAY[@]}"; do
+                      # Trim whitespace
+                      extra_tag=$(echo "$extra_tag" | xargs)
+                      if [ -n "$extra_tag" ]; then
+                        TAGS+=($extra_tag)
+                      fi
+                    done
+                  fi
+
+                  echo "Building image with base tags: ${TAGS[@]}"
+                  echo "Commit hash: $COMMIT_HASH"
+                  echo "Branch: $BRANCH"
+
+                  # Generate final tags with ECR paths
+                  FINAL_TAGS=""
+
+                  for tag in "${TAGS[@]}"; do
+                    # Create base ECR tag
+                    ECR_TAG="$ECR_REGISTRY/${{ inputs.ecr_registry_alias }}/${{ inputs.ecr_repository }}:$tag"
+
+                    # Append architecture suffix if needed
+                    if [ "${{ inputs.append_arch_suffix }}" == "true" ]; then
+                      ECR_TAG="$ECR_TAG-${{ inputs.architecture }}"
+                    fi
+
+                    # Add to final tags
+                    if [ -n "$FINAL_TAGS" ]; then
+                      FINAL_TAGS="$FINAL_TAGS,$ECR_TAG"
                     else
-                      ARCH_TAGS="$ARCH_TAG"
+                      FINAL_TAGS="$ECR_TAG"
                     fi
                   done
 
-                  echo "Architecture-specific tags: $ARCH_TAGS"
-                  echo "arch_tags=$ARCH_TAGS" >> $GITHUB_OUTPUT
+                  echo "Final tags for build: $FINAL_TAGS"
+                  echo "arch_tags=$FINAL_TAGS" >> $GITHUB_OUTPUT
 
             - name: Build and push ${{ inputs.architecture }} image
               id: build-push
@@ -110,7 +160,7 @@ jobs:
                   file: ${{ inputs.dockerfile }}
                   platforms: ${{ inputs.platform }}
                   push: true
-                  tags: ${{ steps.generate-arch-tags.outputs.arch_tags }}
+                  tags: ${{ steps.generate-tags.outputs.arch_tags }}
                   build-args: ${{ inputs.build_args }}
                   labels: |
                       org.opencontainers.image.source=https://github.com/${{ github.repository }}
@@ -124,4 +174,4 @@ jobs:
             - name: Output image info
               run: |
                   echo "Built ${{ inputs.architecture }} image with digest: ${{ steps.build-push.outputs.digest }}"
-                  echo "Tags: ${{ steps.generate-arch-tags.outputs.arch_tags }}"
+                  echo "Tags: ${{ steps.generate-tags.outputs.arch_tags }}"

--- a/.github/workflows/_create-docker-manifest.yml
+++ b/.github/workflows/_create-docker-manifest.yml
@@ -1,0 +1,104 @@
+# Reusable workflow for creating and validating multi-architecture Docker manifests
+name: 'Create Docker Multi-Arch Manifest'
+
+on:
+    workflow_call:
+        inputs:
+            ecr_registry_alias:
+                description: 'ECR registry alias'
+                required: true
+                type: string
+            ecr_repository:
+                description: 'ECR repository name'
+                required: true
+                type: string
+            amd64_tags:
+                description: 'Comma-separated AMD64 tags from build'
+                required: true
+                type: string
+            arm64_tags:
+                description: 'Comma-separated ARM64 tags from build'
+                required: true
+                type: string
+            validation_tag:
+                description: 'Specific tag to validate (e.g., commit hash)'
+                required: true
+                type: string
+
+jobs:
+    merge-manifest:
+        name: Create multi-arch manifest
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Setup AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: login-ecr
+              uses: aws-actions/amazon-ecr-login@v2
+              with:
+                  registry-type: 'public'
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Create and push multi-arch manifest
+              env:
+                  AMD64_TAGS: ${{ inputs.amd64_tags }}
+                  ARM64_TAGS: ${{ inputs.arm64_tags }}
+              run: |
+                  echo "Creating multi-arch manifest from:"
+                  echo "AMD64 tags: $AMD64_TAGS"
+                  echo "ARM64 tags: $ARM64_TAGS"
+
+                  # Convert comma-separated tags to arrays
+                  IFS=',' read -ra AMD64_ARRAY <<< "$AMD64_TAGS"
+                  IFS=',' read -ra ARM64_ARRAY <<< "$ARM64_TAGS"
+
+                  # For each arch tag pair, create a manifest
+                  for i in "${!AMD64_ARRAY[@]}"; do
+                    AMD64_TAG="${AMD64_ARRAY[$i]}"
+                    ARM64_TAG="${ARM64_ARRAY[$i]}"
+
+                    # Extract the target tag by removing the architecture suffix
+                    TARGET_TAG="${AMD64_TAG%-amd64}"
+
+                    echo "Creating manifest for $TARGET_TAG from $AMD64_TAG and $ARM64_TAG"
+
+                    docker buildx imagetools create \
+                      --tag "$TARGET_TAG" \
+                      "$AMD64_TAG" \
+                      "$ARM64_TAG"
+                  done
+
+            - name: Validate multi-arch manifest
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  VALIDATION_TAG: ${{ inputs.validation_tag }}
+              run: |
+                  echo "Validating multi-arch manifest for tag: $VALIDATION_TAG"
+                  IMAGE_URL="$ECR_REGISTRY/${{ inputs.ecr_registry_alias }}/${{ inputs.ecr_repository }}:$VALIDATION_TAG"
+
+                  # Inspect the manifest to verify both architectures are present
+                  MANIFEST_PLATFORMS=$(docker buildx imagetools inspect --format '{{range .Manifest.Manifests}}{{printf "%s/%s\n" .Platform.OS .Platform.Architecture}}{{end}}' "$IMAGE_URL")
+                  echo "Manifest platforms:"
+                  echo "$MANIFEST_PLATFORMS"
+
+                  # Check for both required platforms
+                  if ! echo "$MANIFEST_PLATFORMS" | grep -q '^linux/amd64$'; then
+                    echo "❌ ERROR: linux/amd64 platform not found in manifest"
+                    exit 1
+                  fi
+
+                  if ! echo "$MANIFEST_PLATFORMS" | grep -q '^linux/arm64$'; then
+                    echo "❌ ERROR: linux/arm64 platform not found in manifest"
+                    exit 1
+                  fi
+
+                  echo "✅ SUCCESS: Multi-arch manifest contains both linux/amd64 and linux/arm64"

--- a/.github/workflows/_create-docker-manifest.yml
+++ b/.github/workflows/_create-docker-manifest.yml
@@ -61,6 +61,14 @@ jobs:
                   IFS=',' read -ra AMD64_ARRAY <<< "$AMD64_TAGS"
                   IFS=',' read -ra ARM64_ARRAY <<< "$ARM64_TAGS"
 
+                  # Validate arrays have matching lengths
+                  if [ "${#AMD64_ARRAY[@]}" -ne "${#ARM64_ARRAY[@]}" ]; then
+                    echo "ERROR: AMD64 and ARM64 tag counts don't match"
+                    echo "AMD64 tags (${#AMD64_ARRAY[@]}): ${AMD64_ARRAY[@]}"
+                    echo "ARM64 tags (${#ARM64_ARRAY[@]}): ${ARM64_ARRAY[@]}"
+                    exit 1
+                  fi
+
                   # For each arch tag pair, create a manifest
                   for i in "${!AMD64_ARRAY[@]}"; do
                     AMD64_TAG="${AMD64_ARRAY[$i]}"


### PR DESCRIPTION
### Description

Modularize Docker build workflows with centralized reusable logic and fix git operations for GitHub Actions compatibility.

### Changes

- **Create reusable workflows:**
  - `_build-docker-arch.yml` - Centralized single-arch Docker builds with ECR login and tag generation
  - `_create-docker-manifest.yml` - Multi-arch manifest creation and validation

- **Fix git operations for GitHub Actions:**
  - Replace `git describe` with `git rev-parse --short HEAD` for Docker-safe commit hashes
  - Use `github.ref_name` instead of `git rev-parse --abbrev-ref HEAD` for branch detection (fixes detached HEAD issue)
  - Add missing `id: login-ecr` to ECR login steps for output references

- **Standardize workflows:**
  - Single-arch workflows (Metrics_discovery, Stream_metadata, Stress_test_node, XChain_monitor) simplified to ~50 lines
  - Multi-arch workflows (Subgraph, Towns_anvil) use consistent manifest creation pattern
  - Remove duplicate ECR login steps across workflows
  - Eliminate 400+ lines of duplicated code
  - Standardize path filters to be package-specific
  - Remove legacy `docker_tags` input in favor of direct ECR parameters

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines