### PR TITLE
Make default image load default env config based on TOWNS_ENV var name

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -43,6 +43,7 @@ RUN adduser -D riveruser
 COPY docker/run.sh /etc/run.sh
 COPY --from=builder /bin/river_node /usr/bin/river_node
 COPY --from=builder /bin/river_node_race /usr/bin/river_node_race
+COPY --from=builder /build/env /riveruser/river_node/env
 
 # Use setcap to allow the web server binary to bind to privileged ports
 RUN setcap 'cap_net_bind_service=+ep' /usr/bin/river_node

--- a/core/docker/run.sh
+++ b/core/docker/run.sh
@@ -3,6 +3,19 @@ set -euo pipefail
 
 RUN_MODE="${RUN_MODE:-full}"
 RACE="${RACE:-false}"
+TOWNS_ENV="${TOWNS_ENV:-omega}"
+
+case "$TOWNS_ENV" in
+    mainnet|main)
+        TOWNS_ENV="omega"
+        ;;
+esac
+
+CONFIG_PATH="/riveruser/river_node/env/${TOWNS_ENV}/config.yaml"
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "Missing config for environment '$TOWNS_ENV' at $CONFIG_PATH"
+    exit 1
+fi
 
 RIVER_NODE_BINARY="/usr/bin/river_node"
 cd /riveruser/river_node
@@ -11,19 +24,19 @@ if [ "$RACE" == "true" ]; then
     RIVER_NODE_BINARY="/usr/bin/river_node_race"
 fi
 
-if [ "$RUN_MODE" == "full" ]; then
-    echo "Running full node"
-    exec $RIVER_NODE_BINARY run
-elif [ "$RUN_MODE" == "archive" ]; then
-    echo "Running archive node"
-    exec $RIVER_NODE_BINARY archive
-elif [ "$RUN_MODE" == "notifications" ]; then
-    echo "Running notification service"
-    exec $RIVER_NODE_BINARY notifications
-elif [ "$RUN_MODE" == "app-registry" ]; then
-    echo "Running app registry"
-    exec $RIVER_NODE_BINARY app-registry
-else
-    echo "Unknown RUN_MODE: $RUN_MODE"
-    exit 1
-fi
+echo "Running ${RUN_MODE} node with environment '$TOWNS_ENV'"
+
+case "$RUN_MODE" in
+    full|run)
+        COMMAND="run"
+        ;;
+    archive|notifications|app-registry)
+        COMMAND=$RUN_MODE
+        ;;
+    *)
+        echo "Unknown RUN_MODE: $RUN_MODE"
+        exit 1
+        ;;
+esac
+
+exec $RIVER_NODE_BINARY $COMMAND -c "$CONFIG_PATH"


### PR DESCRIPTION
### Description

If TOWNS_ENV is not set, default to `omega`.
Then load contract addresses, chain ids and public rpc provider from matching config.
Value set by env vars are going to overwrite these values from default config.
In particular, RPC providers should be set.
