### PR TITLE
node: add support to store metadata for streams

### DIFF
--- a/core/node/storage/migrations/000009_add_miniblock_metadata_column.down.sql
+++ b/core/node/storage/migrations/000009_add_miniblock_metadata_column.down.sql
@@ -1,0 +1,23 @@
+ALTER TABLE es DROP COLUMN IF EXISTS metadata;
+
+DO $$
+	DECLARE
+
+    suffix CHAR(2);
+	i INT;
+
+    numPartitions INT;
+
+    BEGIN
+
+    SELECT num_partitions from settings where single_row_key=true into numPartitions;
+
+    FOR i IN 0.. numPartitions LOOP
+        suffix = LPAD(TO_HEX(i), 2, '0');
+        -- Make blockdata mandatory from the miniblock partition
+        -- This will intentionally fail if there are any NULL values in the blockdata column because
+        -- dropping the metadata column from the es table can't be done for these records.
+        EXECUTE 'ALTER TABLE miniblocks_m' || suffix || ' ALTER COLUMN blockdata SET NOT NULL;';
+    END LOOP;
+END;
+$$;

--- a/core/node/storage/migrations/000009_add_miniblock_metadata_column.up.sql
+++ b/core/node/storage/migrations/000009_add_miniblock_metadata_column.up.sql
@@ -1,0 +1,23 @@
+-- Add an optional metadata column to the es table that will hold extra information that
+-- can be used to find block data if it's not stored in the DB.
+ALTER TABLE es ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT NULL;
+
+DO $$
+	DECLARE
+
+	suffix CHAR(2);
+	i INT;
+
+    numPartitions INT;
+
+	BEGIN
+
+    SELECT num_partitions from settings where single_row_key=true into numPartitions;
+
+	FOR i IN 0.. numPartitions LOOP
+		suffix = LPAD(TO_HEX(i), 2, '0');
+        -- Make blockdata nullable to allow storing blockdata external.
+        EXECUTE 'ALTER TABLE miniblocks_m' || suffix || ' ALTER COLUMN blockdata DROP NOT NULL;';
+	END LOOP;
+END;
+$$;

--- a/core/node/storage/pg_ephemeral_store_monitor.go
+++ b/core/node/storage/pg_ephemeral_store_monitor.go
@@ -113,7 +113,7 @@ func (m *ephemeralStreamMonitor) handleStream(ctx context.Context, streamId Stre
 		"ephemeralStreamMonitor.handleStream",
 		pgx.ReadWrite,
 		func(ctx context.Context, tx pgx.Tx) error {
-			if _, err := m.storage.lockEphemeralStream(ctx, tx, streamId, true); err != nil {
+			if _, _, err := m.storage.lockEphemeralStream(ctx, tx, streamId, true); err != nil {
 				return err
 			}
 

--- a/core/node/storage/pg_ephemeral_store_test.go
+++ b/core/node/storage/pg_ephemeral_store_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+	. "github.com/towns-protocol/towns/core/node/shared"
+	"github.com/towns-protocol/towns/core/node/testutils"
+)
+
+// TestStreamMetaDataDB tests writing and reading stream metadata to/from the DB.
+func TestStreamMetaDataDB(t *testing.T) {
+	var (
+		require             = require.New(t)
+		params              = setupStreamStorageTest(t)
+		streamStore         = params.pgStreamStore
+		streamID            = testutils.FakeStreamId(STREAM_MEDIA_BIN)
+		s3MultiPartUploadID = "aabbcc"
+		etag1, pn1          = "etag1", int32(7)
+		etag2, pn2          = "etag2", int32(6)
+		etag3, pn3          = "etag3", int32(8)
+		writtenMD           = &StreamMetaData{
+			S3PartsCount:        1,
+			S3PartsSize:         1,
+			S3MultiPartUploadID: &s3MultiPartUploadID,
+			S3Parts: []*StreamMetaDataS3Part{
+				{ByteSize: 12, S3CompletionPart: &S3CompletedPart{ETag: &etag1, PartNumber: &pn1}},
+				{ByteSize: 32, S3CompletionPart: &S3CompletedPart{ETag: &etag2, PartNumber: &pn2}},
+				{ByteSize: 44, S3CompletionPart: &S3CompletedPart{ETag: &etag3, PartNumber: &pn3}},
+			},
+			S3MultiPartCompletedEtag: nil,
+		}
+		ctx = params.ctx
+	)
+
+	defer params.pgStreamStore.Close(ctx)
+
+	// write stream metadata
+	require.NoError(streamStore.txRunner(
+		ctx,
+		"CreateStreamStorage",
+		pgx.ReadWrite,
+		func(ctx context.Context, tx pgx.Tx) error {
+			sql := streamStore.sqlForStream(
+				`INSERT INTO es (stream_id, latest_snapshot_miniblock, migrated, ephemeral, metadata) VALUES ($1, 0, true, false, $2);`,
+				streamID,
+			)
+
+			_, err := tx.Exec(ctx, sql, streamID, writtenMD)
+			return err
+		}, nil, ""))
+
+	// read stream metadata and ensure it matches with what was written
+	var retrievedMD *StreamMetaData
+	require.NoError(streamStore.txRunner(
+		ctx,
+		"ReadStreamStorage",
+		pgx.ReadOnly,
+		func(ctx context.Context, tx pgx.Tx) error {
+			sql := streamStore.sqlForStream(
+				`SELECT metadata FROM es WHERE stream_id = $1;`,
+				streamID,
+			)
+
+			return tx.QueryRow(ctx, sql, streamID).Scan(&retrievedMD)
+		},
+		nil, ""))
+
+	require.EqualValues(*writtenMD, *retrievedMD)
+}

--- a/core/node/storage/pg_stream_trimmer.go
+++ b/core/node/storage/pg_stream_trimmer.go
@@ -198,7 +198,7 @@ func (t *streamTrimmer) processTrimTaskTx(
 	}()
 
 	// Get the last snapshot miniblock number
-	lastSnapshotMiniblock, err := t.store.lockStream(ctx, tx, task.streamId, true)
+	lastSnapshotMiniblock, _, err := t.store.lockStream(ctx, tx, task.streamId, true)
 	if err != nil {
 		return err
 	}

--- a/core/node/storage/s3_stream_store.go
+++ b/core/node/storage/s3_stream_store.go
@@ -163,7 +163,7 @@ func S3WriteMediaMiniblock(
 		partNumber := int32(1) // single part upload always has part number 1
 		part := &StreamMetaDataS3Part{
 			ByteSize: uint64(len(miniblock.Data)),
-			S3CompletionPart: &s3types.CompletedPart{
+			S3CompletionPart: &S3CompletedPart{
 				ETag:       putObjectResult.ETag,
 				PartNumber: &partNumber,
 			},
@@ -216,7 +216,7 @@ func S3WriteMediaMiniblock(
 
 	streamMD.S3Parts = append(streamMD.S3Parts, &StreamMetaDataS3Part{
 		ByteSize: uint64(len(miniblock.Data)),
-		S3CompletionPart: &s3types.CompletedPart{
+		S3CompletionPart: &S3CompletedPart{
 			ETag:       uploadPartResult.ETag,
 			PartNumber: &s3PartNumber,
 		},


### PR DESCRIPTION
Overview

  - Adds a metadata column (with up/down migrations) so stream records can persist JSON metadata next to stream data.
  - Extends the Postgres stream stores to read/write the new metadata
  - Updates the S3 stream store to consume the metadata type and adds integration tests that exercise the metadata path alongside S3 interactions.

  Testing

  - go test ./core/node/storage -run TestPgEphemeralStore
