### PR TITLE
TOWNS-31164 Bot username validation - do not allow space

### DIFF
--- a/core/node/app_registry/service.go
+++ b/core/node/app_registry/service.go
@@ -928,12 +928,12 @@ func (s *Service) ValidateBotName(
 ) {
 	ctx = logging.CtxWithLog(ctx, logging.FromCtx(ctx).With("method", "ValidateBotName"))
 
-	// Validate input
-	if req.Msg.Username == "" {
+	// Validate username format
+	if err := types.ValidateBotUsername(req.Msg.Username); err != nil {
 		return &connect.Response[ValidateBotNameResponse]{
 			Msg: &ValidateBotNameResponse{
 				IsAvailable:  false,
-				ErrorMessage: "username cannot be empty",
+				ErrorMessage: err.Error(),
 			},
 		}, nil
 	}

--- a/core/node/app_registry/service.go
+++ b/core/node/app_registry/service.go
@@ -929,7 +929,7 @@ func (s *Service) ValidateBotName(
 	ctx = logging.CtxWithLog(ctx, logging.FromCtx(ctx).With("method", "ValidateBotName"))
 
 	// Validate username format
-	if err := types.ValidateBotUsername(req.Msg.Username); err != nil {
+	if err := types.ValidateBotUsername(req.Msg.GetUsername()); err != nil {
 		return &connect.Response[ValidateBotNameResponse]{
 			Msg: &ValidateBotNameResponse{
 				IsAvailable:  false,

--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -257,7 +257,10 @@ func validateSlashCommandName(name string) error {
 	// Check if name contains only letters, numbers, and underscores
 	for i, ch := range name {
 		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_') {
-			return RiverError(protocol.Err_INVALID_ARGUMENT, "command name must contain only letters, numbers, and underscores").
+			return RiverError(
+				protocol.Err_INVALID_ARGUMENT,
+				"command name must contain only letters, numbers, and underscores",
+			).
 				Tag("name", name).
 				Tag("invalidCharAt", i)
 		}

--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -16,9 +16,9 @@ const MAX_SLASH_COMMANDS = 25
 // usernameRegex validates bot usernames:
 // - Must start with a letter or number
 // - Can contain letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-)
-// - Must be between 1 and 64 characters
+// - Must be between 1 and 255 characters
 // - No spaces allowed
-var usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`)
+var usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$`)
 
 // ValidateBotUsername validates a bot username according to the rules
 func ValidateBotUsername(username string) error {

--- a/core/node/app_registry/types/app_metadata.go
+++ b/core/node/app_registry/types/app_metadata.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/towns-protocol/towns/core/node/base"
+	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/protocol"
 )
 
@@ -16,14 +16,14 @@ const MAX_SLASH_COMMANDS = 25
 // usernameRegex validates bot usernames:
 // - Must start with a letter or number
 // - Can contain letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-)
-// - Must be between 1 and 255 characters
+// - Must be between 1 and 256 characters
 // - No spaces allowed
 var usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$`)
 
 // ValidateBotUsername validates a bot username according to the rules
 func ValidateBotUsername(username string) error {
 	if !usernameRegex.MatchString(username) {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "invalid username")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "invalid username")
 	}
 	return nil
 }
@@ -122,24 +122,24 @@ var validExternalUrlSchemes = map[string]struct{}{
 
 func ValidateImageFileUrl(urlStr string) error {
 	if urlStr == "" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL cannot be empty")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "URL cannot be empty")
 	}
 
 	if len(urlStr) > MAX_RESOURCE_URL_LENGTH {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
 			Tag("url_length", len(urlStr)).
 			Tag("max_length", MAX_RESOURCE_URL_LENGTH)
 	}
 
 	parsedUrl, err := url.Parse(urlStr)
 	if err != nil {
-		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).
+		return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).
 			Tag("url", urlStr)
 	}
 
 	// Check if scheme is valid
 	if _, schemeOk := validFileUrlSchemes[parsedUrl.Scheme]; !schemeOk {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid scheme (https, http, or ipfs)").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid scheme (https, http, or ipfs)").
 			Tag("url", urlStr).
 			Tag("scheme", parsedUrl.Scheme)
 	}
@@ -149,20 +149,20 @@ func ValidateImageFileUrl(urlStr string) error {
 
 func ValidateExternalUrl(urlStr string) error {
 	if len(urlStr) > MAX_RESOURCE_URL_LENGTH {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "URL exceeds maximum length").
 			Tag("url_length", len(urlStr)).
 			Tag("max_length", MAX_RESOURCE_URL_LENGTH)
 	}
 
 	parsedUrl, err := url.Parse(urlStr)
 	if err != nil {
-		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).
+		return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "invalid URL format", err).
 			Tag("url", urlStr)
 	}
 
 	// Check if scheme is valid
 	if _, schemeOk := validExternalUrlSchemes[parsedUrl.Scheme]; !schemeOk {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid external URL scheme").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "URL must have a valid external URL scheme").
 			Tag("url", urlStr).
 			Tag("scheme", parsedUrl.Scheme)
 	}
@@ -173,38 +173,38 @@ func ValidateExternalUrl(urlStr string) error {
 // ValidateAppMetadata validates app metadata and returns an error if validation fails
 func ValidateAppMetadata(metadata *protocol.AppMetadata) error {
 	if metadata == nil {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "metadata is required")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "metadata is required")
 	}
 
 	// Validate username format
 	if err := ValidateBotUsername(metadata.GetUsername()); err != nil {
-		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata username validation failed", err).
+		return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata username validation failed", err).
 			Tag("username", metadata.GetUsername())
 	}
 
 	if metadata.GetDisplayName() == "" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "metadata display_name is required")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "metadata display_name is required")
 	}
 
 	if metadata.GetDescription() == "" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "metadata description is required")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "metadata description is required")
 	}
 
 	imageUrl := metadata.GetImageUrl()
 	if err := ValidateImageFileUrl(imageUrl); err != nil {
-		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata image_url validation failed", err).
+		return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata image_url validation failed", err).
 			Tag("image_url", imageUrl)
 	}
 
 	avatarUrl := metadata.GetAvatarUrl()
 	if err := ValidateImageFileUrl(avatarUrl); err != nil {
-		return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata avatar_url validation failed", err).
+		return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata avatar_url validation failed", err).
 			Tag("avatar_url", avatarUrl)
 	}
 
 	if externalUrl := metadata.GetExternalUrl(); externalUrl != "" {
 		if err := ValidateExternalUrl(externalUrl); err != nil {
-			return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata external_url must be a valid URL", err).
+			return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "metadata external_url must be a valid URL", err).
 				Tag("external_url", metadata.GetExternalUrl())
 		}
 	}
@@ -212,7 +212,7 @@ func ValidateAppMetadata(metadata *protocol.AppMetadata) error {
 	// Validate slash commands
 	slashCommands := metadata.GetSlashCommands()
 	if len(slashCommands) > MAX_SLASH_COMMANDS {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT,
+		return RiverError(protocol.Err_INVALID_ARGUMENT,
 			"app metadata slash command count exceeds maximum").
 			Tag("commandCount", len(slashCommands)).
 			Tag("maximum", MAX_SLASH_COMMANDS)
@@ -227,7 +227,7 @@ func ValidateAppMetadata(metadata *protocol.AppMetadata) error {
 
 		cmdName := cmd.GetName()
 		if commandNames[cmdName] {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "duplicate command name").
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "duplicate command name").
 				Tag("commandName", cmdName)
 		}
 		commandNames[cmdName] = true
@@ -239,25 +239,25 @@ func ValidateAppMetadata(metadata *protocol.AppMetadata) error {
 // validateSlashCommandName validates a slash command name
 func validateSlashCommandName(name string) error {
 	if name == "" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command name is required")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "command name is required")
 	}
 
 	if len(name) > 32 {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command name must not exceed 32 characters").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "command name must not exceed 32 characters").
 			Tag("name", name).
 			Tag("length", len(name))
 	}
 
 	// Check if name starts with a letter
 	if len(name) > 0 && !((name[0] >= 'a' && name[0] <= 'z') || (name[0] >= 'A' && name[0] <= 'Z')) {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command name must start with a letter").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "command name must start with a letter").
 			Tag("name", name)
 	}
 
 	// Check if name contains only letters, numbers, and underscores
 	for i, ch := range name {
 		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_') {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command name must contain only letters, numbers, and underscores").
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "command name must contain only letters, numbers, and underscores").
 				Tag("name", name).
 				Tag("invalidCharAt", i)
 		}
@@ -269,7 +269,7 @@ func validateSlashCommandName(name string) error {
 // validateSlashCommand validates a single slash command
 func validateSlashCommand(cmd *protocol.SlashCommand) error {
 	if cmd == nil {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "slash command cannot be nil")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "slash command cannot be nil")
 	}
 
 	// Validate name
@@ -280,12 +280,12 @@ func validateSlashCommand(cmd *protocol.SlashCommand) error {
 	// Validate description
 	description := cmd.GetDescription()
 	if description == "" {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command description is required").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "command description is required").
 			Tag("commandName", cmd.GetName())
 	}
 
 	if len(description) > 256 {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "command description must not exceed 256 characters").
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "command description must not exceed 256 characters").
 			Tag("commandName", cmd.GetName()).
 			Tag("descriptionLength", len(description))
 	}
@@ -358,11 +358,11 @@ func AppMetadataUpdateToMap(update *protocol.AppMetadataUpdate, updateMask []str
 // ValidateAppMetadataUpdate validates partial app metadata updates and returns an error if validation fails
 func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []string) error {
 	if update == nil {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "metadata update is required")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "metadata update is required")
 	}
 
 	if len(updateMask) == 0 {
-		return base.RiverError(protocol.Err_INVALID_ARGUMENT, "update_mask is required and cannot be empty")
+		return RiverError(protocol.Err_INVALID_ARGUMENT, "update_mask is required and cannot be empty")
 	}
 
 	// Create mask set for efficient lookup
@@ -376,31 +376,31 @@ func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []
 	// Validate username if being updated (MANDATORY)
 	if maskSet["username"] {
 		if update.Username == nil || *update.Username == "" {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "username cannot be empty")
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "username cannot be empty")
 		}
 	}
 
 	// Validate display_name if being updated (MANDATORY)
 	if maskSet["display_name"] {
 		if update.DisplayName == nil || *update.DisplayName == "" {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "display_name cannot be empty")
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "display_name cannot be empty")
 		}
 	}
 
 	// Validate description if being updated (MANDATORY)
 	if maskSet["description"] {
 		if update.Description == nil || *update.Description == "" {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "description cannot be empty")
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "description cannot be empty")
 		}
 	}
 
 	// Validate image_url if being updated (MANDATORY)
 	if maskSet["image_url"] {
 		if update.ImageUrl == nil || *update.ImageUrl == "" {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "image_url cannot be empty")
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "image_url cannot be empty")
 		}
 		if err := ValidateImageFileUrl(*update.ImageUrl); err != nil {
-			return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "image_url validation failed", err).
+			return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "image_url validation failed", err).
 				Tag("image_url", *update.ImageUrl)
 		}
 	}
@@ -408,10 +408,10 @@ func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []
 	// Validate avatar_url if being updated (MANDATORY)
 	if maskSet["avatar_url"] {
 		if update.AvatarUrl == nil || *update.AvatarUrl == "" {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT, "avatar_url cannot be empty")
+			return RiverError(protocol.Err_INVALID_ARGUMENT, "avatar_url cannot be empty")
 		}
 		if err := ValidateImageFileUrl(*update.AvatarUrl); err != nil {
-			return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "avatar_url validation failed", err).
+			return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "avatar_url validation failed", err).
 				Tag("avatar_url", *update.AvatarUrl)
 		}
 	}
@@ -420,7 +420,7 @@ func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []
 	if maskSet["external_url"] && update.ExternalUrl != nil {
 		if *update.ExternalUrl != "" {
 			if err := ValidateExternalUrl(*update.ExternalUrl); err != nil {
-				return base.RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "external_url validation failed", err).
+				return RiverErrorWithBase(protocol.Err_INVALID_ARGUMENT, "external_url validation failed", err).
 					Tag("external_url", *update.ExternalUrl)
 			}
 		}
@@ -429,7 +429,7 @@ func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []
 	// Validate slash_commands if being updated
 	if maskSet["slash_commands"] && update.SlashCommands != nil {
 		if len(update.SlashCommands) > MAX_SLASH_COMMANDS {
-			return base.RiverError(protocol.Err_INVALID_ARGUMENT,
+			return RiverError(protocol.Err_INVALID_ARGUMENT,
 				"slash command count exceeds maximum").
 				Tag("commandCount", len(update.SlashCommands)).
 				Tag("maximum", MAX_SLASH_COMMANDS)
@@ -444,7 +444,7 @@ func ValidateAppMetadataUpdate(update *protocol.AppMetadataUpdate, updateMask []
 
 			cmdName := cmd.GetName()
 			if commandNames[cmdName] {
-				return base.RiverError(protocol.Err_INVALID_ARGUMENT, "duplicate command name").
+				return RiverError(protocol.Err_INVALID_ARGUMENT, "duplicate command name").
 					Tag("commandName", cmdName)
 			}
 			commandNames[cmdName] = true

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -2122,9 +2122,14 @@ func TestAppRegistry_ValidateBotName(t *testing.T) {
 			expectAvailable:  false,
 			expectErrMessage: "(3:INVALID_ARGUMENT) invalid username",
 		},
-		"Very long name": {
-			name:            strings.Repeat("a", 200),
+		"256 character username": {
+			name:            strings.Repeat("a", 256),
 			expectAvailable: true,
+		},
+		"257 character username (too long)": {
+			name:             strings.Repeat("a", 257),
+			expectAvailable:  false,
+			expectErrMessage: "(3:INVALID_ARGUMENT) invalid username",
 		},
 	}
 

--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -2111,15 +2111,16 @@ func TestAppRegistry_ValidateBotName(t *testing.T) {
 		"Empty name": {
 			name:             "",
 			expectAvailable:  false,
-			expectErrMessage: "username cannot be empty",
+			expectErrMessage: "(3:INVALID_ARGUMENT) invalid username",
 		},
 		"Different case of existing username": {
 			name:            strings.ToUpper(existingBotUsername),
 			expectAvailable: true, // Expect case-sensitive username uniqueness
 		},
 		"Name with spaces": {
-			name:            "Bot With Spaces",
-			expectAvailable: true,
+			name:             "Bot With Spaces",
+			expectAvailable:  false,
+			expectErrMessage: "(3:INVALID_ARGUMENT) invalid username",
 		},
 		"Very long name": {
 			name:            strings.Repeat("a", 200),
@@ -2241,7 +2242,7 @@ func TestAppRegistry_Register(t *testing.T) {
 				AvatarUrl:   "https://example.com/avatar.png",
 			},
 			authenticatingWallet: ownerWallet,
-			expectedErr:          "metadata username is required",
+			expectedErr:          "metadata username validation failed",
 		},
 		"Invalid metadata - missing description": {
 			appId:   appWallet.Address[:],


### PR DESCRIPTION
### Description

Added a bunch of username validation for bots:
- Must start with a letter or number
- Can contain letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-)
- Must be between 1 and 255 characters
- No spaces allowed

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
