### PR TITLE
Refactor debug server setup to support TLS + DisableOnPublicPort setting 

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -554,8 +554,9 @@ type DebugEndpointsConfig struct {
 
 	// PrivateDebugServerAddress is the address to start the debug server on, such as "127.0.0.1:8080" or ":8080" to listen on all interfaces.
 	// If not set, the debug server will not be started.
-	// There is no TLS and no authentication, all debug endpoints, including pprof, are exposed.
+	// There is no authentication, all debug endpoints, including pprof, are exposed.
 	// This is highly privileged endpoint and should not be exposed to the public internet.
+	// This is a TLS endpoint and it uses same certificate as the public port.
 	PrivateDebugServerAddress string
 
 	// MemProfileDir is the directory to write the memory profile to.
@@ -567,6 +568,10 @@ type DebugEndpointsConfig struct {
 	// MemProfileInterval is the interval to write memory profiles with, like "5m".
 	// First profile is written at MemProfileInterval / 2 after start.
 	MemProfileInterval time.Duration
+
+	// DisableOnPublicPort is a flag to disable all debug endpoints except /debug/multi on the public port.
+	// This is convenience setting to disable all settings at once instead of setting each one to false.
+	DisableOnPublicPort bool
 }
 
 type RiverRegistryConfig struct {

--- a/core/env/common/config.yaml
+++ b/core/env/common/config.yaml
@@ -12,7 +12,6 @@ log:
 
 debugEndpoints:
     pprof: true
-    privateDebugServerAddress: ':8080'
 
 # Notifications setting when node is run in notification mode
 notifications:

--- a/core/justfile
+++ b/core/justfile
@@ -695,6 +695,17 @@ print-logs:
     LOGS=(${INSTANCE_BASE}/*/logs/tty.*.log)
     tail -n 10 ${LOGS[@]} | yarn exec pino-pretty
 
+# Print last 100 or N lines from instance INSTANCE_NUM log, use 00, 01, etc. for INSTANCE_NUM
+print-log INSTANCE_NUM *N:
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    source ${ENV_FILE}
+    shopt -s nullglob
+    NUM="{{N}}"
+    if [ -z "${NUM}" ]; then
+        NUM=100
+    fi
+    tail -n ${NUM} ${INSTANCE_BASE}/${INSTANCE_NUM}/logs/dev.log | yarn exec pino-pretty
+
 # Tail stderr from all instances
 tail-stderr:
     #!/usr/bin/env -S bash {{BASH_OPTS}}

--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -496,6 +496,67 @@ func (s *Service) loadTLSConfig() (*tls.Config, error) {
 	return cfg, nil
 }
 
+func (s *Service) createListener(addr string) (net.Listener, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if !s.config.DisableHttps {
+		tlsConfig, err := s.loadTLSConfig()
+		if err != nil {
+			return nil, err
+		}
+		listener = tls.NewListener(listener, tlsConfig)
+	}
+
+	if !s.config.Log.Simplify {
+		s.defaultLogger.Infow("Listening", "addr", addr)
+	}
+
+	s.onClose(listener.Close)
+
+	return listener, nil
+}
+
+func (s *Service) createHttpServer(listener net.Listener, handler http.Handler) (*http.Server, error) {
+	// TODO: set http2 settings here
+	http2Server := &http2.Server{}
+
+	if s.config.DisableHttps {
+		handler = h2c.NewHandler(handler, http2Server)
+		s.defaultLogger.Warnw("Starting H2C server without TLS")
+	}
+
+	httpServer := &http.Server{
+		Addr:    listener.Addr().String(),
+		Handler: handler,
+		BaseContext: func(listener net.Listener) context.Context {
+			return s.serverCtx
+		},
+		ErrorLog: utils.NewHttpLogger(s.serverCtx),
+	}
+	// ensure that x/http2 is used
+	// https://github.com/golang/go/issues/42534
+	err := http2.ConfigureServer(httpServer, http2Server)
+	if err != nil {
+		return nil, err
+	}
+
+	go s.serve(httpServer, listener)
+
+	return httpServer, nil
+}
+
+func (s *Service) serve(httpServer *http.Server, listener net.Listener) {
+	err := httpServer.Serve(listener)
+	if err != nil && err != http.ErrServerClosed {
+		s.defaultLogger.Errorw("Serve failed", "error", err, "addr", listener.Addr().String())
+	} else {
+		s.defaultLogger.Infow("Serve stopped", "addr", listener.Addr().String())
+	}
+}
+
 func (s *Service) runHttpServer() error {
 	ctx := s.serverCtx
 	log := logging.FromCtx(ctx)
@@ -509,28 +570,18 @@ func (s *Service) runHttpServer() error {
 		}
 
 		address = fmt.Sprintf("%s:%d", cfg.Address, cfg.Port)
-		s.listener, err = net.Listen("tcp", address)
+
+		s.listener, err = s.createListener(address)
 		if err != nil {
 			return err
-		}
-
-		if !cfg.DisableHttps {
-			tlsConfig, err := s.loadTLSConfig()
-			if err != nil {
-				return err
-			}
-			s.listener = tls.NewListener(s.listener, tlsConfig)
-		}
-
-		if !cfg.Log.Simplify {
-			log.Infow("Listening", "addr", address)
 		}
 	} else {
 		if cfg.Port != 0 {
 			log.Warnw("Port is ignored when listener is provided")
 		}
+
+		s.onClose(s.listener.Close)
 	}
-	s.onClose(s.listener.Close)
 
 	mux := http.NewServeMux()
 	s.mux = mux
@@ -572,42 +623,13 @@ func (s *Service) runHttpServer() error {
 
 	handler := corsMiddleware.Handler(mux)
 
-	// TODO: set http2 settings here
-	http2Server := &http2.Server{}
-
-	if cfg.DisableHttps {
-		handler = h2c.NewHandler(handler, http2Server)
-		log.Warnw("Starting H2C server without TLS")
-	}
-
-	s.httpServer = &http.Server{
-		Addr:    address,
-		Handler: handler,
-		BaseContext: func(listener net.Listener) context.Context {
-			return ctx
-		},
-		ErrorLog: utils.NewHttpLogger(ctx),
-	}
-	// ensure that x/http2 is used
-	// https://github.com/golang/go/issues/42534
-	err = http2.ConfigureServer(s.httpServer, http2Server)
+	s.httpServer, err = s.createHttpServer(s.listener, handler)
 	if err != nil {
 		return err
 	}
 
-	go s.serve()
-
 	s.onClose(s.httpServerClose)
 	return nil
-}
-
-func (s *Service) serve() {
-	err := s.httpServer.Serve(s.listener)
-	if err != nil && err != http.ErrServerClosed {
-		s.defaultLogger.Errorw("Serve failed", "error", err)
-	} else {
-		s.defaultLogger.Infow("Serve stopped")
-	}
 }
 
 func (s *Service) initEntitlements() error {


### PR DESCRIPTION
### Description

After this change using settings like this:

```
RIVER_DEBUGENDPOINTS_DISABLEONPUBLICPORT=true
RIVER_DEBUGENDPOINTS_PRIVATEDEBUGSERVERADDRESS=:8080
```
disabled /debug on public port and enables it on 8080.

/debug/multi status page is still published since a lot of component rely on it on being available for status.
