### PR TITLE
feat: add protocolFee to getJoinSpacePriceDetails response

### DIFF
--- a/packages/sdk/src/tests/multi/spaceWithVariousPriceConfigurations.test.ts
+++ b/packages/sdk/src/tests/multi/spaceWithVariousPriceConfigurations.test.ts
@@ -155,9 +155,12 @@ describe('spaceWithVariousPriceConfigurations', () => {
             membershipRequirements,
         )
 
-        const { price: joinPrice } = await bobSpaceDapp.getJoinSpacePriceDetails(spaceId)
+        const { price: joinPrice, protocolFee } =
+            await bobSpaceDapp.getJoinSpacePriceDetails(spaceId)
 
-        expect(joinPrice.toBigInt()).toBe(ethers.utils.parseEther('1').toBigInt())
+        expect(joinPrice.toBigInt()).toBe(
+            ethers.utils.parseEther('1').toBigInt() + protocolFee.toBigInt(),
+        )
 
         log('Alice should be able to join space')
 

--- a/packages/web3/tests/getJoinSpacePriceDetails.test.ts
+++ b/packages/web3/tests/getJoinSpacePriceDetails.test.ts
@@ -70,8 +70,10 @@ describe('getJoinSpacePriceDetails', () => {
         const spaceId = SpaceIdFromSpaceAddress(spaceAddress)
 
         const priceDetails = await spaceDapp.getJoinSpacePriceDetails(spaceAddress)
+        const protocolFee = priceDetails.protocolFee
+        const totalPrice = price.add(protocolFee)
 
-        expect(priceDetails.price.toBigInt()).toBe(price.toBigInt())
+        expect(priceDetails.price.toBigInt()).toBe(totalPrice.toBigInt())
         expect(priceDetails.prepaidSupply.toBigInt()).toBe(0n)
         expect(priceDetails.remainingFreeSupply.toBigInt()).toBe(0n)
 


### PR DESCRIPTION
### Description

Added protocol fee to the `getJoinSpacePriceDetails` method to properly account for the total cost when joining a space.

### Changes

- Added `protocolFee` property to the return type of `getJoinSpacePriceDetails`
- Updated the method to fetch protocol fee data via multicall
- Modified the method to decode and return the protocol fee value
- Updated tests to verify that the price includes the protocol fee

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines